### PR TITLE
Tags as map

### DIFF
--- a/pkg/abstract_test.go
+++ b/pkg/abstract_test.go
@@ -10,7 +10,7 @@ func TestFilterThroughTags(t *testing.T) {
 	// Arrange
 	expected := true
 	tagsData := tagsData{}
-	filterTags := []Tag{}
+	filterTags := map[string]string{}
 
 	// Act
 	actual := tagsData.filterThroughTags(filterTags)

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -37,8 +37,8 @@ type cloudwatchData struct {
 	GetMetricDataTimestamps *time.Time
 	NilToZero               *bool
 	AddCloudwatchTimestamp  *bool
-	CustomTags              []Tag
-	Tags                    []Tag
+	CustomTags              map[string]string
+	Tags                    map[string]string
 	Dimensions              []*cloudwatch.Dimension
 	Region                  *string
 	AccountId               *string
@@ -299,7 +299,7 @@ func getFullMetricsList(namespace string, metric *Metric, clientCloudwatch cloud
 	return &res
 }
 
-func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags []Tag, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*tagsData, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
+func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags map[string]string, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*tagsData, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
 	type filterValues map[string]*tagsData
 	dimensionsFilter := make(map[string]filterValues)
 	for _, dr := range dimensionRegexps {
@@ -377,10 +377,10 @@ func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool) map[strin
 	}
 
 	for _, label := range cwd.CustomTags {
-		labels["custom_tag_"+promStringTag(label.Key, labelsSnakeCase)] = label.Value
+		labels["custom_tag_"+promStringTag(label, labelsSnakeCase)] = cwd.CustomTags[label]
 	}
 	for _, tag := range cwd.Tags {
-		labels["tag_"+promStringTag(tag.Key, labelsSnakeCase)] = tag.Value
+		labels["tag_"+promStringTag(tag, labelsSnakeCase)] = cwd.Tags[tag]
 	}
 
 	return labels

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -62,7 +62,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		region           string
 		accountId        *string
 		namespace        string
-		customTags       []Tag
+		customTags       map[string]string
 		tagsOnMetrics    exportedTagsOnMetrics
 		dimensionRegexps []*string
 		resources        []*tagsData
@@ -90,13 +90,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				dimensionRegexps: SupportedServices.GetService("ec2").DimensionRegexps,
 				resources: []*tagsData{
 					{
-						ID: aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
-						Tags: []*Tag{
-							{
-								Key:   "Name",
-								Value: "some-Node",
-							},
-						},
+						ID:        aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
+						Tags:      map[string]string{"Name": "some-Node"},
 						Namespace: aws.String("ec2"),
 						Region:    aws.String("us-east-1"),
 					},
@@ -144,16 +139,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Statistics: []string{
 						"Average",
 					},
-					Tags: []Tag{
-						{
-							Key:   "Value1",
-							Value: "",
-						},
-						{
-							Key:   "Value2",
-							Value: "",
-						},
-					},
+					Tags: map[string]string{"Value1": "", "Value2": ""},
 				},
 			},
 		},
