### PR TITLE
services: add PrivateLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ We will contact you as soon as possible.
   * mq (AWS/AmazonMQ) - Managed Message Broker Service
   * neptune (AWS/Neptune) - Neptune
   * nlb (AWS/NetworkELB) - Network Load Balancer
-  * private-link-endpoints (AWS/PrivateLinkEndpoints) - Private Link Endpoints
-  * private-link-services (AWS/PrivateLinkServices) - Private Link Endpoints
+  * vpc-endpoint (AWS/PrivateLinkEndpoints) - VPC Endpoint
+  * vpc-endpoint-service (AWS/PrivateLinkServices) - VPC Endpoint Service
   * redshift (AWS/Redshift) - Redshift Database
   * rds (AWS/RDS) - Relational Database Service
   * route53 (AWS/Route53) - Route53 Health Checks

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ We will contact you as soon as possible.
   * mq (AWS/AmazonMQ) - Managed Message Broker Service
   * neptune (AWS/Neptune) - Neptune
   * nlb (AWS/NetworkELB) - Network Load Balancer
+  * private-link-endpoints (AWS/PrivateLinkEndpoints) - Private Link Endpoints
+  * private-link-services (AWS/PrivateLinkServices) - Private Link Endpoints
   * redshift (AWS/Redshift) - Redshift Database
   * rds (AWS/RDS) - Relational Database Service
   * route53 (AWS/Route53) - Route53 Health Checks

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -550,6 +550,12 @@ var (
 				aws.String(":loadbalancer/(?P<LoadBalancer>.+)$"),
 			},
 		}, {
+			Namespace: "AWS/PrivateLinkEndpoints",
+			Alias:     "private-link-endpoints",
+		}, {
+			Namespace: "AWS/PrivateLinkServices",
+			Alias:     "private-link-services",
+		}, {
 			Namespace: "AWS/RDS",
 			Alias:     "rds",
 			ResourceFilters: []*string{

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -551,10 +551,22 @@ var (
 			},
 		}, {
 			Namespace: "AWS/PrivateLinkEndpoints",
-			Alias:     "private-link-endpoints",
+			Alias:     "vpc-endpoint",
+			ResourceFilters: []*string{
+				aws.String("ec2:vpc-endpoint"),
+			},
+			DimensionRegexps: []*string{
+				aws.String(":vpc-endpoint/(?P<VPC_Endpoint_Id>.+)"),
+			},
 		}, {
 			Namespace: "AWS/PrivateLinkServices",
-			Alias:     "private-link-services",
+			Alias:     "vpc-endpoint-service",
+			ResourceFilters: []*string{
+				aws.String("ec2:vpc-endpoint-service"),
+			},
+			DimensionRegexps: []*string{
+				aws.String(":vpc-endpoint-service:(?P<Service_Id>.+)"),
+			},
 		}, {
 			Namespace: "AWS/RDS",
 			Alias:     "rds",


### PR DESCRIPTION
Added PrivateLink metrics from two namespaces: AWS/PrivateLinkEndpoints and AWS/PrivateLinkServices

Closes #533 