### PR TITLE
Read DMS replication instance identifier from the DMS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We will contact you as soon as possible.
   * cassandra (AWS/Cassandra) - Cassandra
   * cloudfront (AWS/CloudFront) - Cloud Front
   * cognito-idp (AWS/Cognito) - Cognito
-  * dms (AWS/DocDB) - Database Migration Service
+  * dms (AWS/DMS) - Database Migration Service
   * docdb (AWS/DocDB) - DocumentDB (with MongoDB compatibility)
   * dx (AWS/DX) - Direct Connect
   * dynamodb (AWS/DynamoDB) - NoSQL Key-Value Database
@@ -404,6 +404,13 @@ The following IAM permission is required to discover tagged API Gateway REST API
 
 ```json
 "apigateway:GET"
+```
+
+The following IAM permissions are required to discover tagged Database Migration Service (DMS) replication instances and tasks:
+
+```json
+"dms:DescribeReplicationInstances",
+"dms:DescribeReplicationTasks"
 ```
 
 ## Running locally

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -47,6 +47,7 @@ func scrapeAwsData(
 						client:           cache.GetTagging(&region, role),
 						apiGatewayClient: cache.GetAPIGateway(&region, role),
 						asgClient:        cache.GetASG(&region, role),
+						dmsClient:        cache.GetDMS(&region, role),
 						ec2Client:        cache.GetEC2(&region, role),
 					}
 

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
@@ -81,6 +82,7 @@ type tagsInterface struct {
 	asgClient        autoscalingiface.AutoScalingAPI
 	apiGatewayClient apigatewayiface.APIGatewayAPI
 	ec2Client        ec2iface.EC2API
+	dmsClient        databasemigrationserviceiface.DatabaseMigrationServiceAPI
 }
 
 func (iface tagsInterface) get(job *Job, region string) ([]*taggedResource, error) {

--- a/pkg/prometheus.go
+++ b/pkg/prometheus.go
@@ -45,6 +45,10 @@ var (
 		Name: "yace_cloudwatch_ec2api_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	dmsAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_dmsapi_requests_total",
+		Help: "Help is not implemented yet.",
+	})
 )
 
 type PrometheusMetric struct {

--- a/pkg/services_test.go
+++ b/pkg/services_test.go
@@ -1,0 +1,241 @@
+package exporter
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
+	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
+)
+
+func TestDMSFilterFunc(t *testing.T) {
+	tests := []struct {
+		name            string
+		iface           tagsInterface
+		inputResources  []*taggedResource
+		outputResources []*taggedResource
+	}{
+		{
+			"empty input resources",
+			tagsInterface{},
+			[]*taggedResource{},
+			[]*taggedResource{},
+		},
+		{
+			"replication tasks and instances",
+			tagsInterface{
+				dmsClient: dmsClient{
+					describeReplicationInstancesOutput: &databasemigrationservice.DescribeReplicationInstancesOutput{
+						ReplicationInstances: []*databasemigrationservice.ReplicationInstance{
+							{
+								ReplicationInstanceArn:        aws.String("arn:aws:dms:us-east-1:123123123123:rep:ABCDEFG1234567890"),
+								ReplicationInstanceIdentifier: aws.String("repl-instance-identifier-1"),
+							},
+							{
+								ReplicationInstanceArn:        aws.String("arn:aws:dms:us-east-1:123123123123:rep:ZZZZZZZZZZZZZZZZZ"),
+								ReplicationInstanceIdentifier: aws.String("repl-instance-identifier-2"),
+							},
+							{
+								ReplicationInstanceArn:        aws.String("arn:aws:dms:us-east-1:123123123123:rep:YYYYYYYYYYYYYYYYY"),
+								ReplicationInstanceIdentifier: aws.String("repl-instance-identifier-3"),
+							},
+						},
+					},
+					describeReplicationTasksOutput: &databasemigrationservice.DescribeReplicationTasksOutput{
+						ReplicationTasks: []*databasemigrationservice.ReplicationTask{
+							{
+								ReplicationTaskArn:     aws.String("arn:aws:dms:us-east-1:123123123123:task:9999999999999999"),
+								ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123123123123:rep:ZZZZZZZZZZZZZZZZZ"),
+							},
+							{
+								ReplicationTaskArn:     aws.String("arn:aws:dms:us-east-1:123123123123:task:2222222222222222"),
+								ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123123123123:rep:ZZZZZZZZZZZZZZZZZ"),
+							},
+							{
+								ReplicationTaskArn:     aws.String("arn:aws:dms:us-east-1:123123123123:task:3333333333333333"),
+								ReplicationInstanceArn: aws.String("arn:aws:dms:us-east-1:123123123123:rep:WWWWWWWWWWWWWWWWW"),
+							},
+						},
+					},
+				},
+			},
+			[]*taggedResource{
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:rep:ABCDEFG1234567890",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:rep:WXYZ987654321",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:task:9999999999999999",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 3",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:task:5555555555555555",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 4",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:subgrp:demo-subgrp",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 5",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:endpoint:1111111111111111",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 6",
+						},
+					},
+				},
+			},
+			[]*taggedResource{
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:rep:ABCDEFG1234567890/repl-instance-identifier-1",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:rep:WXYZ987654321",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:task:9999999999999999/repl-instance-identifier-2",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 3",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:task:5555555555555555",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 4",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:subgrp:demo-subgrp",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 5",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:dms:us-east-1:123123123123:endpoint:1111111111111111",
+					Namespace: "dms",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 6",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dms := SupportedServices.GetService("dms")
+
+			outputResources, err := dms.FilterFunc(test.iface, test.inputResources)
+			if err != nil {
+				t.Logf("Error from FilterFunc: %v", err)
+				t.FailNow()
+			}
+			if len(outputResources) != len(test.outputResources) {
+				t.Logf("len(outputResources) = %d, want %d", len(outputResources), len(test.outputResources))
+				t.Fail()
+			}
+			for i, resource := range outputResources {
+				if len(test.outputResources) <= i {
+					break
+				}
+				wantResource := *test.outputResources[i]
+				if !reflect.DeepEqual(*resource, wantResource) {
+					t.Errorf("outputResources[%d] = %+v, want %+v", i, *resource, wantResource)
+				}
+			}
+		})
+	}
+}
+
+type dmsClient struct {
+	databasemigrationserviceiface.DatabaseMigrationServiceAPI
+	describeReplicationInstancesOutput *databasemigrationservice.DescribeReplicationInstancesOutput
+	describeReplicationTasksOutput     *databasemigrationservice.DescribeReplicationTasksOutput
+}
+
+func (dms dmsClient) DescribeReplicationInstancesPagesWithContext(ctx aws.Context, input *databasemigrationservice.DescribeReplicationInstancesInput, fn func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool, opts ...request.Option) error {
+	fn(dms.describeReplicationInstancesOutput, true)
+	return nil
+}
+func (dms dmsClient) DescribeReplicationTasksPagesWithContext(ctx aws.Context, input *databasemigrationservice.DescribeReplicationTasksInput, fn func(*databasemigrationservice.DescribeReplicationTasksOutput, bool) bool, opts ...request.Option) error {
+	fn(dms.describeReplicationTasksOutput, true)
+	return nil
+}

