### PR TITLE
Fix the calculation of start and end times for GetMetricData

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ We will contact you as soon as possible.
 | Option               | Description                                                                       |
 | -------------------- | --------------------------------------------------------------------------------- |
 | labels-snake-case    | Causes labels on metrics to be output in snake case instead of camel case         |
-| floating-time-window | Use a floating start/end time window instead of rounding times to 5 min intervals |
 
 ### Top level configuration
 
@@ -133,12 +132,13 @@ Note: Only [tagged resources](https://docs.aws.amazon.com/general/latest/gr/aws_
 | Key                    | Description                                                                                              |
 | ---------------------- | -------------------------------------------------------------------------------------------------------- |
 | regions                | List of AWS regions                                                                                      |
-| type                   | Cloudwatch service alias ("alb", "ec2", etc) or namespace name ("AWS/EC2", "AWS/S3", etc).                                                |
+| type                   | Cloudwatch service alias ("alb", "ec2", etc) or namespace name ("AWS/EC2", "AWS/S3", etc).               |
 | length (Default 120)   | How far back to request data for in seconds                                                              |
 | delay                  | If set it will request metrics up until `current_time - delay`                                           |
 | roles                  | List of IAM roles to assume (optional)                                                                   |
 | searchTags             | List of Key/Value pairs to use for tag filtering (all must match), Value can be a regex.                 |
 | period                 | Statistic period in seconds (General Setting for all metrics in this job)                                |
+| roundingPeriod         | Specifies how the current time is rounded before calculating start/end times for CloudWatch GetMetricData requests. This rounding is optimize performance of the CloudWatch request. This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes).  to For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.                     |
 | addCloudwatchTimestamp | Export the metric with the original CloudWatch timestamp (General Setting for all metrics in this job)   |
 | customTags             | Custom tags to be added as a list of Key/Value pairs                                                     |
 | metrics                | List of metric definitions                                                                               |

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -281,3 +281,94 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		})
 	}
 }
