### PR TITLE
Fix race condition setting end time for discovery jobs.

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -235,7 +235,9 @@ func scrapeDiscoveryJobUsingMetricData(
 					}
 				}
 			}
+			mux.Lock()
 			endtime = *filter.EndTime
+			mux.Unlock()
 		}(i)
 	}
 	//here set end time as start time


### PR DESCRIPTION
This fixes a data race happening when goroutines calling GetMetricData
attempt to update the `endtime` variable.