--- a/pkg/sessions_test.go
+++ b/pkg/sessions_test.go
@@ -402,6 +402,7 @@ func TestClear(t *testing.T) {
 							tagging:    createTagSession(mock.Session, &region, role, false),
 							asg:        createASGSession(mock.Session, &region, role, false),
 							ec2:        createEC2Session(mock.Session, &region, role, false),
+							dms:        createDMSSession(mock.Session, &region, role, false),
 							apiGateway: createAPIGatewaySession(mock.Session, &region, role, false),
 							onlyStatic: true,
 						},
@@ -471,6 +472,10 @@ func TestClear(t *testing.T) {
 						t.Logf("`ec2 client` %v in region %v is not nil", role, region)
 						t.Fail()
 					}
+					if client.dms != nil {
+						t.Logf("`dms client` %v in region %v is not nil", role, region)
+						t.Fail()
+					}
 					if client.apiGateway != nil {
 						t.Logf("`apiGateway client` %v in region %v is not nil", role, region)
 						t.Fail()
@@ -506,6 +511,7 @@ func TestRefresh(t *testing.T) {
 							tagging:    nil,
 							asg:        nil,
 							ec2:        nil,
+							dms:        nil,
 							apiGateway: nil,
 						},
 					},
@@ -529,6 +535,7 @@ func TestRefresh(t *testing.T) {
 							tagging:    nil,
 							asg:        nil,
 							ec2:        nil,
+							dms:        nil,
 							apiGateway: nil,
 							onlyStatic: true,
 						},
