### PR TITLE
fix targetgroup arn lookup #529

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -302,6 +302,7 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 	}
 	for _, cwMetric := range metricsList {
 		skip := false
+		alreadyFound := false
 		r := &taggedResource{
 			ARN:       "global",
 			Namespace: namespace,
@@ -309,9 +310,12 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 		for _, dimension := range cwMetric.Dimensions {
 			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok {
 				if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
-					skip = true
+					if !alreadyFound {
+						skip = true
+					}
 					break
 				} else {
+					alreadyFound = true
 					r = d
 				}
 			}


### PR DESCRIPTION
This provides a way to retain the metric name arn and tags if at least one dimension filter matches. The current implementation is always using the last dimension lookup whatever that might be. This change does retain the metrics if it already matched previously.

With this change you can fix #529 using the following config:
```
"discovery":
  "jobs":
  - "enableMetricData": true
    "metrics":
    - "length": 3600
      "name": "ProcessedBytes"
      "period": 300
      "statistics":
      - "Sum"
    "regions":
    - "eu-west-1"
    "type": "alb"
  - "enableMetricData": true
    "metrics":
    - "length": 300
      "name": "HealthyHostCount"
      "period": 300
      "statistics":
      - "Minimum"
    - "length": 300
      "name": "UnHealthyHostCount"
      "period": 300
      "statistics":
      - "Maximum"
    searchTags:
      - key: Port
        value: .*
    "regions":
    - "eu-west-1"
    "type": "alb"
```

Note using the alb type twice. We use it with the tag we expect to be present on the targetgroup ARN.