### PR TITLE
Filter start & endtime fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ yet-another-cloudwatch-exporter
 vendor
 dist
 yace
+
+# editor guff
+.*.swp
+.*.swo
+*~
+.vscode

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -163,10 +163,10 @@ func (s *scraper) scrape(ctx context.Context) (err error) {
 	defer sem.Release(1)
 
 	newRegistry := prometheus.NewRegistry()
-	endtime := exporter.UpdateMetrics(config, newRegistry, s.now, *metricsPerQuery, *fips, *floatingTimeWindow, *labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore)
+	s.now = time.Now().Add(-150 * time.Second).Round(5 * time.Minute)
+	exporter.UpdateMetrics(config, newRegistry, s.now, *metricsPerQuery, *fips, *floatingTimeWindow, *labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore)
 	// this might have a data race to access registry
 	s.registry = newRegistry
-	s.now = endtime
 	log.Debug("Metrics scraped.")
 	return nil
 }

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -118,21 +118,18 @@ func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string,
 
 	}
 
-	var endTime time.Time
-	var startTime time.Time
 	if now.IsZero() {
 		//This is first run
 		if floatingTimeWindow {
 			now = time.Now()
 		} else {
-			now = time.Now().Round(5 * time.Minute)
+			// round down to nearest 5min
+			now = time.Now().Add(-150 * time.Second).Round(5 * time.Minute)
 		}
-		endTime = now.Add(-time.Duration(delay) * time.Second)
-		startTime = now.Add(-(time.Duration(length) + time.Duration(delay)) * time.Second)
-	} else {
-		endTime = now.Add(time.Duration(length) * time.Second)
-		startTime = now
 	}
+
+	startTime := now.Add(-(time.Duration(length) + time.Duration(delay)) * time.Second)
+	endTime := now.Add(-time.Duration(delay) * time.Second)
 
 	dataPointOrder := "TimestampDescending"
 	output = &cloudwatch.GetMetricDataInput{

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -123,7 +123,8 @@ func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string,
 		if floatingTimeWindow {
 			now = time.Now()
 		} else {
-			// round down to nearest 5min
+			// Round down to last 5min - rounding is recommended by AWS:
+			// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html#API_GetMetricData_RequestParameters
 			now = time.Now().Add(-150 * time.Second).Round(5 * time.Minute)
 		}
 	}


### PR DESCRIPTION
This PR fixes the `StartTime` & `EndTime` in the filter provided to `getMetricData()` AFAICT.  It:
* stops the next iteration using the endtime of the previous iteration
* adds an initial scrape for decoupled scraping, otherwise you need to wait (a default of 5min) before getting any response
* changes the rounding from nearest 5min, to the previous 5min

We have had trouble collecting S3 bucket size for a while.  On further inspection, it seems that the window calculations are wrong.  Initially, the first scrape worked, then gave no results for subsequent iterations of decoupled scrapes.  With the latest release, weren't getting any results.

When testing with the following config:
```
    metrics:
      - name: BucketSizeBytes
        statistics:
          - Average
        period: 86400
        length: 172800
        delay: 0
        addCloudwatchTimestamp: false
```

Were getting the following:
```
> date; timeout 50 ./yace -debug -scraping-interval=10 > /tmp/log; cat /tmp/log | rg "StartTime:" | sed -e 's/\\n/\n/g' | rg "(Start|End)Time"
Fri 17 Sep 2021 21:48:35 AEST
  EndTime: 2021-09-17 21:50:00 +1000 AEST,
  StartTime: 2021-09-15 21:50:00 +1000 AEST
  EndTime: 2021-09-19 21:50:00 +1000 AEST,
  StartTime: 2021-09-17 21:50:00 +1000 AEST
  EndTime: 2021-09-21 21:50:00 +1000 AEST,
  StartTime: 2021-09-19 21:50:00 +1000 AEST
  EndTime: 2021-09-23 21:50:00 +1000 AEST,
  StartTime: 2021-09-21 21:50:00 +1000 AEST
```
i.e. the window moved 2days into the future every iteration.
Also note the time rounded up (from minute 48 to 50), which could cause gaps.

These updates ->
```
> timeout 50 ./yace -debug -scraping-interval=20 > /tmp/log; cat /tmp/log | rg "StartTime:" | sed -e 's/\\n/\n/g' | rg "(Start|End)Time"
  EndTime: 2021-09-17 21:25:00 +1000 AEST,
  StartTime: 2021-09-15 21:25:00 +1000 AEST
  EndTime: 2021-09-17 21:25:00 +1000 AEST,
  StartTime: 2021-09-15 21:25:00 +1000 AEST
  EndTime: 2021-09-17 21:30:00 +1000 AEST,
  StartTime: 2021-09-15 21:30:00 +1000 AEST
```

Also tested with `./yace -debug -decoupled-scraping=false` with similar positive results.

If I had more time I'd add some tests, but it's not super easy to simulate..