### PR TITLE
Propagate context down to AWS clients.

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -118,7 +118,6 @@ func main() {
 	s := NewScraper()
 	cache := exporter.NewSessionCache(config, fips)
 
-	// TODO: Pipe ctx through to the AWS calls.
 	ctx, cancelRunningScrape := context.WithCancel(context.Background())
 	go s.decoupled(ctx, cache)
 
@@ -215,7 +214,7 @@ func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
 	defer sem.Release(1)
 
 	newRegistry := prometheus.NewRegistry()
-	exporter.UpdateMetrics(config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache)
+	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache)
 
 	// this might have a data race to access registry
 	s.registry = newRegistry

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -85,16 +85,15 @@ type tagsInterface struct {
 	dmsClient        databasemigrationserviceiface.DatabaseMigrationServiceAPI
 }
 
-func (iface tagsInterface) get(job *Job, region string) ([]*taggedResource, error) {
+func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]*taggedResource, error) {
 	svc := SupportedServices.GetService(job.Type)
 	var resources []*taggedResource
 
 	if len(svc.ResourceFilters) > 0 {
-		var inputparams = &resourcegroupstaggingapi.GetResourcesInput{
+		inputparams := &resourcegroupstaggingapi.GetResourcesInput{
 			ResourceTypeFilters: svc.ResourceFilters,
 		}
 		c := iface.client
-		ctx := context.Background()
 		pageNum := 0
 
 		err := c.GetResourcesPagesWithContext(ctx, inputparams, func(page *resourcegroupstaggingapi.GetResourcesOutput, lastPage bool) bool {
@@ -130,7 +129,7 @@ func (iface tagsInterface) get(job *Job, region string) ([]*taggedResource, erro
 	}
 
 	if svc.ResourceFunc != nil {
-		newResources, err := svc.ResourceFunc(iface, job, region)
+		newResources, err := svc.ResourceFunc(ctx, iface, job, region)
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +137,7 @@ func (iface tagsInterface) get(job *Job, region string) ([]*taggedResource, erro
 	}
 
 	if svc.FilterFunc != nil {
-		filteredResources, err := svc.FilterFunc(iface, resources)
+		filteredResources, err := svc.FilterFunc(ctx, iface, resources)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-type ResourceFunc func(tagsInterface, *Job, string) ([]*taggedResource, error)
+type ResourceFunc func(context.Context, tagsInterface, *Job, string) ([]*taggedResource, error)
 
-type FilterFunc func(tagsInterface, []*taggedResource) ([]*taggedResource, error)
+type FilterFunc func(context.Context, tagsInterface, []*taggedResource) ([]*taggedResource, error)
 
 type serviceFilter struct {
 	Namespace        string
@@ -67,8 +67,7 @@ var (
 				aws.String("apis/(?P<ApiName>[^/]+)$"),
 				aws.String("apis/(?P<ApiName>[^/]+)/stages/(?P<Stage>[^/]+)$"),
 			},
-			FilterFunc: func(iface tagsInterface, inputResources []*taggedResource) (outputResources []*taggedResource, err error) {
-				ctx := context.Background()
+			FilterFunc: func(ctx context.Context, iface tagsInterface, inputResources []*taggedResource) (outputResources []*taggedResource, err error) {
 				apiGatewayAPICounter.Inc()
 				var limit int64 = 500 // max number of results per page. default=25, max=500
 				const maxPages = 10
@@ -124,8 +123,7 @@ var (
 			DimensionRegexps: []*string{
 				aws.String("autoScalingGroupName/(?P<AutoScalingGroupName>[^/]+)"),
 			},
-			ResourceFunc: func(iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
-				ctx := context.Background()
+			ResourceFunc: func(ctx context.Context, iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
 				pageNum := 0
 				return resources, iface.asgClient.DescribeAutoScalingGroupsPagesWithContext(ctx, &autoscaling.DescribeAutoScalingGroupsInput{},
 					func(page *autoscaling.DescribeAutoScalingGroupsOutput, more bool) bool {
@@ -194,12 +192,11 @@ var (
 				aws.String("task:(?P<ReplicationTaskIdentifier>[^/]+)/(?P<ReplicationInstanceIdentifier>[^/]+)"),
 			},
 			// Append the replication instance identifier to DMS task and instance ARNs
-			FilterFunc: func(iface tagsInterface, inputResources []*taggedResource) (outputResources []*taggedResource, err error) {
+			FilterFunc: func(ctx context.Context, iface tagsInterface, inputResources []*taggedResource) (outputResources []*taggedResource, err error) {
 				if len(inputResources) == 0 {
 					return inputResources, nil
 				}
 
-				ctx := context.Background()
 				replicationInstanceIdentifiers := make(map[string]string)
 				pageNum := 0
 				if err := iface.dmsClient.DescribeReplicationInstancesPagesWithContext(ctx, nil,
@@ -313,8 +310,7 @@ var (
 			DimensionRegexps: []*string{
 				aws.String("(?P<FleetRequestId>.*)"),
 			},
-			ResourceFunc: func(iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
-				ctx := context.Background()
+			ResourceFunc: func(ctx context.Context, iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
 				pageNum := 0
 				return resources, iface.ec2Client.DescribeSpotFleetRequestsPagesWithContext(ctx, &ec2.DescribeSpotFleetRequestsInput{},
 					func(page *ec2.DescribeSpotFleetRequestsOutput, more bool) bool {
@@ -613,8 +609,7 @@ var (
 				aws.String(":transit-gateway/(?P<TransitGateway>[^/]+)"),
 				aws.String("(?P<TransitGateway>[^/]+)/(?P<TransitGatewayAttachment>[^/]+)"),
 			},
-			ResourceFunc: func(iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
-				ctx := context.Background()
+			ResourceFunc: func(ctx context.Context, iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
 				pageNum := 0
 				return resources, iface.ec2Client.DescribeTransitGatewayAttachmentsPagesWithContext(ctx, &ec2.DescribeTransitGatewayAttachmentsInput{},
 					func(page *ec2.DescribeTransitGatewayAttachmentsOutput, more bool) bool {

--- a/pkg/services_test.go
+++ b/pkg/services_test.go
@@ -1,6 +1,7 @@
 package exporter
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -203,7 +204,7 @@ func TestDMSFilterFunc(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			dms := SupportedServices.GetService("dms")
 
-			outputResources, err := dms.FilterFunc(test.iface, test.inputResources)
+			outputResources, err := dms.FilterFunc(context.Background(), test.iface, test.inputResources)
 			if err != nil {
 				t.Logf("Error from FilterFunc: %v", err)
 				t.FailNow()

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -1,11 +1,14 @@
 package exporter
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
 func UpdateMetrics(
+	ctx context.Context,
 	config ScrapeConf,
 	registry *prometheus.Registry,
 	metricsPerQuery int,
@@ -14,6 +17,7 @@ func UpdateMetrics(
 	cache SessionCache,
 ) {
 	tagsData, cloudwatchData := scrapeAwsData(
+		ctx,
 		config,
 		metricsPerQuery,
 		cloudwatchSemaphore,


### PR DESCRIPTION
Add `context` as first parameter to all main methods so that it can be
propagated down to AWS clients and used within http requests.