### PR TITLE
skip metric if Cloudwatch timestamp is enabled and no metric data - fixed

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -502,7 +502,7 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData, labelsSnakeCase bool) 
 				includeTimestamp = *c.AddCloudwatchTimestamp
 			}
 			exportedDatapoint, timestamp := getDatapoint(c, statistic)
-			if exportedDatapoint == nil && c.AddCloudwatchTimestamp == nil {
+			if exportedDatapoint == nil && !*c.AddCloudwatchTimestamp {
 				var nan float64 = math.NaN()
 				exportedDatapoint = &nan
 				includeTimestamp = false


### PR DESCRIPTION
my previous pull request https://github.com/ivx/yet-another-cloudwatch-exporter/pull/383 was not correct and introduced regression, this pull request fixes it. So please consider releasing 0.28.1 minor version with this fix.