### PR TITLE
[config] Add version field into format

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ We will contact you as soon as possible.
 
 ### Top level configuration
 
-| Key       | Description                       |
-| --------- | --------------------------------- |
-| version   | Configuration file version number |
-| discovery | Auto-discovery configuration      |
-| static    | List of static configurations     |
+| Key        | Description                   |
+| ---------- | ----------------------------- |
+| apiVersion | Configuration file version    |
+| discovery  | Auto-discovery configuration  |
+| static     | List of static configurations |
 
 ### Auto-discovery configuration
 
@@ -175,7 +175,7 @@ general setting.  The currently inherited settings are period, and addCloudwatch
 ### Example of config File
 
 ```yaml
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   exportedTagsOnMetrics:
     ec2:

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ We will contact you as soon as possible.
 
 ### Top level configuration
 
-| Key       | Description                   |
-| --------- | ----------------------------- |
-| discovery | Auto-discovery configuration  |
-| static    | List of static configurations |
+| Key       | Description                             |
+| --------- | --------------------------------------- |
+| version   | Configuration file version number (int) |
+| discovery | Auto-discovery configuration            |
+| static    | List of static configurations           |
 
 ### Auto-discovery configuration
 
@@ -174,6 +175,7 @@ general setting.  The currently inherited settings are period, and addCloudwatch
 ### Example of config File
 
 ```yaml
+version: 0
 discovery:
   exportedTagsOnMetrics:
     ec2:

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ We will contact you as soon as possible.
 
 ### Top level configuration
 
-| Key       | Description                             |
-| --------- | --------------------------------------- |
-| version   | Configuration file version number (int) |
-| discovery | Auto-discovery configuration            |
-| static    | List of static configurations           |
+| Key       | Description                       |
+| --------- | --------------------------------- |
+| version   | Configuration file version number |
+| discovery | Auto-discovery configuration      |
+| static    | List of static configurations     |
 
 ### Auto-discovery configuration
 
