### PR TITLE
Refactor tagsData (now taggedResource) and add test cases.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,11 +23,7 @@ jobs:
 
     - name: Get dependencies
       run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+        go mod download
 
     - name: Build
       run: go build -o yace cmd/yace/main.go

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
 
-	exporter "github.com/ivx/yet-another-cloudwatch-exporter/pkg"
+	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
 )
 
 var version = "custom-build"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ivx/yet-another-cloudwatch-exporter
+module github.com/nerdswords/yet-another-cloudwatch-exporter
 
 go 1.17
 
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.37
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -13,12 +14,15 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
 	google.golang.org/protobuf v1.26.0-rc.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -160,3 +161,5 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/abstract_test.go
+++ b/pkg/abstract_test.go
@@ -9,7 +9,7 @@ func TestFilterThroughTags(t *testing.T) {
 
 	// Arrange
 	expected := true
-	tagsData := tagsData{}
+	tagsData := taggedResource{}
 	filterTags := []Tag{}
 
 	// Act

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -65,7 +65,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		customTags       []Tag
 		tagsOnMetrics    exportedTagsOnMetrics
 		dimensionRegexps []*string
-		resources        []*tagsData
+		resources        []*taggedResource
 		metricsList      []*cloudwatch.Metric
 		m                *Metric
 	}
@@ -88,17 +88,17 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 				},
 				dimensionRegexps: SupportedServices.GetService("ec2").DimensionRegexps,
-				resources: []*tagsData{
+				resources: []*taggedResource{
 					{
-						ID: aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
-						Tags: []*Tag{
+						ARN: "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
+						Tags: []Tag{
 							{
 								Key:   "Name",
 								Value: "some-Node",
 							},
 						},
-						Namespace: aws.String("ec2"),
-						Region:    aws.String("us-east-1"),
+						Namespace: "ec2",
+						Region:    "us-east-1",
 					},
 				},
 				metricsList: []*cloudwatch.Metric{
@@ -171,17 +171,17 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 				},
 				dimensionRegexps: SupportedServices.GetService("kafka").DimensionRegexps,
-				resources: []*tagsData{
+				resources: []*taggedResource{
 					{
-						ID: aws.String("arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12"),
-						Tags: []*Tag{
+						ARN: "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
+						Tags: []Tag{
 							{
 								Key:   "Test",
 								Value: "Value",
 							},
 						},
-						Namespace: aws.String("kafka"),
-						Region:    aws.String("us-east-1"),
+						Namespace: "kafka",
+						Region:    "us-east-1",
 					},
 				},
 				metricsList: []*cloudwatch.Metric{

--- a/pkg/aws_tags_test.go
+++ b/pkg/aws_tags_test.go
@@ -2,38 +2,313 @@ package exporter
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestMigrateTagsToPrometheus(t *testing.T) {
-	// Setup Test
-	id := "tag_Id"
-	namespace := "AWS/Service"
-	region := "us-east-1"
-	tagItem := Tag{Key: "Name", Value: "tag_Value"}
-	tags := []*Tag{&tagItem}
-	tagData := tagsData{ID: &id, Namespace: &namespace, Region: &region, Tags: tags}
-	tagsData := []*tagsData{&tagData}
+func Test_FilterThroughTags(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		resourceTags []Tag
+		filterTags   []Tag
+		result       bool
+	}{
+		{
+			testName: "exactly matching tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			result: true,
+		},
+		{
+			testName: "unmatching tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k2",
+					Value: "v2",
+				},
+			},
+			result: false,
+		},
+		{
+			testName: "resource has more tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+				{
+					Key:   "k2",
+					Value: "v2",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			result: true,
+		},
+		{
+			testName: "filter has more tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+				{
+					Key:   "k2",
+					Value: "v2",
+				},
+			},
+			result: false,
+		},
+		{
+			testName: "unmatching tag key",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k2",
+					Value: "v1",
+				},
+			},
+			result: false,
+		},
+		{
+			testName: "unmatching tag value",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v2",
+				},
+			},
+			result: false,
+		},
+		{
+			testName:     "resource without tags",
+			resourceTags: []Tag{},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v2",
+				},
+			},
+			result: false,
+		},
+		{
+			testName: "empty filter tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{},
+			result:     true,
+		},
+		{
+			testName: "filter with value regex",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			filterTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v.*",
+				},
+			},
+			result: true,
+		},
+	}
 
