### PR TITLE
Improve promString performance

### DIFF
--- a/pkg/prometheus.go
+++ b/pkg/prometheus.go
@@ -51,6 +51,24 @@ var (
 	})
 )
 
+var replacer = strings.NewReplacer(
+	" ", "_",
+	",", "_",
+	"\t", "_",
+	"/", "_",
+	"\\", "_",
+	".", "_",
+	"-", "_",
+	":", "_",
+	"=", "_",
+	"“", "_",
+	"@", "_",
+	"<", "_",
+	">", "_",
+	"%", "_percent",
+)
+var splitRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
 type PrometheusMetric struct {
 	name             *string
 	labels           map[string]string
@@ -145,26 +163,9 @@ func promStringTag(text string, labelsSnakeCase bool) string {
 }
 
 func sanitize(text string) string {
-	replacer := strings.NewReplacer(
-		" ", "_",
-		",", "_",
-		"\t", "_",
-		"/", "_",
-		"\\", "_",
-		".", "_",
-		"-", "_",
-		":", "_",
-		"=", "_",
-		"“", "_",
-		"@", "_",
-		"<", "_",
-		">", "_",
-		"%", "_percent",
-	)
 	return replacer.Replace(text)
 }
 
 func splitString(text string) string {
-	splitRegexp := regexp.MustCompile(`([a-z0-9])([A-Z])`)
 	return splitRegexp.ReplaceAllString(text, `$1.$2`)
 }

--- a/pkg/prometheus_test.go
+++ b/pkg/prometheus_test.go
@@ -1,0 +1,55 @@
+package exporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitString(t *testing.T) {
+	var testCases = []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "GlobalTopicCount",
+			output: "Global.Topic.Count",
+		},
+		{
+			input:  "CPUUtilization",
+			output: "CPUUtilization",
+		},
+		{
+			input:  "StatusCheckFailed_Instance",
+			output: "Status.Check.Failed_Instance",
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.output, splitString(tc.input))
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	var testCases = []struct {
+		input  string
+		output string
+	}{
+		{
+			input:  "Global.Topic.Count",
+			output: "Global_Topic_Count",
+		},
+		{
+			input:  "Status.Check.Failed_Instance",
+			output: "Status_Check_Failed_Instance",
+		},
+		{
+			input:  "IHaveA%Sign",
+			output: "IHaveA_percentSign",
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.output, sanitize(tc.input))
+	}
+}


### PR DESCRIPTION
When profiling a large scrape for CPU + Memory, creating this replacer + compiling the regex stood out a lot due to the number of calls to `promString`. Moving them to package level should help improve this.