### PR TITLE
Introduce structured logs to logging interface

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -35,15 +35,17 @@ func scrapeAwsData(
 				wg.Add(1)
 				go func(discoveryJob *Job, region string, role Role) {
 					defer wg.Done()
+					jobLogger := logger.With("job_type", discoveryJob.Type, "region", region, "arn", role.RoleArn)
 					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 					if err != nil || result.Account == nil {
-						logger.Error(err, "Couldn't get account Id for role %s", role.RoleArn)
+						jobLogger.Error(err, "Couldn't get account Id")
 						return
 					}
+					jobLogger = jobLogger.With("account", *result.Account)
 
 					clientCloudwatch := cloudwatchInterface{
 						client: cache.GetCloudwatch(&region, role),
-						logger: logger,
+						logger: jobLogger,
 					}
 
 					clientTag := tagsInterface{
@@ -53,10 +55,10 @@ func scrapeAwsData(
 						asgClient:        cache.GetASG(&region, role),
 						dmsClient:        cache.GetDMS(&region, role),
 						ec2Client:        cache.GetEC2(&region, role),
-						logger:           logger,
+						logger:           jobLogger,
 					}
 
-					resources, metrics := scrapeDiscoveryJobUsingMetricData(ctx, discoveryJob, region, result.Account, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch, metricsPerQuery, discoveryJob.RoundingPeriod, tagSemaphore, logger)
+					resources, metrics := scrapeDiscoveryJobUsingMetricData(ctx, discoveryJob, region, result.Account, config.Discovery.ExportedTagsOnMetrics, clientTag, clientCloudwatch, metricsPerQuery, discoveryJob.RoundingPeriod, tagSemaphore, jobLogger)
 					mux.Lock()
 					awsInfoData = append(awsInfoData, resources...)
 					cwData = append(cwData, metrics...)
@@ -72,18 +74,20 @@ func scrapeAwsData(
 				wg.Add(1)
 				go func(staticJob *Static, region string, role Role) {
 					defer wg.Done()
+					jobLogger := logger.With("static_job_name", staticJob.Name, "region", region, "arn", role.RoleArn)
 					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 					if err != nil || result.Account == nil {
-						logger.Error(err, "Couldn't get account Id for role %s", role.RoleArn)
+						jobLogger.Error(err, "Couldn't get account Id")
 						return
 					}
+					jobLogger = jobLogger.With("account", *result.Account)
 
 					clientCloudwatch := cloudwatchInterface{
 						client: cache.GetCloudwatch(&region, role),
-						logger: logger,
+						logger: jobLogger,
 					}
 
-					metrics := scrapeStaticJob(ctx, staticJob, region, result.Account, clientCloudwatch, cloudwatchSemaphore, logger)
+					metrics := scrapeStaticJob(ctx, staticJob, region, result.Account, clientCloudwatch, cloudwatchSemaphore, jobLogger)
 
 					mux.Lock()
 					cwData = append(cwData, metrics...)
@@ -183,12 +187,12 @@ func getMetricDataForQueries(
 		<-tagSemaphore
 
 		if err != nil {
-			logger.Error(err, "Failed to get full metric list for %s on %s job in region %s", metric.Name, svc.Namespace, region)
+			logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", svc.Namespace)
 			continue
 		}
 
 		if len(resources) == 0 {
-			logger.Debug("No resources for metric %s on %s job", metric.Name, svc.Namespace)
+			logger.Debug("No resources for metric", "metric_name", metric.Name, "namespace", svc.Namespace)
 		}
 		getMetricDatas = append(getMetricDatas, getFilteredMetricDatas(region, accountId, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, svc.DimensionRegexps, resources, metricsList.Metrics, metric)...)
 	}
@@ -213,7 +217,7 @@ func scrapeDiscoveryJobUsingMetricData(
 	resources, err := clientTag.get(ctx, job, region)
 	<-tagSemaphore
 	if err != nil {
-		logger.Error(err, "Couldn't describe resources for region %s, in account %s", region, *accountId)
+		logger.Error(err, "Couldn't describe resources")
 		return
 	}
 
@@ -221,7 +225,7 @@ func scrapeDiscoveryJobUsingMetricData(
 	getMetricDatas := getMetricDataForQueries(ctx, job, svc, region, accountId, tagsOnMetrics, clientCloudwatch, resources, tagSemaphore, logger)
 	metricDataLength := len(getMetricDatas)
 	if metricDataLength == 0 {
-		logger.Debug("No metrics data for %s", job.Type)
+		logger.Debug("No metrics data found")
 		return
 	}
 

--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -49,7 +49,6 @@ func scrapeAwsData(
 					}
 
 					clientTag := tagsInterface{
-						account:          *result.Account,
 						client:           cache.GetTagging(&region, role),
 						apiGatewayClient: cache.GetAPIGateway(&region, role),
 						asgClient:        cache.GetASG(&region, role),

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -82,7 +82,7 @@ func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespac
 		" --start-time " + startTime.Format(time.RFC3339) +
 		" --end-time " + endTime.Format(time.RFC3339))
 
-	logger.Debug("Output: %v", *output)
+	logger.Debug("createGetMetricStatisticsInput", "output", *output)
 	return output
 }
 
@@ -129,7 +129,7 @@ func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string,
 		time.Duration(roundingPeriod)*time.Second,
 		time.Duration(length)*time.Second,
 		time.Duration(delay)*time.Second)
-	logger.Debug("GetMetricData StartTime: %s, EndTime: %s", startTime.Format(timeFormat), endTime.Format(timeFormat))
+	logger.Debug("GetMetricData Window", "start_time", startTime.Format(timeFormat), "end_time", endTime.Format(timeFormat))
 
 	dataPointOrder := "TimestampDescending"
 	output = &cloudwatch.GetMetricDataInput{
@@ -197,11 +197,11 @@ func dimensionsToCliString(dimensions []*cloudwatch.Dimension) (output string) {
 func (iface cloudwatchInterface) get(ctx context.Context, filter *cloudwatch.GetMetricStatisticsInput) []*cloudwatch.Datapoint {
 	c := iface.client
 
-	iface.logger.Debug("GetMetricStatisticsInput: %v", filter)
+	iface.logger.Debug("GetMetricStatistics", "input", filter)
 
 	resp, err := c.GetMetricStatisticsWithContext(ctx, filter)
 
-	iface.logger.Debug("GetMetricStatisticsOutput: %v", resp)
+	iface.logger.Debug("GetMetricStatistics", "output", resp)
 
 	cloudwatchAPICounter.Inc()
 	cloudwatchGetMetricStatisticsAPICounter.Inc()
@@ -220,7 +220,7 @@ func (iface cloudwatchInterface) getMetricData(ctx context.Context, filter *clou
 	var resp cloudwatch.GetMetricDataOutput
 
 	if iface.logger.IsDebugEnabled() {
-		iface.logger.Debug("GetMetricDataInput: %v", filter)
+		iface.logger.Debug("GetMetricData", "input", filter)
 	}
 
 	// Using the paged version of the function
@@ -233,7 +233,7 @@ func (iface cloudwatchInterface) getMetricData(ctx context.Context, filter *clou
 		})
 
 	if iface.logger.IsDebugEnabled() {
-		iface.logger.Debug("GetMetricDataOutput: %v", resp)
+		iface.logger.Debug("GetMetricData", "output", resp)
 	}
 
 	if err != nil {

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -77,7 +77,6 @@ func (r taggedResource) metricTags(tagsOnMetrics exportedTagsOnMetrics) []Tag {
 
 // https://docs.aws.amazon.com/sdk-for-go/api/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface/
 type tagsInterface struct {
-	account          string
 	client           resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	asgClient        autoscalingiface.AutoScalingAPI
 	apiGatewayClient apigatewayiface.APIGatewayAPI

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -102,7 +102,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 			resourceGroupTaggingAPICounter.Inc()
 
 			if len(page.ResourceTagMappingList) == 0 {
-				iface.logger.Error(errors.New("resource tag list is empty"), "Account %s contained no tagged resource. Tags must be defined for %s to be discovered.", iface.account, job.Type)
+				iface.logger.Error(errors.New("resource tag list is empty"), "Account contained no tagged resource. Tags must be defined for resources to be discovered.")
 			}
 
 			for _, resourceTagMapping := range page.ResourceTagMappingList {
@@ -119,7 +119,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 				if resource.filterThroughTags(job.SearchTags) {
 					resources = append(resources, &resource)
 				} else {
-					iface.logger.Debug("Skipping resource %s because search tags do not match", resource.ARN)
+					iface.logger.Debug("Skipping resource because search tags do not match")
 				}
 			}
 			return pageNum < 100

--- a/pkg/logruslogger.go
+++ b/pkg/logruslogger.go
@@ -1,31 +1,116 @@
 package exporter
 
-import log "github.com/sirupsen/logrus"
+import (
+	"encoding"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	log "github.com/sirupsen/logrus"
+)
 
 type logrusLogger struct {
-	logger *log.Logger
+	entry *log.Entry
 }
 
-func NewLogrusLogger(logger *log.Logger) logrusLogger {
-	return logrusLogger{logger}
+func (l logrusLogger) Info(message string, keyvals ...interface{}) {
+	l.entry.WithFields(toFields(keyvals...)).Info(message)
 }
 
-func (l logrusLogger) Info(message string, args ...interface{}) {
-	l.logger.Infof(message, args...)
+func (l logrusLogger) Debug(message string, keyvals ...interface{}) {
+	l.entry.WithFields(toFields(keyvals...)).Debug(message)
 }
 
-func (l logrusLogger) Debug(message string, args ...interface{}) {
-	l.logger.Debugf(message, args...)
+func (l logrusLogger) Error(err error, message string, keyvals ...interface{}) {
+	l.entry.WithFields(toFields(keyvals...)).WithError(err).Error(message)
 }
 
-func (l logrusLogger) Error(err error, message string, args ...interface{}) {
-	l.logger.WithError(err).Errorf(message, args...)
+func (l logrusLogger) Warn(message string, keyvals ...interface{}) {
+	l.entry.WithFields(toFields(keyvals...)).Warn(message)
 }
 
-func (l logrusLogger) Warn(message string, args ...interface{}) {
-	l.logger.Warnf(message, args...)
+func (l logrusLogger) With(keyvals ...interface{}) Logger {
+	return logrusLogger{l.entry.WithFields(toFields(keyvals...))}
 }
 
 func (l logrusLogger) IsDebugEnabled() bool {
-	return l.logger.IsLevelEnabled(log.DebugLevel)
+	return l.entry.Logger.IsLevelEnabled(log.DebugLevel)
+}
+
+func NewLogrusLogger(logger *log.Logger) logrusLogger {
+	return logrusLogger{log.NewEntry(logger)}
+}
+
+var ErrMissingValue = errors.New("(MISSING)")
+
+// This code is from https://github.com/go-kit/log/blob/main/json_logger.go#L23-L91 which safely handles odd keyvals
+// lengths, and safely converting interface{} -> string
+func toFields(keyvals ...interface{}) log.Fields {
+	n := (len(keyvals) + 1) / 2 // +1 to handle case when len is odd
+	m := make(map[string]interface{}, n)
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i]
+		var v interface{} = ErrMissingValue
+		if i+1 < len(keyvals) {
+			v = keyvals[i+1]
+		}
+		merge(m, k, v)
+	}
+
+	return m
+}
+
+func merge(dst map[string]interface{}, k, v interface{}) {
+	var key string
+	switch x := k.(type) {
+	case string:
+		key = x
+	case fmt.Stringer:
+		key = safeString(x)
+	default:
+		key = fmt.Sprint(x)
+	}
+
+	// We want json.Marshaler and encoding.TextMarshaller to take priority over
+	// err.Error() and v.String(). But json.Marshall (called later) does that by
+	// default so we force a no-op if it's one of those 2 case.
+	switch x := v.(type) {
+	case json.Marshaler:
+	case encoding.TextMarshaler:
+	case error:
+		v = safeError(x)
+	case fmt.Stringer:
+		v = safeString(x)
+	}
+
+	dst[key] = v
+}
+
+func safeString(str fmt.Stringer) (s string) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = "NULL"
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = str.String()
+	return
+}
+
+func safeError(err error) (s interface{}) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(err); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = nil
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+	s = err.Error()
+	return
 }

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -48,9 +48,10 @@ func UpdateMetrics(
 }
 
 type Logger interface {
-	Info(message string, args ...interface{})
-	Debug(message string, args ...interface{})
-	Error(err error, message string, args ...interface{})
-	Warn(message string, args ...interface{})
+	Info(message string, keyvals ...interface{})
+	Debug(message string, keyvals ...interface{})
+	Error(err error, message string, keyvals ...interface{})
+	Warn(message string, keyvals ...interface{})
+	With(keyvals ...interface{}) Logger
 	IsDebugEnabled() bool
 }


### PR DESCRIPTION
This refactors the logging interface provided to `upgrade.go` to structured logging with [fields](https://github.com/sirupsen/logrus#fields) instead of embedded data. This makes it easier to propagate data for logging purposes during the scraping process. 

This change was not applied to the AWS client logs. It is possible to provide a logger implementation in their client config but the interface is one function, `Log(...interface{})` and the end result is rather ugly with their multi-line log messages, 
```
{"level":"info","msg":"[DEBUG: Response tagging/GetResources Details:\n---[ RESPONSE ]--------------------------------------\nHTTP/1.1 200 OK\r\nContent-Length: 18919\r\nContent-Type: application/x-amz-json-1.1\r\nDate: Tue, 21 Jun 2022 19:09:23 GMT\r\nX-Amzn-Requestid: 405a2cc6-1fa2-4778-8d8c-1c538d51568f\r\n\r\n\n-----------------------------------------------------]","time":"2022-06-21T15:09:24-04:00"}
```

Follow up on, https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/564.