-	// Arrange
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			res := taggedResource{
+				ARN:       "aws::arn",
+				Namespace: "AWS/Service",
+				Region:    "us-east-1",
+				Tags:      tc.resourceTags,
+			}
+
+			require.Equal(t, tc.result, res.filterThroughTags(tc.filterTags))
+		})
+	}
+}
+
+func Test_MetricTags(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		resourceTags []Tag
+		exportedTags exportedTagsOnMetrics
+		result       []Tag
+	}{
+		{
+			testName: "empty exported tag",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			exportedTags: exportedTagsOnMetrics{},
+			result:       []Tag{},
+		},
+		{
+			testName: "single exported tag",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			exportedTags: exportedTagsOnMetrics{
+				"AWS/Service": []string{"k1"},
+			},
+			result: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+		},
+		{
+			testName: "multiple exported tags",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			exportedTags: exportedTagsOnMetrics{
+				"AWS/Service": []string{"k1", "k2"},
+			},
+			result: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+				{
+					Key:   "k2",
+					Value: "",
+				},
+			},
+		},
+		{
+			testName:     "resource without tags",
+			resourceTags: []Tag{},
+			exportedTags: exportedTagsOnMetrics{
+				"AWS/Service": []string{"k1"},
+			},
+			result: []Tag{
+				{
+					Key:   "k1",
+					Value: "",
+				},
+			},
+		},
+		{
+			testName: "empty exported tags for service",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			exportedTags: exportedTagsOnMetrics{
+				"AWS/Service": []string{},
+			},
+			result: []Tag{},
+		},
+		{
+			testName: "unmatching service",
+			resourceTags: []Tag{
+				{
+					Key:   "k1",
+					Value: "v1",
+				},
+			},
+			exportedTags: exportedTagsOnMetrics{
+				"AWS/Service_unknown": []string{"k1"},
+			},
+			result: []Tag{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			res := taggedResource{
+				ARN:       "aws::arn",
+				Namespace: "AWS/Service",
+				Region:    "us-east-1",
+				Tags:      tc.resourceTags,
+			}
+
+			require.Equal(t, tc.result, res.metricTags(tc.exportedTags))
+		})
+	}
+}
+
+func Test_MigrateTagsToPrometheus(t *testing.T) {
+	resources := []*taggedResource{{
+		ARN:       "aws::arn",
+		Namespace: "AWS/Service",
+		Region:    "us-east-1",
+		Tags: []Tag{
+			{
+				Key:   "Name",
+				Value: "tag_Value",
+			},
+		},
+	}}
+
 	prometheusMetricName := "aws_service_info"
-	promLabels := make(map[string]string)
-	promLabels["name"] = "tag_Id"
-	promLabels["tag_Name"] = "tag_Value"
 	var metricValue float64 = 0
+	expected := []*PrometheusMetric{{
+		name: &prometheusMetricName,
+		labels: map[string]string{
+			"name":     "aws::arn",
+			"tag_Name": "tag_Value",
+		},
+		value: &metricValue,
+	}}
 
-	p := PrometheusMetric{
-		name:   &prometheusMetricName,
-		labels: promLabels,
-		value:  &metricValue,
-	}
-	expected := []*PrometheusMetric{&p}
+	actual := migrateTagsToPrometheus(resources, false)
 
-	// Act
-	actual := migrateTagsToPrometheus(tagsData, false)
-
-	// Assert
-	if *actual[0].name != *expected[0].name {
-		t.Fatalf("\nexpected: %q\nactual:  %q", len(expected), len(actual))
-	}
-
+	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
This is a minor refactoring around the code in `aws_tags.go`:
- rename struct to taggedResource
- move methods next to the receiver
- cleanup taggedResource fields (`ID`->`ARN`, no pointers)
- add tests

No user-facing functionality is changed here.