### PR TITLE
Accept a logger interface in update.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,9 @@ The entrypoint to use YACE as a library is the `UpdateMetrics` func in [update.g
   - Prometheus requires that all metrics exported with the same key have the same labels
   - This map will track all labels observed and ensure they are exported on all metrics with the same key in the provided `registry`
   - You should provide the same instance of this map if you intend to re-use the `registry` between calls
+- `logger`
+  - Any implementation of the [Logger Interface](./pkg/update.go#L50)
+  - `exporter.NewLogrusLogger(log.StandardLogger())` is an acceptable default
 
 The update definition also includes an exported slice of [Metrics](./pkg/update.go#L11) which includes AWS API call metrics. These can be registered with the provided `registry` if you want them
 included in the AWS scrape results. If you are using multiple instances of `registry` it might make more sense to register these metrics in the application using YACE as a library to better 

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -116,7 +116,7 @@ func main() {
 	}
 
 	s := NewScraper()
-	cache := exporter.NewSessionCache(config, fips)
+	cache := exporter.NewSessionCache(config, fips, exporter.NewLogrusLogger(log.StandardLogger()))
 
 	ctx, cancelRunningScrape := context.WithCancel(context.Background())
 	go s.decoupled(ctx, cache)
@@ -149,7 +149,7 @@ func main() {
 		}
 
 		log.Println("Reset session cache")
-		cache = exporter.NewSessionCache(config, fips)
+		cache = exporter.NewSessionCache(config, fips, exporter.NewLogrusLogger(log.StandardLogger()))
 
 		cancelRunningScrape()
 		// TODO: Pipe ctx through to the AWS calls.
@@ -221,7 +221,7 @@ func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
 			log.Warning("Could not register cloudwatch api metric")
 		}
 	}
-	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels)
+	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels, exporter.NewLogrusLogger(log.StandardLogger()))
 
 	// this might have a data race to access registry
 	s.registry = newRegistry

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -43,6 +43,7 @@ func scrapeAwsData(
 
 					clientCloudwatch := cloudwatchInterface{
 						client: cache.GetCloudwatch(&region, role),
+						logger: logger,
 					}
 
 					clientTag := tagsInterface{
@@ -52,6 +53,7 @@ func scrapeAwsData(
 						asgClient:        cache.GetASG(&region, role),
 						dmsClient:        cache.GetDMS(&region, role),
 						ec2Client:        cache.GetEC2(&region, role),
+						logger:           logger,
 					}
 
 					resources, metrics := scrapeDiscoveryJobUsingMetricData(ctx, discoveryJob, region, result.Account, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch, metricsPerQuery, discoveryJob.RoundingPeriod, tagSemaphore, logger)
@@ -78,6 +80,7 @@ func scrapeAwsData(
 
 					clientCloudwatch := cloudwatchInterface{
 						client: cache.GetCloudwatch(&region, role),
+						logger: logger,
 					}
 
 					metrics := scrapeStaticJob(ctx, staticJob, region, result.Account, clientCloudwatch, cloudwatchSemaphore, logger)

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -6,15 +6,16 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/service/sts"
-	log "github.com/sirupsen/logrus"
 )
 
 func scrapeAwsData(
 	ctx context.Context,
 	config ScrapeConf,
 	metricsPerQuery int,
-	cloudwatchSemaphore, tagSemaphore chan struct{},
+	cloudwatchSemaphore,
+	tagSemaphore chan struct{},
 	cache SessionCache,
+	logger Logger,
 ) ([]*taggedResource, []*cloudwatchData) {
 	mux := &sync.Mutex{}
 
@@ -36,7 +37,7 @@ func scrapeAwsData(
 					defer wg.Done()
 					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 					if err != nil || result.Account == nil {
-						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
+						logger.Error(err, "Couldn't get account Id for role %s", role.RoleArn)
 						return
 					}
 
@@ -53,7 +54,7 @@ func scrapeAwsData(
 						ec2Client:        cache.GetEC2(&region, role),
 					}
 
-					resources, metrics := scrapeDiscoveryJobUsingMetricData(ctx, discoveryJob, region, result.Account, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch, metricsPerQuery, discoveryJob.RoundingPeriod, tagSemaphore)
+					resources, metrics := scrapeDiscoveryJobUsingMetricData(ctx, discoveryJob, region, result.Account, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch, metricsPerQuery, discoveryJob.RoundingPeriod, tagSemaphore, logger)
 					mux.Lock()
 					awsInfoData = append(awsInfoData, resources...)
 					cwData = append(cwData, metrics...)
@@ -71,7 +72,7 @@ func scrapeAwsData(
 					defer wg.Done()
 					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 					if err != nil || result.Account == nil {
-						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
+						logger.Error(err, "Couldn't get account Id for role %s", role.RoleArn)
 						return
 					}
 
@@ -79,7 +80,7 @@ func scrapeAwsData(
 						client: cache.GetCloudwatch(&region, role),
 					}
 
-					metrics := scrapeStaticJob(ctx, staticJob, region, result.Account, clientCloudwatch, cloudwatchSemaphore)
+					metrics := scrapeStaticJob(ctx, staticJob, region, result.Account, clientCloudwatch, cloudwatchSemaphore, logger)
 
 					mux.Lock()
 					cwData = append(cwData, metrics...)
@@ -92,7 +93,7 @@ func scrapeAwsData(
 	return awsInfoData, cwData
 }
 
-func scrapeStaticJob(ctx context.Context, resource *Static, region string, accountId *string, clientCloudwatch cloudwatchInterface, cloudwatchSemaphore chan struct{}) (cw []*cloudwatchData) {
+func scrapeStaticJob(ctx context.Context, resource *Static, region string, accountId *string, clientCloudwatch cloudwatchInterface, cloudwatchSemaphore chan struct{}, logger Logger) (cw []*cloudwatchData) {
 	mux := &sync.Mutex{}
 	var wg sync.WaitGroup
 
@@ -125,6 +126,7 @@ func scrapeStaticJob(ctx context.Context, resource *Static, region string, accou
 				data.Dimensions,
 				&resource.Namespace,
 				metric,
+				logger,
 			)
 
 			data.Points = clientCloudwatch.get(ctx, filter)
@@ -163,7 +165,8 @@ func getMetricDataForQueries(
 	tagsOnMetrics exportedTagsOnMetrics,
 	clientCloudwatch cloudwatchInterface,
 	resources []*taggedResource,
-	tagSemaphore chan struct{}) []cloudwatchData {
+	tagSemaphore chan struct{},
+	logger Logger) []cloudwatchData {
 	var getMetricDatas []cloudwatchData
 
 	// For every metric of the job
@@ -177,12 +180,12 @@ func getMetricDataForQueries(
 		<-tagSemaphore
 
 		if err != nil {
-			log.Errorf("Failed to get full metric list for %s on %s job in region %s: %v", metric.Name, svc.Namespace, region, err)
+			logger.Error(err, "Failed to get full metric list for %s on %s job in region %s", metric.Name, svc.Namespace, region)
 			continue
 		}
 
 		if len(resources) == 0 {
-			log.Debugf("No resources for metric %s on %s job", metric.Name, svc.Namespace)
+			logger.Debug("No resources for metric %s on %s job", metric.Name, svc.Namespace)
 		}
 		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
 	}
@@ -199,22 +202,23 @@ func scrapeDiscoveryJobUsingMetricData(
 	clientCloudwatch cloudwatchInterface,
 	metricsPerQuery int,
 	roundingPeriod *int64,
-	tagSemaphore chan struct{}) (resources []*taggedResource, cw []*cloudwatchData) {
+	tagSemaphore chan struct{},
+	logger Logger) (resources []*taggedResource, cw []*cloudwatchData) {
 
 	// Add the info tags of all the resources
 	tagSemaphore <- struct{}{}
 	resources, err := clientTag.get(ctx, job, region)
 	<-tagSemaphore
 	if err != nil {
-		log.Printf("Couldn't describe resources for region %s: %s\n", region, err.Error())
+		logger.Error(err, "Couldn't describe resources for region %s, in account %s", region, *accountId)
 		return
 	}
 
 	svc := SupportedServices.GetService(job.Type)
-	getMetricDatas := getMetricDataForQueries(ctx, job, svc, region, accountId, tagsOnMetrics, clientCloudwatch, resources, tagSemaphore)
+	getMetricDatas := getMetricDataForQueries(ctx, job, svc, region, accountId, tagsOnMetrics, clientCloudwatch, resources, tagSemaphore, logger)
 	metricDataLength := len(getMetricDatas)
 	if metricDataLength == 0 {
-		log.Debugf("No metrics data for %s", job.Type)
+		logger.Debug("No metrics data for %s", job.Type)
 		return
 	}
 
@@ -234,7 +238,7 @@ func scrapeDiscoveryJobUsingMetricData(
 				end = metricDataLength
 			}
 			input := getMetricDatas[i:end]
-			filter := createGetMetricDataInput(input, &svc.Namespace, length, job.Delay, roundingPeriod)
+			filter := createGetMetricDataInput(input, &svc.Namespace, length, job.Delay, roundingPeriod, logger)
 			data := clientCloudwatch.getMetricData(ctx, filter)
 			if data != nil {
 				output := make([]*cloudwatchData, 0)

--- a/pkg/logruslogger.go
+++ b/pkg/logruslogger.go
@@ -1,0 +1,31 @@
+package exporter
+
+import log "github.com/sirupsen/logrus"
+
+type logrusLogger struct {
+	logger *log.Logger
+}
+
+func NewLogrusLogger(logger *log.Logger) logrusLogger {
+	return logrusLogger{logger}
+}
+
+func (l logrusLogger) Info(message string, args ...interface{}) {
+	l.logger.Infof(message, args...)
+}
+
+func (l logrusLogger) Debug(message string, args ...interface{}) {
+	l.logger.Debugf(message, args...)
+}
+
+func (l logrusLogger) Error(err error, message string, args ...interface{}) {
+	l.logger.WithError(err).Errorf(message, args...)
+}
+
+func (l logrusLogger) Warn(message string, args ...interface{}) {
+	l.logger.Warnf(message, args...)
+}
+
+func (l logrusLogger) IsDebugEnabled() bool {
+	return l.logger.IsLevelEnabled(log.DebugLevel)
+}


### PR DESCRIPTION
This PR introduces a logging interface to be used in the process of updating metrics. This is the last global dependency which exists in the library entrypoint. This will make it a lot easier for library consumers to plugin their own logging implementation which can carry extra contextual information for logs.

I did also translate all the `Printf` use cases to `Error` because all of them felt like error cases vs info.

I plan to do a follow up on this to switch log messages which embed data in the message to [structured logs](https://github.com/sirupsen/logrus#fields).