### PR TITLE
feat: add multi-arch docker build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
 
     - name: Build and Publish docker image
-      run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{ github.event.release.tag_name }} --build-arg VERSION=${{github.event.release.tag_name}} --push .
+      run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{github.ref_name}} --build-arg VERSION=${{github.ref_name}} --push .
     
     - name: Build && release binaries
       uses: docker://goreleaser/goreleaser:v0.179.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
-on: release
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*'
 
 name: Build, test and publish
 jobs:
@@ -6,28 +10,27 @@ jobs:
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
-    - name: Is release published?
-      if: github.event.action != 'published'
-      run: exit 78
     - uses: actions/checkout@master
-    - name: Build docker image
-      run: docker build -t yace --build-arg VERSION=${{ github.event.release.tag_name }} .
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Log into docker
       env:
         DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         DOCKER_REGISTRY_URL: ghcr.io
         DOCKER_USERNAME: ${{ github.actor }}
       run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
-    - name: Release if tagged
-      if: "!startswith(github.ref, 'refs/tags/v')"
-      run: exit 78
-    - name: Tag docker image
-      run: docker tag yace ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{ github.event.release.tag_name }}
+
+    - name: Build and Publish docker image
+      run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{ github.event.release.tag_name }} --build-arg VERSION=${{github.event.release.tag_name}} --push .
+    
     - name: Build && release binaries
       uses: docker://goreleaser/goreleaser:v0.179.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: release
-    - name: Publish docker image
-      run: docker push ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . ./
-RUN go test -cover ./...
 
 ENV GOOS linux
-ARG GOARCH
-ENV GOARCH ${GOARCH:-amd64}
 ENV CGO_ENABLED=0
 
 ARG VERSION
@@ -30,4 +27,3 @@ WORKDIR /exporter/
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /opt/yace /usr/local/bin/yace
 USER exporter
-


### PR DESCRIPTION
I noticed this PR was incomplete and has since been reverted https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/488 - I've expanded on this PR to fully support multi-arch docker builds in this repo.

I ran the action against my fork, [which you can validate here ](https://github.com/charlie-haley/yet-another-cloudwatch-exporter/runs/5068424691?check_suite_focus=true)

fixes https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/484