### PR TITLE
Allow jobs to only fetch metrics that include specified dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Note: Only [tagged resources](https://docs.aws.amazon.com/general/latest/gr/aws_
 | roundingPeriod         | Specifies how the current time is rounded before calculating start/end times for CloudWatch GetMetricData requests. This rounding is optimize performance of the CloudWatch request. This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes).  to For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.                     |
 | addCloudwatchTimestamp | Export the metric with the original CloudWatch timestamp (General Setting for all metrics in this job)   |
 | customTags             | Custom tags to be added as a list of Key/Value pairs                                                     |
+| dimensionNames         | List of metric dimensions to request. Any metric without exactly these dimensions will not be requested. Any empty or undefined list results in all dimension combinations being included.
 | metrics                | List of metric definitions                                                                               |
 
 searchTags example:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Note: Only [tagged resources](https://docs.aws.amazon.com/general/latest/gr/aws_
 | roundingPeriod         | Specifies how the current time is rounded before calculating start/end times for CloudWatch GetMetricData requests. This rounding is optimize performance of the CloudWatch request. This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes).  to For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.                     |
 | addCloudwatchTimestamp | Export the metric with the original CloudWatch timestamp (General Setting for all metrics in this job)   |
 | customTags             | Custom tags to be added as a list of Key/Value pairs                                                     |
-| dimensionNames         | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. |
+| dimensionNameRequirements | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. |
 | metrics                | List of metric definitions                                                                               |
 
 searchTags example:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Note: Only [tagged resources](https://docs.aws.amazon.com/general/latest/gr/aws_
 | roundingPeriod         | Specifies how the current time is rounded before calculating start/end times for CloudWatch GetMetricData requests. This rounding is optimize performance of the CloudWatch request. This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes).  to For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.                     |
 | addCloudwatchTimestamp | Export the metric with the original CloudWatch timestamp (General Setting for all metrics in this job)   |
 | customTags             | Custom tags to be added as a list of Key/Value pairs                                                     |
-| dimensionNames         | List of metric dimensions to request. Any metric without exactly these dimensions will not be requested. Any empty or undefined list results in all dimension combinations being included.
+| dimensionNames         | List of metric dimensions to query. Before querying metric values, the total list of metrics will be filtered to only those that contain exactly this list of dimensions. An empty or undefined list results in all dimension combinations being included. |
 | metrics                | List of metric definitions                                                                               |
 
 searchTags example:

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -195,7 +195,7 @@ func getMetricDataForQueries(
 		if len(resources) == 0 {
 			logger.Debug("No resources for metric", "metric_name", metric.Name, "namespace", svc.Namespace)
 		}
-		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
+		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, discoveryJob.DimensionNames, metric)...)
 	}
 	return getMetricDatas
 }

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -195,7 +195,7 @@ func getMetricDataForQueries(
 		if len(resources) == 0 {
 			logger.Debug("No resources for metric", "metric_name", metric.Name, "namespace", svc.Namespace)
 		}
-		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, discoveryJob.DimensionNames, metric)...)
+		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, discoveryJob.DimensionNameRequirements, metric)...)
 	}
 	return getMetricDatas
 }

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -345,13 +345,13 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 	return getMetricsData
 }
 
