### PR TITLE
Scrape discovery job using metric data

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -199,18 +199,19 @@ func scrapeDiscoveryJobUsingMetricData(
 
 	svc := SupportedServices.GetService(job.Type)
 	getMetricDatas := getMetricDataForQueries(job, svc, region, accountId, tagsOnMetrics, clientCloudwatch, resources, tagSemaphore)
-	maxMetricCount := metricsPerQuery
 	metricDataLength := len(getMetricDatas)
+	if metricDataLength == 0 {
+		log.Debugf("No metrics data for %s", job.Type)
+		return
+	}
+
+	maxMetricCount := metricsPerQuery
 	length := GetMetricDataInputLength(job)
 	partition := int(math.Ceil(float64(metricDataLength) / float64(maxMetricCount)))
 
 	mux := &sync.Mutex{}
 	var wg sync.WaitGroup
 	wg.Add(partition)
-
-	if metricDataLength == 0 {
-		log.Debugf("No metrics data for %s", job.Type)
-	}
 
 	for i := 0; i < metricDataLength; i += maxMetricCount {
 		go func(i int) {


### PR DESCRIPTION
59426d2 - commit does early bailout if we don't have metric data, since there is nothing to do at the end of function.

cbd57f5 - builds metric data into local array and once the for loop has been finished with merge results into cw. This way, we don't have to mux.Lock() and mux.Unlock()  for every MetricDataResult.