### PR TITLE
[tags] If resoruce tag list is empty, it is probably misconfiguration that needs more context

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -37,6 +37,7 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					}
 
 					clientTag := tagsInterface{
+						account:          *accountId,
 						client:           createTagSession(&region, role, fips),
 						apiGatewayClient: createAPIGatewaySession(&region, role, fips),
 						asgClient:        createASGSession(&region, role, fips),

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -28,6 +28,7 @@ type tagsData struct {
 
 // https://docs.aws.amazon.com/sdk-for-go/api/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface/
 type tagsInterface struct {
+	account          string
 	client           resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	asgClient        autoscalingiface.AutoScalingAPI
 	apiGatewayClient apigatewayiface.APIGatewayAPI
@@ -110,7 +111,7 @@ func (iface tagsInterface) get(job *Job, region string) (resources []*tagsData, 
 			resourceGroupTaggingAPICounter.Inc()
 
 			if len(page.ResourceTagMappingList) == 0 {
-				log.Debugf("Resource tag list is empty. Tags must be defined for %s to be discovered.", job.Type)
+				log.Errorf("Resource tag list is empty (in %s). Tags must be defined for %s to be discovered.", iface.account, job.Type)
 			}
 
 			for _, resourceTagMapping := range page.ResourceTagMappingList {


### PR DESCRIPTION
Based on my own mistakes in upgrade process:
- `Resource tag list is empty. Tags must be defined for ...` is something that probably means misconfiguration and as such, I would like to see it as error message.
- Message on its own doesn't help you much, if you have something like 5+ accounts in your configuration setup. If we can add account information into error message, it gives us much better tools to figure out what the issue is.

On my case, I was sure that I have made the roleArns related change into config file (but turns out that I hadn't).  When I added account information into error message, it was trying to find `ecs-svc` resources on an AWS account that doesn't have ECS cluster and suddenly things started to make sense.