### PR TITLE
Update README - disable automatic sts assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,9 @@ The following IAM permissions are required to discover tagged Database Migration
 "dms:DescribeReplicationTasks"
 ```
 
+## EC2 and STS Assume Role
+YACE will automatically attempt to assume the role associated with a machine within EC2. If this is undesirable behavior turn off the use of the use of metadata endpoint by setting the environment variable `AWS_EC2_METADATA_DISABLED=true`.
+
 ## Running locally
 
 ```shell


### PR DESCRIPTION
Situation: YACE deployed onto a AWS EKS cluster where the K8S node has a role. YACE automatically discovers the role & attempts to use it rather than using the supplied `~/.aws/credentials` file. The discovery of the role is through the EC2 Metadata service. As many pods are running on the k8s node, the associated role is not privileged.   

Updated the README to include a description of how to disable automatic role assumption when running YACE on a EC2 machine by turning of the use of the EC2 Metadata endpoint.