@@ -175,7 +175,7 @@ general setting.  The currently inherited settings are period, and addCloudwatch
 ### Example of config File
 
 ```yaml
-version: 0
+version: v1alpha1
 discovery:
   exportedTagsOnMetrics:
     ec2:

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ScrapeConf struct {
-	Version   int       `yaml:"version"`
+	Version   string    `yaml:"version"`
 	Discovery Discovery `yaml:"discovery"`
 	Static    []*Static `yaml:"static"`
 }
@@ -122,8 +122,8 @@ func (c *ScrapeConf) Validate() error {
 			}
 		}
 	}
-	if c.Version != 0 {
-		return fmt.Errorf("version line missing or version is unknown (%d)", c.Version)
+	if c.Version != "" && c.Version != "v1alpha1" {
+		return fmt.Errorf("version line missing or version is unknown (%s)", c.Version)
 	}
 
 	return nil

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 type ScrapeConf struct {
+	Version   int       `yaml:"version"`
 	Discovery Discovery `yaml:"discovery"`
 	Static    []*Static `yaml:"static"`
 }
@@ -120,6 +121,9 @@ func (c *ScrapeConf) Validate() error {
 				return err
 			}
 		}
+	}
+	if c.Version != 0 {
+		return fmt.Errorf("version line missing or version is unknown (%d)", c.Version)
 	}
 
 	return nil

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -10,9 +10,9 @@ import (
 )
 
 type ScrapeConf struct {
-	Version   string    `yaml:"version"`
-	Discovery Discovery `yaml:"discovery"`
-	Static    []*Static `yaml:"static"`
+	ApiVersion string    `yaml:"apiVersion"`
+	Discovery  Discovery `yaml:"discovery"`
+	Static     []*Static `yaml:"static"`
 }
 
 type Discovery struct {
@@ -122,8 +122,8 @@ func (c *ScrapeConf) Validate() error {
 			}
 		}
 	}
-	if c.Version != "" && c.Version != "v1alpha1" {
-		return fmt.Errorf("version line missing or version is unknown (%s)", c.Version)
+	if c.ApiVersion != "" && c.ApiVersion != "v1alpha1" {
+		return fmt.Errorf("apiVersion line missing or version is unknown (%s)", c.ApiVersion)
 	}
 
 	return nil

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -35,6 +35,9 @@ func TestBadConfigs(t *testing.T) {
 		}, {
 			configFile: "externalid_with_empty_rolearn.bad.yml",
 			errorMsg:   "RoleArn should not be empty",
+		}, {
+			configFile: "unknown_version.bad.yml",
+			errorMsg:   "version line missing or version is unknown (101)",
 		},
 	}
 

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -37,7 +37,7 @@ func TestBadConfigs(t *testing.T) {
 			errorMsg:   "RoleArn should not be empty",
 		}, {
 			configFile: "unknown_version.bad.yml",
-			errorMsg:   "version line missing or version is unknown (invalidVersion)",
+			errorMsg:   "apiVersion line missing or version is unknown (invalidVersion)",
 		},
 	}
 

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -37,7 +37,7 @@ func TestBadConfigs(t *testing.T) {
 			errorMsg:   "RoleArn should not be empty",
 		}, {
 			configFile: "unknown_version.bad.yml",
-			errorMsg:   "version line missing or version is unknown (101)",
+			errorMsg:   "version line missing or version is unknown (invalidVersion)",
 		},
 	}
 

--- a/pkg/testdata/config_test.yml
+++ b/pkg/testdata/config_test.yml
@@ -1,4 +1,4 @@
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   exportedTagsOnMetrics:
     ebs:

--- a/pkg/testdata/config_test.yml
+++ b/pkg/testdata/config_test.yml
@@ -1,4 +1,4 @@
-version: 0
+version: v1alpha1
 discovery:
   exportedTagsOnMetrics:
     ebs:

--- a/pkg/testdata/empty_rolearn.ok.yml
+++ b/pkg/testdata/empty_rolearn.ok.yml
@@ -1,4 +1,4 @@
-version: 0
+version: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/empty_rolearn.ok.yml
+++ b/pkg/testdata/empty_rolearn.ok.yml
@@ -1,3 +1,4 @@
+version: 0
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/empty_rolearn.ok.yml
+++ b/pkg/testdata/empty_rolearn.ok.yml
@@ -1,4 +1,4 @@
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_with_empty_rolearn.bad.yml
+++ b/pkg/testdata/externalid_with_empty_rolearn.bad.yml
@@ -1,4 +1,4 @@
-version: 0
+version: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_with_empty_rolearn.bad.yml
+++ b/pkg/testdata/externalid_with_empty_rolearn.bad.yml
@@ -1,3 +1,4 @@
+version: 0
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_with_empty_rolearn.bad.yml
+++ b/pkg/testdata/externalid_with_empty_rolearn.bad.yml
@@ -1,4 +1,4 @@
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_without_rolearn.bad.yml
+++ b/pkg/testdata/externalid_without_rolearn.bad.yml
@@ -1,4 +1,4 @@
-version: 0
+version: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_without_rolearn.bad.yml
+++ b/pkg/testdata/externalid_without_rolearn.bad.yml
@@ -1,3 +1,4 @@
+version: 0
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/externalid_without_rolearn.bad.yml
+++ b/pkg/testdata/externalid_without_rolearn.bad.yml
@@ -1,4 +1,4 @@
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/multiple_roles.ok.yml
+++ b/pkg/testdata/multiple_roles.ok.yml
@@ -1,4 +1,4 @@
-version: 0
+version: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/multiple_roles.ok.yml
+++ b/pkg/testdata/multiple_roles.ok.yml
@@ -1,3 +1,4 @@
+version: 0
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/multiple_roles.ok.yml
+++ b/pkg/testdata/multiple_roles.ok.yml
@@ -1,4 +1,4 @@
-version: v1alpha1
+apiVersion: v1alpha1
 discovery:
   jobs:
   - type: s3

--- a/pkg/testdata/unknown_version.bad.yml
+++ b/pkg/testdata/unknown_version.bad.yml
@@ -1,4 +1,4 @@
-version: 101
+version: invalidVersion
 discovery:
   exportedTagsOnMetrics:
     ebs:

--- a/pkg/testdata/unknown_version.bad.yml
+++ b/pkg/testdata/unknown_version.bad.yml
@@ -1,4 +1,4 @@
-version: 0
+version: 101
 discovery:
   exportedTagsOnMetrics:
     ebs:

--- a/pkg/testdata/unknown_version.bad.yml
+++ b/pkg/testdata/unknown_version.bad.yml
@@ -1,4 +1,4 @@
-version: invalidVersion
+apiVersion: invalidVersion
 discovery:
   exportedTagsOnMetrics:
     ebs:


### PR DESCRIPTION
Version field in configuration file would give us easy way to ensure that user is aware of any breaking changes that might have happened (like that change with `roles` in 0.28.0-alpha). When exporter reaches more mature level, it might also be used as basis for figuring out if we want to offer some sort of backward compatibility between different configuration file format.

In this pull request, we use version zero as a starting point simply because I don't want to force people to set it, before we actually have actual breaking change that users should be aware of.