### PR TITLE
Fix nilToZero

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -502,7 +502,7 @@ func migrateCloudwatchToPrometheus(cwd []*cloudwatchData, labelsSnakeCase bool) 
 				includeTimestamp = *c.AddCloudwatchTimestamp
 			}
 			exportedDatapoint, timestamp := getDatapoint(c, statistic)
-			if exportedDatapoint == nil && c.AddCloudwatchTimestamp == nil {
+			if exportedDatapoint == nil && (c.AddCloudwatchTimestamp == nil || *c.AddCloudwatchTimestamp == false) {
 				var nan float64 = math.NaN()
 				exportedDatapoint = &nan
 				includeTimestamp = false


### PR DESCRIPTION
Hello,
After upgrading yace to latest we noticed that nilToZero does not work as expected , this pr fixes it for the case that 
 * there is ALB to monitor 
 * cloudwatch returns no value for some metrics for this given alb e.g.  HTTPCode_ELB_5XX_Count (aws_alb_httpcode_target_5_xx_count_sum)

c.AddCloudwatchTimestamp is not nil , it is false even if you dont define it on config file. So it never gets into this if block.

note: if there is no resource to monitor and you still want zero valued metrics to be generated like older releases does , this doesn't fix it. 

```
discovery:
  jobs:
  - type: alb
    regions:
      - us-east-1
    metrics:
      - name: HTTPCode_Target_5XX_Count
        statistics:
        - 'Sum'
        period: 60
        length: 600
        delay: 120
        nilToZero: true
```