@@ -553,6 +560,7 @@ func TestRefresh(t *testing.T) {
 							tagging:    createTagSession(mock.Session, &region, role, false),
 							asg:        createASGSession(mock.Session, &region, role, false),
 							ec2:        createEC2Session(mock.Session, &region, role, false),
+							dms:        createDMSSession(mock.Session, &region, role, false),
 							apiGateway: createAPIGatewaySession(mock.Session, &region, role, false),
 						},
 					},
@@ -604,6 +612,10 @@ func TestRefresh(t *testing.T) {
 					}
 					if client.ec2 == nil {
 						t.Logf("`ec2 client` %v in region %v still nil", role, region)
+						t.Fail()
+					}
+					if client.dms == nil {
+						t.Logf("`dms client` %v in region %v still nil", role, region)
 						t.Fail()
 					}
 					if client.apiGateway == nil {
@@ -677,6 +689,18 @@ func TestSessionCacheGetEC2(t *testing.T) {
 		})
 }
 
+func TestSessionCacheGetDMS(t *testing.T) {
+	testGetAWSClient(
+		t, "DMS",
+		func(t *testing.T, cache *sessionCache, region *string, role Role) {
+			iface := cache.GetDMS(region, role)
+			if iface == nil {
+				t.Fail()
+				return
+			}
+		})
+}
+
 func TestSessionCacheGetAPIGateway(t *testing.T) {
 	testGetAWSClient(
 		t, "APIGateway",
@@ -717,6 +741,7 @@ func testGetAWSClient(
 							tagging:    createTagSession(mock.Session, &region, role, false),
 							asg:        createASGSession(mock.Session, &region, role, false),
 							ec2:        createEC2Session(mock.Session, &region, role, false),
+							dms:        createDMSSession(mock.Session, &region, role, false),
 							apiGateway: createAPIGatewaySession(mock.Session, &region, role, false),
 						},
 					},
@@ -740,6 +765,7 @@ func testGetAWSClient(
 							tagging:    createTagSession(mock.Session, &region, role, false),
 							asg:        createASGSession(mock.Session, &region, role, false),
 							ec2:        createEC2Session(mock.Session, &region, role, false),
+							dms:        createDMSSession(mock.Session, &region, role, false),
 							apiGateway: createAPIGatewaySession(mock.Session, &region, role, false),
 						},
 					},
@@ -978,6 +1004,18 @@ func TestCreateEC2Session(t *testing.T) {
 			}
 		})
 
+}
+
+func TestCreateDMSSession(t *testing.T) {
+	testAWSClient(
+		t,
+		"DMS",
+		func(t *testing.T, s *session.Session, region *string, role Role, fips bool) {
+			iface := createDMSSession(s, region, role, fips)
+			if iface == nil {
+				t.Fail()
+			}
+		})
 }
 
 func TestCreateAPIGatewaySession(t *testing.T) {

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -28,7 +28,7 @@ func UpdateMetrics(
 	metrics = append(metrics, migrateTagsToPrometheus(tagsData, labelsSnakeCase)...)
 
 	registry.MustRegister(NewPrometheusCollector(metrics))
-	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchAPIErrorCounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter, apiGatewayAPICounter, targetGroupsAPICounter} {
+	for _, counter := range []prometheus.Counter{cloudwatchAPICounter, cloudwatchAPIErrorCounter, cloudwatchGetMetricDataAPICounter, cloudwatchGetMetricStatisticsAPICounter, resourceGroupTaggingAPICounter, autoScalingAPICounter, apiGatewayAPICounter, targetGroupsAPICounter, ec2APICounter, dmsAPICounter} {
 		if err := registry.Register(counter); err != nil {
 			log.Warning("Could not publish cloudwatch api metric")
 		}


### PR DESCRIPTION
The replication instance and replication task ARNs do not contain the
value that DMS uses for the ReplicationInstanceIdentifier dimension.

Fixes #485