-func metricDimensionsMatchNames(metric *cloudwatch.Metric, dimensionNames []string) bool {
-	if len(dimensionNames) != len(metric.Dimensions) {
+func metricDimensionsMatchNames(metric *cloudwatch.Metric, dimensionNameRequirements []string) bool {
+	if len(dimensionNameRequirements) != len(metric.Dimensions) {
 		return false
 	}
 	for _, dimension := range metric.Dimensions {
 		foundMatch := false
-		for _, dimensionName := range dimensionNames {
+		for _, dimensionName := range dimensionNameRequirements {
 			if *dimension.Name == dimensionName {
 				foundMatch = true
 				break

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -245,12 +245,12 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		{
 			"alb",
 			args{
-				region:     "us-east-1",
-				accountId:  aws.String("123123123123"),
-				namespace:  "alb",
-				customTags: nil,
-				tagsOnMetrics: nil,
-				dimensionRegexps: SupportedServices.GetService("alb").DimensionRegexps,
+				region:                    "us-east-1",
+				accountId:                 aws.String("123123123123"),
+				namespace:                 "alb",
+				customTags:                nil,
+				tagsOnMetrics:             nil,
+				dimensionRegexps:          SupportedServices.GetService("alb").DimensionRegexps,
 				dimensionNameRequirements: []string{"LoadBalancer", "TargetGroup"},
 				resources: []*taggedResource{
 					{

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -66,6 +66,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		customTags       []Tag
 		tagsOnMetrics    exportedTagsOnMetrics
 		dimensionRegexps []*string
+		dimensionNames   []string
 		resources        []*taggedResource
 		metricsList      []*cloudwatch.Metric
 		m                *Metric
@@ -241,10 +242,130 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				},
 			},
 		},
+		{
+			"alb",
+			args{
+				region:     "us-east-1",
+				accountId:  aws.String("123123123123"),
+				namespace:  "alb",
+				customTags: nil,
+				tagsOnMetrics: nil,
+				dimensionRegexps: SupportedServices.GetService("alb").DimensionRegexps,
+				dimensionNames: []string{"LoadBalancer", "TargetGroup"},
+				resources: []*taggedResource{
+					{
+						ARN: "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
+						Tags: []Tag{
+							{
+								Key:   "Name",
+								Value: "some-ALB",
+							},
+						},
+						Namespace: "alb",
+						Region:    "us-east-1",
+					},
+				},
+				metricsList: []*cloudwatch.Metric{
+					{
+						MetricName: aws.String("RequestCount"),
+						Dimensions: []*cloudwatch.Dimension{
+							{
+								Name:  aws.String("LoadBalancer"),
+								Value: aws.String("app/some-ALB/0123456789012345"),
+							},
+							{
+								Name:  aws.String("TargetGroup"),
+								Value: aws.String("targetgroup/some-ALB/9999666677773333"),
+							},
+							{
+								Name:  aws.String("AvailabilityZone"),
+								Value: aws.String("us-east-1"),
+							},
+						},
+						Namespace: aws.String("AWS/ApplicationELB"),
+					},
+					{
+						MetricName: aws.String("RequestCount"),
+						Dimensions: []*cloudwatch.Dimension{
+							{
+								Name:  aws.String("LoadBalancer"),
+								Value: aws.String("app/some-ALB/0123456789012345"),
+							},
+							{
+								Name:  aws.String("TargetGroup"),
+								Value: aws.String("targetgroup/some-ALB/9999666677773333"),
+							},
+						},
+						Namespace: aws.String("AWS/ApplicationELB"),
+					},
+					{
+						MetricName: aws.String("RequestCount"),
+						Dimensions: []*cloudwatch.Dimension{
+							{
+								Name:  aws.String("LoadBalancer"),
+								Value: aws.String("app/some-ALB/0123456789012345"),
+							},
+							{
+								Name:  aws.String("AvailabilityZone"),
+								Value: aws.String("us-east-1"),
+							},
+						},
+						Namespace: aws.String("AWS/ApplicationELB"),
+					},
+					{
+						MetricName: aws.String("RequestCount"),
+						Dimensions: []*cloudwatch.Dimension{
+							{
+								Name:  aws.String("LoadBalancer"),
+								Value: aws.String("app/some-ALB/0123456789012345"),
+							},
+						},
+						Namespace: aws.String("AWS/ApplicationELB"),
+					},
+				},
+				m: &Metric{
+					Name: "RequestCount",
+					Statistics: []string{
+						"Sum",
+					},
+					Period:                 60,
+					Length:                 600,
+					Delay:                  120,
+					NilToZero:              aws.Bool(false),
+					AddCloudwatchTimestamp: aws.Bool(false),
+				},
+			},
+			[]cloudwatchData{
+				{
+					AccountId:              aws.String("123123123123"),
+					AddCloudwatchTimestamp: aws.Bool(false),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("LoadBalancer"),
+							Value: aws.String("app/some-ALB/0123456789012345"),
+						},
+						{
+							Name:  aws.String("TargetGroup"),
+							Value: aws.String("targetgroup/some-ALB/9999666677773333"),
+						},
+					},
+					ID:        aws.String("arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345"),
+					Metric:    aws.String("RequestCount"),
+					Namespace: aws.String("alb"),
+					NilToZero: aws.Bool(false),
+					Period:    60,
+					Region:    aws.String("us-east-1"),
+					Statistics: []string{
+						"Sum",
+					},
+					Tags: []Tag{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.m) {
+			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.dimensionNames, tt.args.m) {
 				if *got.AccountId != *tt.wantGetMetricsData[i].AccountId {
 					t.Errorf("getFilteredMetricDatas().AccountId = %v, want %v", *got.AccountId, *tt.wantGetMetricsData[i].AccountId)
 				}

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -60,16 +60,16 @@ func TestSortyByTimeStamp(t *testing.T) {
 
 func Test_getFilteredMetricDatas(t *testing.T) {
 	type args struct {
-		region           string
-		accountId        *string
-		namespace        string
-		customTags       []Tag
-		tagsOnMetrics    exportedTagsOnMetrics
-		dimensionRegexps []*string
-		dimensionNames   []string
-		resources        []*taggedResource
-		metricsList      []*cloudwatch.Metric
-		m                *Metric
+		region                    string
+		accountId                 *string
+		namespace                 string
+		customTags                []Tag
+		tagsOnMetrics             exportedTagsOnMetrics
+		dimensionRegexps          []*string
+		dimensionNameRequirements []string
+		resources                 []*taggedResource
+		metricsList               []*cloudwatch.Metric
+		m                         *Metric
 	}
 	tests := []struct {
 		name               string
@@ -251,7 +251,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				customTags: nil,
 				tagsOnMetrics: nil,
 				dimensionRegexps: SupportedServices.GetService("alb").DimensionRegexps,
-				dimensionNames: []string{"LoadBalancer", "TargetGroup"},
+				dimensionNameRequirements: []string{"LoadBalancer", "TargetGroup"},
 				resources: []*taggedResource{
 					{
 						ARN: "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
@@ -365,7 +365,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.dimensionNames, tt.args.m) {
+			for i, got := range getFilteredMetricDatas(tt.args.region, tt.args.accountId, tt.args.namespace, tt.args.customTags, tt.args.tagsOnMetrics, tt.args.dimensionRegexps, tt.args.resources, tt.args.metricsList, tt.args.dimensionNameRequirements, tt.args.m) {
 				if *got.AccountId != *tt.wantGetMetricsData[i].AccountId {
 					t.Errorf("getFilteredMetricDatas().AccountId = %v, want %v", *got.AccountId, *tt.wantGetMetricsData[i].AccountId)
 				}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -33,6 +33,7 @@ type Job struct {
 	Roles                  []Role    `yaml:"roles"`
 	SearchTags             []Tag     `yaml:"searchTags"`
 	CustomTags             []Tag     `yaml:"customTags"`
+	DimensionNames         []string  `yaml:"dimensionNames"`
 	Metrics                []*Metric `yaml:"metrics"`
 	Length                 int64     `yaml:"length"`
 	Delay                  int64     `yaml:"delay"`

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -28,20 +28,20 @@ type Discovery struct {
 type exportedTagsOnMetrics map[string][]string
 
 type Job struct {
-	Regions                []string  `yaml:"regions"`
-	Type                   string    `yaml:"type"`
-	Roles                  []Role    `yaml:"roles"`
-	SearchTags             []Tag     `yaml:"searchTags"`
-	CustomTags             []Tag     `yaml:"customTags"`
-	DimensionNames         []string  `yaml:"dimensionNames"`
-	Metrics                []*Metric `yaml:"metrics"`
-	Length                 int64     `yaml:"length"`
-	Delay                  int64     `yaml:"delay"`
-	Period                 int64     `yaml:"period"`
-	RoundingPeriod         *int64    `yaml:"roundingPeriod"`
-	Statistics             []string  `yaml:"statistics"`
-	AddCloudwatchTimestamp *bool     `yaml:"addCloudwatchTimestamp"`
-	NilToZero              *bool     `yaml:"nilToZero"`
+	Regions                   []string  `yaml:"regions"`
+	Type                      string    `yaml:"type"`
+	Roles                     []Role    `yaml:"roles"`
+	SearchTags                []Tag     `yaml:"searchTags"`
+	CustomTags                []Tag     `yaml:"customTags"`
+	DimensionNameRequirements []string  `yaml:"dimensionNameRequirements"`
+	Metrics                   []*Metric `yaml:"metrics"`
+	Length                    int64     `yaml:"length"`
+	Delay                     int64     `yaml:"delay"`
+	Period                    int64     `yaml:"period"`
+	RoundingPeriod            *int64    `yaml:"roundingPeriod"`
+	Statistics                []string  `yaml:"statistics"`
+	AddCloudwatchTimestamp    *bool     `yaml:"addCloudwatchTimestamp"`
+	NilToZero                 *bool     `yaml:"nilToZero"`
 }
 
 type Static struct {


### PR DESCRIPTION
This change adds a new auto-discovery job field `DimensionNames` which restricts the requested metrics to only those which match the provided dimensions. This can enable significant cost savings by only request specific dimension combinations for cloudwatch data.

For example, ALBs have the `RequestCount` metric with these dimension combinations. The numbers provided are the number of metrics for a hypothetical ALB with 2 TGs and 3 AZs.
* `LoadBalancer`: 1
* `LoadBalancer`, `TargetGroup`: 2
* `LoadBalancer`, `AvailabilityZone`: 3
* `LoadBalancer`, `TargetGroup`, `AvailabilityZone`: 6

If we only care about the `LoadBalancer,TargetGroup` combination, this PR allows us to fetch 2 data points instead of 12. 

Fixes #570 