### PR TITLE
Allow VPC Endpoint (Service) resources to be discovered without tag api

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,13 @@ The following IAM permissions are required to discover tagged Database Migration
 "dms:DescribeReplicationTasks"
 ```
 
+The following IAM permissions are required to discover VPC Endpoint and VPC Endpoint Service resources:
+
+```json
+"ec2:DescribeVpcEndpoints",
+"ec2:DescribeVpcEndpointServiceConfigurations"
+```
+
 ## Running locally
 
 ```shell

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -552,12 +552,10 @@ var (
 		}, {
 			Namespace: "AWS/PrivateLinkEndpoints",
 			Alias:     "vpc-endpoint",
-			ResourceFilters: []*string{
-				aws.String("ec2:vpc-endpoint"),
-			},
 			DimensionRegexps: []*string{
 				aws.String(":vpc-endpoint/(?P<VPC_Endpoint_Id>.+)"),
 			},
+			// CloudFormation doesn't support tagging VPCEndpoint resources, so use a ResourceFunc instead of a ResourceFilter
 			ResourceFunc: func(ctx context.Context, iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
 				pageNum := 0
 				return resources, iface.ec2Client.DescribeVpcEndpointsPagesWithContext(ctx, &ec2.DescribeVpcEndpointsInput{},
@@ -587,12 +585,10 @@ var (
 		}, {
 			Namespace: "AWS/PrivateLinkServices",
 			Alias:     "vpc-endpoint-service",
-			ResourceFilters: []*string{
-				aws.String("ec2:vpc-endpoint-service"),
-			},
 			DimensionRegexps: []*string{
 				aws.String(":vpc-endpoint-service/(?P<Service_Id>.+)"),
 			},
+			// CloudFormation doesn't support tagging VPCEndpointService resources, so use a ResourceFunc instead of a ResourceFilter
 			ResourceFunc: func(ctx context.Context, iface tagsInterface, job *Job, region string) (resources []*taggedResource, err error) {
 				firstRequest := true
 				var nextToken *string


### PR DESCRIPTION
Fixes #567

This PR updates discovery of these resources to not use the AWS tag API. While the tag API works and these resources can be tagged, they cannot be tagged through CloudFormation, so this PR aligns with CloudFormation's limitations.

I can imagine that the maintainers of this project may want to only deviate from using the tags API when strictly necessary. If that is the case then this PR can be closed, but I think this change is worth considering.