+
+// StubClock stub implementation of Clock interface that allows tests
+// to control time.Now()
+type StubClock struct {
+	currentTime time.Time
+}
+
+func (mt StubClock) Now() time.Time {
+	return mt.currentTime
+}
+
+func Test_MetricWindow(t *testing.T) {
+
+	type data struct {
+		roundingPeriod    time.Duration
+		length            time.Duration
+		delay             time.Duration
+		clock             StubClock
+		expectedStartTime time.Time
+		expectedEndTime   time.Time
+	}
+
+	testCases := []struct {
+		testName string
+		data     data
+	}{
+		{
+			testName: "Go back four minutes and round to the nearest two minutes with two minute delay",
+			data: data{
+				roundingPeriod: 120 * time.Second,
+				length:         120 * time.Second,
+				delay:          120 * time.Second,
+				clock: StubClock{
+					currentTime: time.Date(2021, 11, 20, 0, 0, 0, 0, time.UTC),
+				},
+				expectedStartTime: time.Date(2021, 11, 19, 23, 56, 0, 0, time.UTC),
+				expectedEndTime:   time.Date(2021, 11, 19, 23, 58, 0, 0, time.UTC),
+			},
+		},
+		{
+			testName: "Go back four minutes with two minute delay nad no rounding",
+			data: data{
+				roundingPeriod: 0,
+				length:         120 * time.Second,
+				delay:          120 * time.Second,
+				clock: StubClock{
+					currentTime: time.Date(2021, 1, 1, 0, 02, 22, 33, time.UTC),
+				},
+				expectedStartTime: time.Date(2020, 12, 31, 23, 58, 22, 33, time.UTC),
+				expectedEndTime:   time.Date(2021, 1, 1, 0, 0, 22, 33, time.UTC),
+			},
+		},
+		{
+			testName: "Go back two days and round to the nearest day (midnight) with zero delay",
+			data: data{
+				roundingPeriod: 86400 * time.Second,  // 1 day
+				length:         172800 * time.Second, // 2 days
+				delay:          0,
+				clock: StubClock{
+					currentTime: time.Date(2021, 11, 20, 8, 33, 44, 0, time.UTC),
+				},
+				expectedStartTime: time.Date(2021, 11, 18, 0, 0, 0, 0, time.UTC),
+				expectedEndTime:   time.Date(2021, 11, 20, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			testName: "Go back two days and round to the nearest 5 minutes with zero delay",
+			data: data{
+				roundingPeriod: 300 * time.Second,    // 5 min
+				length:         172800 * time.Second, // 2 days
+				delay:          0,
+				clock: StubClock{
+					currentTime: time.Date(2021, 11, 20, 8, 33, 44, 0, time.UTC),
+				},
+				expectedStartTime: time.Date(2021, 11, 18, 8, 30, 0, 0, time.UTC),
+				expectedEndTime:   time.Date(2021, 11, 20, 8, 30, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+
+			startTime, endTime := determineGetMetricDataWindow(tc.data.clock, tc.data.roundingPeriod, tc.data.length, tc.data.delay)
+			if !startTime.Equal(tc.data.expectedStartTime) {
+				t.Errorf("start time incorrect. Expected: %s, Actual: %s", tc.data.expectedStartTime.Format(timeFormat), startTime.Format(timeFormat))
+				t.Errorf("end time incorrect. Expected: %s, Actual: %s", tc.data.expectedEndTime.Format(timeFormat), endTime.Format(timeFormat))
+			}
+		})
+	}
+}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const defaultPeriodSeconds = int64(300)
+const defaultLengthSeconds = int64(300)
+const defaultDelaySeconds = int64(300)
+
 type ScrapeConf struct {
 	ApiVersion string    `yaml:"apiVersion"`
 	Discovery  Discovery `yaml:"discovery"`
@@ -29,9 +33,10 @@ type Job struct {
 	SearchTags             []Tag     `yaml:"searchTags"`
 	CustomTags             []Tag     `yaml:"customTags"`
 	Metrics                []*Metric `yaml:"metrics"`
-	Length                 int       `yaml:"length"`
-	Delay                  int       `yaml:"delay"`
-	Period                 int       `yaml:"period"`
+	Length                 int64     `yaml:"length"`
+	Delay                  int64     `yaml:"delay"`
+	Period                 int64     `yaml:"period"`
+	RoundingPeriod         *int64    `yaml:"roundingPeriod"`
 	Statistics             []string  `yaml:"statistics"`
 	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
 	NilToZero              *bool     `yaml:"nilToZero"`
@@ -55,9 +60,9 @@ type Role struct {
 type Metric struct {
 	Name                   string   `yaml:"name"`
 	Statistics             []string `yaml:"statistics"`
-	Period                 int      `yaml:"period"`
-	Length                 int      `yaml:"length"`
-	Delay                  int      `yaml:"delay"`
+	Period                 int64    `yaml:"period"`
+	Length                 int64    `yaml:"length"`
+	Delay                  int64    `yaml:"delay"`
 	NilToZero              *bool    `yaml:"nilToZero"`
 	AddCloudwatchTimestamp *bool    `yaml:"addCloudwatchTimestamp"`
 }
@@ -217,7 +222,7 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *Job) er
 		if discovery.Period != 0 {
 			mPeriod = discovery.Period
 		} else {
-			mPeriod = 300
+			mPeriod = defaultPeriodSeconds
 		}
 	}
 	if mPeriod < 1 {
@@ -228,7 +233,7 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *Job) er
 		if discovery.Length != 0 {
 			mLength = discovery.Length
 		} else {
-			mLength = 120
+			mLength = defaultLengthSeconds
 		}
 	}
 
@@ -237,7 +242,7 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *Job) er
 		if discovery.Delay != 0 {
 			mDelay = discovery.Delay
 		} else {
-			mDelay = 120
+			mDelay = defaultDelaySeconds
 		}
 	}
 

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1,8 +1,6 @@
 package exporter
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
@@ -10,18 +8,16 @@ import (
 func UpdateMetrics(
 	config ScrapeConf,
 	registry *prometheus.Registry,
-	now time.Time,
 	metricsPerQuery int,
-	fips, floatingTimeWindow, labelsSnakeCase bool,
+	labelsSnakeCase bool,
 	cloudwatchSemaphore, tagSemaphore chan struct{},
 	cache SessionCache,
-) time.Time {
-	tagsData, cloudwatchData, endtime := scrapeAwsData(
+) {
+	tagsData, cloudwatchData := scrapeAwsData(
 		config,
-		now,
 		metricsPerQuery,
-		fips, floatingTimeWindow,
-		cloudwatchSemaphore, tagSemaphore,
+		cloudwatchSemaphore,
+		tagSemaphore,
 		cache,
 	)
 	var metrics []*PrometheusMetric
@@ -37,5 +33,4 @@ func UpdateMetrics(
 			log.Warning("Could not publish cloudwatch api metric")
 		}
 	}
-	return *endtime
 }


### PR DESCRIPTION
Fixes #479

This PR tries to address the problems I outlined in #479.

Here's what I did:
- Updated to always use the wall clock time to calculate start/end of GetMetricData requests
- Remove the hard coded 5 minute rounding of time currently done prior to finding start/end times and instead round based on the shortest configured period for the scrape job
- Add a config option to the job which allows users to easily control the rounding of the time. This is especially useful when someone has a very long period such as 1 day (for S3 metrics) but doesn't want to the time rounded to the nearest day.
- Remove the `floating-time-window` flag. The same functionality can be achieved by setting the new `roundingPeriod` configuration option to 0.
- The `fips` arg was unused by some functions, so I removed it from all function params where it wasn't used (just basic cleanup work, I can put it back if you need it?)
- Extract constants for default period, delay and length settings

Looking forward to your feedback!