### PR TITLE
services: add kinesis-analytics

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -477,6 +477,9 @@ var (
 				aws.String(":stream/(?P<StreamName>[^/]+)"),
 			},
 		}, {
+			Namespace: "AWS/KinesisAnalytics",
+			Alias:     "kinesis-analytics",
+		}, {
 			Namespace: "AWS/Lambda",
 			Alias:     "lambda",
 			ResourceFilters: []*string{


### PR DESCRIPTION
This adds support for the [`AWS/KinesisAnalytics`](
https://docs.aws.amazon.com/kinesisanalytics/latest/dev/monitoring-metrics.html)
namespace.