### PR TITLE
Issues form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: 🐞 Bug
+description: File a bug report
+title: "[BUG] <title>"
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,44 @@
+name: 🆕 Feature
+description: Request a new feature
+title: "[FEATURE] <title>"
+labels: [enhancement]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you are requesting.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Feature description
+    description: A concise description of what you're expecting.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What might the configuration look like?
+    description: Example configuration (useful as a baseline during development).
+    placeholder: |
+      ```yml
+      discovery:
+        jobs:
+        - type: <name of service>
+          period: 30
+          length: 600
+          metrics:
+          - name: SomeExportedMetric
+            statistics: [Minimum, Maximum]
+      ```
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false


### PR DESCRIPTION
I was searching through issues but labels aren't used much. They're also painful to add by hand, so I thought it might be a good idea to use Issues Forms:

- Prompt users for a type of issue
- Auto label by issue type

It is also easier on the issue requester because it can prompt them for the necessary information.

### Issue types

![Issue Types](https://user-images.githubusercontent.com/10092581/142290291-4922f3cd-dbf8-44b4-a69a-3ccd8ee9f5e5.png)

#### Bug

![Bug Form](https://user-images.githubusercontent.com/10092581/142290427-056030ef-4327-4dc1-9046-a309c744c5f8.png)

#### Feature request

![Feature Request Form](https://user-images.githubusercontent.com/10092581/142290433-c00caab2-52ef-4b5a-9f53-b22cbb52f518.png)