@@ -173,13 +159,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				dimensionRegexps: SupportedServices.GetService("kafka").DimensionRegexps,
 				resources: []*tagsData{
 					{
-						ID: aws.String("arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12"),
-						Tags: []*Tag{
-							{
-								Key:   "Test",
-								Value: "Value",
-							},
-						},
+						ID:        aws.String("arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12"),
+						Tags:      map[string]string{"Test": "Value"},
 						Namespace: aws.String("kafka"),
 						Region:    aws.String("us-east-1"),
 					},
@@ -227,16 +208,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Statistics: []string{
 						"Average",
 					},
-					Tags: []Tag{
-						{
-							Key:   "Value1",
-							Value: "",
-						},
-						{
-							Key:   "Value2",
-							Value: "",
-						},
-					},
+					Tags: map[string]string{"Value1": "", "Value2": ""},
 				},
 			},
 		},

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -21,7 +21,7 @@ import (
 
 type tagsData struct {
 	ID        *string
-	Tags      []*Tag
+	Tags      map[string]string
 	Namespace *string
 	Region    *string
 }
@@ -121,7 +121,7 @@ func (iface tagsInterface) get(job *Job, region string) (resources []*tagsData, 
 				}
 
 				for _, t := range resourceTagMapping.Tags {
-					resource.Tags = append(resource.Tags, &Tag{Key: *t.Key, Value: *t.Value})
+					resource.Tags[*t.Key] = *t.Value
 				}
 
 				if resource.filterThroughTags(job.SearchTags) {
@@ -156,8 +156,8 @@ func migrateTagsToPrometheus(tagData []*tagsData, labelsSnakeCase bool) []*Prome
 
 	for _, d := range tagData {
 		for _, entry := range d.Tags {
-			if !stringInSlice(entry.Key, tagList[*d.Namespace]) {
-				tagList[*d.Namespace] = append(tagList[*d.Namespace], entry.Key)
+			if !stringInSlice(entry, tagList[*d.Namespace]) {
+				tagList[*d.Namespace] = append(tagList[*d.Namespace], entry)
 			}
 		}
 	}
@@ -173,13 +173,7 @@ func migrateTagsToPrometheus(tagData []*tagsData, labelsSnakeCase bool) []*Prome
 
 		for _, entry := range tagList[*d.Namespace] {
 			labelKey := "tag_" + promStringTag(entry, labelsSnakeCase)
-			promLabels[labelKey] = ""
-
-			for _, rTag := range d.Tags {
-				if entry == rTag.Key {
-					promLabels[labelKey] = rTag.Value
-				}
-			}
+			promLabels[labelKey] = d.Tags[entry]
 		}
 
 		var i int

--- a/pkg/aws_tags_test.go
+++ b/pkg/aws_tags_test.go
@@ -9,8 +9,7 @@ func TestMigrateTagsToPrometheus(t *testing.T) {
 	id := "tag_Id"
 	namespace := "AWS/Service"
 	region := "us-east-1"
-	tagItem := Tag{Key: "Name", Value: "tag_Value"}
-	tags := []*Tag{&tagItem}
+	tags := map[string]string{"Name": "tag_Value"}
 	tagData := tagsData{ID: &id, Namespace: &namespace, Region: &region, Tags: tags}
 	tagsData := []*tagsData{&tagData}
 

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -22,11 +22,13 @@ type Discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type Job struct {
-	Regions                []string  `yaml:"regions"`
-	Type                   string    `yaml:"type"`
-	Roles                  []Role    `yaml:"roles"`
-	SearchTags             []Tag     `yaml:"searchTags"`
-	CustomTags             []Tag     `yaml:"customTags"`
+	Regions                []string `yaml:"regions"`
+	Type                   string   `yaml:"type"`
+	Roles                  []Role   `yaml:"roles"`
+	SearchTagsList         []Tag    `yaml:"searchTags"`
+	CustomTagsList         []Tag    `yaml:"customTags"`
+	SearchTags             map[string]string
+	CustomTags             map[string]string
 	Metrics                []*Metric `yaml:"metrics"`
 	Length                 int       `yaml:"length"`
 	Delay                  int       `yaml:"delay"`
@@ -36,13 +38,14 @@ type Job struct {
 }
 
 type Static struct {
-	Name       string      `yaml:"name"`
-	Regions    []string    `yaml:"regions"`
-	Roles      []Role      `yaml:"roles"`
-	Namespace  string      `yaml:"namespace"`
-	CustomTags []Tag       `yaml:"customTags"`
-	Dimensions []Dimension `yaml:"dimensions"`
-	Metrics    []*Metric   `yaml:"metrics"`
+	Name           string   `yaml:"name"`
+	Regions        []string `yaml:"regions"`
+	Roles          []Role   `yaml:"roles"`
+	Namespace      string   `yaml:"namespace"`
+	CustomTagsList []Tag    `yaml:"customTags"`
+	CustomTags     map[string]string
+	Dimensions     []Dimension `yaml:"dimensions"`
+	Metrics        []*Metric   `yaml:"metrics"`
 }
 
 type Role struct {
@@ -80,15 +83,27 @@ func (c *ScrapeConf) Load(file *string) error {
 		return err
 	}
 
-	for _, job := range c.Discovery.Jobs {
+	for n, job := range c.Discovery.Jobs {
 		if len(job.Roles) == 0 {
 			job.Roles = []Role{{}} // use current IAM role
 		}
+		c.Discovery.Jobs[n].SearchTags = map[string]string{}
+		for _, tag := range c.Discovery.Jobs[n].SearchTagsList {
+			c.Discovery.Jobs[n].SearchTags[tag.Key] = tag.Value
+		}
+		c.Discovery.Jobs[n].CustomTags = map[string]string{}
+		for _, tag := range c.Discovery.Jobs[n].CustomTagsList {
+			c.Discovery.Jobs[n].CustomTags[tag.Key] = tag.Value
+		}
 	}
 
-	for _, job := range c.Static {
+	for n, job := range c.Static {
 		if len(job.Roles) == 0 {
 			job.Roles = []Role{{}} // use current IAM role
+		}
+		c.Static[n].CustomTags = map[string]string{}
+		for _, tag := range c.Discovery.Jobs[n].SearchTagsList {
+			c.Static[n].CustomTags[tag.Key] = tag.Value
 		}
 	}
 

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -141,7 +141,7 @@ var (
 							}
 
 							for _, t := range asg.Tags {
-								resource.Tags = append(resource.Tags, &Tag{Key: *t.Key, Value: *t.Value})
+								resource.Tags[*t.Key] = *t.Value
 							}
 
 							if resource.filterThroughTags(job.SearchTags) {
@@ -255,7 +255,7 @@ var (
 							}
 
 							for _, t := range ec2Spot.Tags {
-								resource.Tags = append(resource.Tags, &Tag{Key: *t.Key, Value: *t.Value})
+								resource.Tags[*t.Key] = *t.Value
 							}
 
 							if resource.filterThroughTags(job.SearchTags) {
@@ -533,7 +533,7 @@ var (
 							}
 
 							for _, t := range tgwa.Tags {
-								resource.Tags = append(resource.Tags, &Tag{Key: *t.Key, Value: *t.Value})
+								resource.Tags[*t.Key] = *t.Value
 							}
 
 							if resource.filterThroughTags(job.SearchTags) {


### PR DESCRIPTION
AWS API always refers to tags as a list of structs with Key and Value fields, but I've never seen a good reason why we couldn't address tags as a map. The map is much more convenient than the list for our purposes since we don't care about the order in which tags appear in API calls. 
The only downside (that I've been able to figure out) is that we have to convert a list of structs into the map, because we can use it.