### PR TITLE
Refactor how the global `labelMap` is handled

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -203,6 +203,8 @@ func (s *scraper) decoupled(ctx context.Context, cache exporter.SessionCache) {
 	}
 }
 
+var observedMetricLabels = map[string]exporter.LabelSet{}
+
 func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
 	if !sem.TryAcquire(1) {
 		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
@@ -214,7 +216,7 @@ func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
 	defer sem.Release(1)
 
 	newRegistry := prometheus.NewRegistry()
-	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache)
+	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels)
 
 	// this might have a data race to access registry
 	s.registry = newRegistry


### PR DESCRIPTION
When attempting to use this repo as a library it's possible to run in to a problem where unexpected labels appear on metrics because the [labelMap](https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/master/pkg/aws_cloudwatch.go#L48) is global across calls to `UpdateMetrics` in `pkg/update.go`. The label map is used to ensure metrics all have consistent labels.

This PR,

- Allows consumers to provide their own set of `observedMetricLabels` to `UpdateMetrics` 
- Moves the global value to main.go where it will not impact individual calls to `UpdateMetrics`
- Refactors `recordLabelsForMetric` to update the provided `observedMetricLabels` instead of doing copies (there's no concurrency I can see at this point so it should be safe) 
- Refactor `ensureLabelConsistencyForMetrics` to update data in the provided `metrics` slice vs allocating a new slice
- Eliminate a `log.Fatal` in the code path related to adding these labels which can cause unexpected crashes when being used as a library 