### PR TITLE
[test] Use !strings.Contains(a,b) instead of (strings.Index(a,b) == -1)

### DIFF
--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -42,7 +42,7 @@ func TestBadConfigs(t *testing.T) {
 		config := ScrapeConf{}
 		configFile := fmt.Sprintf("testdata/%s", tc.configFile)
 		if err := config.Load(&configFile); err != nil {
-			if strings.Index(err.Error(), tc.errorMsg) == -1 {
+			if !strings.Contains(err.Error(), tc.errorMsg) {
 				t.Errorf("expecter error for config file %q to contain %q but got: %s", tc.configFile, tc.errorMsg, err)
 				t.FailNow()
 			}


### PR DESCRIPTION
Since we don't care about the actual index if a contains b, we might use strings.Contains() instead.