### PR TITLE
Allow setting default statistics in job config

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ discovery:
       - eu-west-1
     length: 900
     delay: 120
+    statistics:
+      - Minimum
+      - Maximum
+      - Sum
     searchTags:
       - key: KubernetesCluster
         value: production-19
@@ -239,6 +243,8 @@ discovery:
         length: 900 #(this will be ignored)
         delay: 300 #(this will be ignored)
         nilToZero: true
+      - name: HTTPCode_Backend_5XX
+        period: 60
   - type: alb
     regions:
       - eu-west-1

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -32,6 +32,7 @@ type Job struct {
 	Length                 int       `yaml:"length"`
 	Delay                  int       `yaml:"delay"`
 	Period                 int       `yaml:"period"`
+	Statistics             []string  `yaml:"statistics"`
 	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
 	NilToZero              *bool     `yaml:"nilToZero"`
 }
@@ -201,9 +202,16 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *Job) er
 	if m.Name == "" {
 		return fmt.Errorf("Metric [%s/%d] in %v: Name should not be empty", m.Name, metricIdx, parent)
 	}
-	if len(m.Statistics) == 0 {
-		return fmt.Errorf("Metric [%s/%d] in %v: Statistics should not be empty", m.Name, metricIdx, parent)
+
+	mStatistics := m.Statistics
+	if len(mStatistics) == 0 && discovery != nil {
+		if len(discovery.Statistics) > 0 {
+			mStatistics = discovery.Statistics
+		} else {
+			return fmt.Errorf("Metric [%s/%d] in %v: Statistics should not be empty", m.Name, metricIdx, parent)
+		}
 	}
+
 	mPeriod := m.Period
 	if mPeriod == 0 && discovery != nil {
 		if discovery.Period != 0 {
@@ -261,6 +269,7 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *Job) er
 	m.Delay = mDelay
 	m.NilToZero = mNilToZero
 	m.AddCloudwatchTimestamp = mAddCloudwatchTimestamp
+	m.Statistics = mStatistics
 
 	return nil
 }

--- a/pkg/testdata/config_test.yml
+++ b/pkg/testdata/config_test.yml
@@ -47,6 +47,10 @@ discovery:
       - eu-west-1
     length: 900
     delay: 120
+    statistics:
+      - Minimum
+      - Maximum
+      - Sum
     searchTags:
       - Key: KubernetesCluster
         Value: production-19
@@ -63,6 +67,8 @@ discovery:
         length: 900 #(this will be ignored)
         delay: 300 #(this will be ignored)
         nilToZero: true
+      - name: HTTPCode_Backend_5XX
+        period: 60
   - type: alb
     regions:
       - eu-west-1


### PR DESCRIPTION
We can already set default values for most values, but we can't for statistics, and force the user to explicitly set them. I cannot
immediately see why we can't also set statistics with a default value.

This copies the logic for other values, but instead of setting a default, it fails if neither a default or an explicit value is set.