### PR TITLE
fix apigateway method and resouce dimension bug

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -65,8 +65,6 @@ var (
 			DimensionRegexps: []*string{
 				aws.String("apis/(?P<ApiName>[^/]+)$"),
 				aws.String("apis/(?P<ApiName>[^/]+)/stages/(?P<Stage>[^/]+)$"),
-				aws.String("apis/(?P<ApiName>[^/]+)/resources/(?P<Resource>[^/]+)$"),
-				aws.String("apis/(?P<ApiName>[^/]+)/resources/(?P<Resource>[^/]+)/methods/(?P<Method>[^/]+)$"),
 			},
 			FilterFunc: func(iface tagsInterface, inputResources []*taggedResource) (outputResources []*taggedResource, err error) {
 				ctx := context.Background()


### PR DESCRIPTION
Those two regexps where failing when using detailed cloudwatch metrics to show Resource and Method dimensions. 
Closes #416 