### PR TITLE
If get-caller-identity fails then something is wrong, so bail out

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -26,7 +26,7 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					defer wg.Done()
 					clientSts := createStsSession(role)
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-					if err != nil {
+					if err != nil || result.Account == nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
 						return
 					}
@@ -63,7 +63,7 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					defer wg.Done()
 					clientSts := createStsSession(role)
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-					if err != nil {
+					if err != nil || result.Account == nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
 						return
 					}

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -28,7 +28,7 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 					if err != nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
-
+						return
 					}
 					accountId := result.Account
 
@@ -65,6 +65,7 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 					if err != nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
+						return
 					}
 					accountId := result.Account
 

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -52,7 +52,10 @@ func createStsSession(role Role) *sts.STS {
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 	maxStsRetries := 5
-	config := &aws.Config{MaxRetries: &maxStsRetries}
+	config := &aws.Config{
+		MaxRetries:                    &maxStsRetries,
+		CredentialsChainVerboseErrors: aws.Bool(true),
+	}
 	if log.IsLevelEnabled(log.DebugLevel) {
 		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
 	}

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -50,12 +50,12 @@ var labelMap = make(map[string][]string)
 func createStsSession(role Role) *sts.STS {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			CredentialsChainVerboseErrors: aws.Bool(true),
+		},
 	}))
 	maxStsRetries := 5
-	config := &aws.Config{
-		MaxRetries:                    &maxStsRetries,
-		CredentialsChainVerboseErrors: aws.Bool(true),
-	}
+	config := &aws.Config{MaxRetries: &maxStsRetries}
 	if log.IsLevelEnabled(log.DebugLevel) {
 		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
 	}
@@ -72,7 +72,10 @@ func createStsSession(role Role) *sts.STS {
 func createCloudwatchSession(region *string, role Role, fips bool) *cloudwatch.CloudWatch {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
-		Config:            aws.Config{Region: aws.String(*region)},
+		Config: aws.Config{
+			Region:                        aws.String(*region),
+			CredentialsChainVerboseErrors: aws.Bool(true),
+		},
 	}))
 
 	maxCloudwatchRetries := 5

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -35,6 +35,7 @@ type tagsInterface struct {
 }
 
 func createSession(role Role, config *aws.Config) *session.Session {
+	config.CredentialsChainVerboseErrors = aws.Bool(true)
 	sess, err := session.NewSession(config)
 	if err != nil {
 		log.Fatalf("Failed to create session due to %v", err)


### PR DESCRIPTION
Fixes #371 and any issue that could have been due to temporarily malformed creds.

`GetCallerIdentity` is available to all roles, so if it does not succeed then it is highly likely that something is wrong with either AWS, the network, or the credentials. Thus, no subsequent scrape should be expected to succeed and we should exit the scrape entirely.

Let me know if there is anything else I should add to this PR, or if this is the wrong approach to take to solve the problem!