### PR TITLE
Add helm chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ Dockerfile
 Jenkinsfile
 README.md
 vendor/
+charts/

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,3 +9,45 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build docker image
       run: docker build -t yace --build-arg VERSION=${{github.event.release.tag_name}} .
+
+  lintTestHelmChart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.5.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config ct.yaml)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ct.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,31 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: release
+  publishHelmChart:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,29 +34,3 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: release
-  publishHelmChart:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.8.1
-
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,5 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.0
-        with:
-          charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release_helm.yml
+++ b/.github/workflows/release_helm.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    branches:
+      - master
+
+name: Build, test and publish
+jobs:
+  publishHelmChart:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config.yml
 yet-another-cloudwatch-exporter
+!charts/yet-another-cloudwatch-exporter
 vendor
 dist
 yace

--- a/README.md
+++ b/README.md
@@ -502,7 +502,11 @@ docker run -d --rm -v $PWD/credentials:/exporter/.aws/credentials -v $PWD/config
 ```
 
 ## Kubernetes Installation
+### Install with HELM
+* [README](charts/yet-another-cloudwatch-exporter/README.md)
 
+
+### Install with manifests
 ```yaml
 ---
 apiVersion: v1

--- a/charts/yet-another-cloudwatch-exporter/.helmignore
+++ b/charts/yet-another-cloudwatch-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: yet-another-cloudwatch-exporter
 description: Yet Another Cloudwatch Exporter
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "v0.36.1-alpha"
 home: https://github.com/nerdswords/yet-another-cloudwatch-exporter
 sources:

--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: yet-another-cloudwatch-exporter
+description: Yet Another Cloudwatch Exporter
+type: application
+version: 0.6.0
+appVersion: "v0.36.1-alpha"
+home: https://github.com/nerdswords/yet-another-cloudwatch-exporter
+sources:
+- https://github.com/nerdswords/yet-another-cloudwatch-exporter
+keywords:
+- aws
+- cloudwatch
+- prometheus
+- exporter
+- yet-another
+- yace

--- a/charts/yet-another-cloudwatch-exporter/README.md
+++ b/charts/yet-another-cloudwatch-exporter/README.md
@@ -1,0 +1,105 @@
+# Cloudwatch exporter
+
+* Installs [YACE - yet another cloudwatch exporter](https://github.com/nerdswords/yet-another-cloudwatch-exporter)
+
+## TL;DR;
+
+```console
+$ helm repo add nerdswords https://nerdswords.github.io/yet-another-cloudwatch-exporter
+$ helm install nerdswords/yet-another-cloudwatch-exporter
+```
+
+## Introduction
+
+This chart bootstraps a [YACE - yet another cloudwatch exporter](https://github.com/nerdswords/yet-another-cloudwatch-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- [kube2iam](https://github.com/jtblin/kube2iam) installed to use the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key** or **aws.secret.name**
+- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) installed to use serviceMonitor and/or prometheusRule
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add nerdswords https://nerdswords.github.io/yet-another-cloudwatch-exporter
+$ # pass AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as values
+$ helm install --name my-release nerdswords/yet-another-cloudwatch-exporter --set aws.aws_access_key_id=$AWS_ACCESS_KEY_ID,aws.aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+
+$ # or store them in a secret and pass its name as a value
+$ kubectl create secret generic <SECRET_NAME> --from-literal=access_key=$AWS_ACCESS_KEY_ID --from-literal=secret_key=$AWS_SECRET_ACCESS_KEY
+$ helm install --name my-release nerdswords/yet-another-cloudwatch-exporter --set aws.secret.name=<SECRET_NAME>
+
+$ # or add a role to aws with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions) to add to cloud watch and pass its name as a value
+$ helm install --name my-release nerdswords/yet-another-cloudwatch-exporter --set aws.role=<ROLL_NAME>
+```
+
+The command deploys YACE exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the YACE Exporter chart and their default values.
+
+| Parameter                         | Description                                                             | Default                     |
+| --------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
+| `image.repository`                | Image                                                                   | `quay.io/invisionag/yet-another-cloudwatch-exporter`  |
+| `image.tag`                       | Image tag                                                               | `v0.13.7`                   |
+| `image.pullPolicy`                | Image pull policy                                                       | `IfNotPresent`              |
+| `command`                         | Container entrypoint command                                            | `[]`                        |
+| `service.type`                    | Service type                                                            | `ClusterIP`                 |
+| `service.port`                    | The service port                                                        | `80`                        |
+| `resources`                       |                                                                         | `{}`                        |
+| `extraArgs`                       | Additional container arguments                                          | `[]`                        |
+| `aws.role`                        | AWS IAM Role To Use                                                     |                             |
+| `aws.aws_access_key_id`           | AWS access key id                                                       |                             |
+| `aws.aws_secret_access_key`       | AWS secret access key                                                   |                             |
+| `aws.secret.name`                 | The name of a pre-created secret in which AWS credentials are stored    |                             |
+| `aws.secret.includesSessionToken` | Whether or not the pre-created secret contains an AWS STS session token |                             |
+| `config`                          | YACE configuration (default found in the webpage)                       | `example configuration`     |
+| `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
+| `serviceAccount.name`             | Name of the service account.                                            |                             |
+| `serviceAccount.annotations`      | Custom annotations for service                                          | `{}`                        |
+| `serviceAccount.labels`           | Additional custom labels for the service                                | `{}`                        |
+| `tolerations`                     | Add tolerations                                                         | `[]`                        |
+| `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
+| `affinity`                        | node/pod affinities                                                     | `{}`                        |
+| `livenessProbe`                   | Liveness probe settings                                                 |                             |
+| `readinessProbe`                  | Readiness probe settings                                                |                             |
+| `serviceMonitor.enabled`          | Use servicemonitor from prometheus operator                             | `false`                     |
+| `serviceMonitor.namespace`        | Namespace thes Servicemonitor  is installed in                          |                             |
+| `serviceMonitor.interval`         | How frequently Prometheus should scrape                                 |                             |
+| `serviceMonitor.telemetryPath`    | path to yave telemtery-path                                             |                             |
+| `serviceMonitor.labels`           | labels for the ServiceMonitor passed to Prometheus Operator             | `{}`                        |
+| `serviceMonitor.timeout`          | Timeout after which the scrape is ended                                 |                             |
+| `ingress.enabled`                 | Enables Ingress                                                         | `false`                     |
+| `ingress.annotations`             | Ingress annotations                                                     | `{}`                        |
+| `ingress.labels`                  | Custom labels                                                           | `{}`                        |
+| `ingress.hosts`                   | Ingress accepted hostnames                                              | `[]`                        |
+| `ingress.tls`                     | Ingress TLS configuration                                               | `[]`                        |
+| `podAnnotations`                  | Custom pod annotations                                                  | `{}`                        |
+| `podLabels`                       | Custom pod labels                                                       | `{}`                        |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name my-release \
+    --set aws.role=my-aws-role \
+    nerdswords/yet-another-cloudwatch-exporter
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name my-release -f values.yaml nerdswords/yet-another-cloudwatch-exporter
+```

--- a/charts/yet-another-cloudwatch-exporter/templates/NOTES.txt
+++ b/charts/yet-another-cloudwatch-exporter/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "yet-another-cloudwatch-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "yet-another-cloudwatch-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "yet-another-cloudwatch-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "yet-another-cloudwatch-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/_helpers.tpl
+++ b/charts/yet-another-cloudwatch-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "yet-another-cloudwatch-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "yet-another-cloudwatch-exporter.labels" -}}
+helm.sh/chart: {{ include "yet-another-cloudwatch-exporter.chart" . }}
+{{ include "yet-another-cloudwatch-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "yet-another-cloudwatch-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "yet-another-cloudwatch-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "yet-another-cloudwatch-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "yet-another-cloudwatch-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/configmap.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+data:
+  config.yml: |
+{{- (tpl .Values.config $) | nindent 4 }}

--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{ if .Values.aws.role}}iam.amazonaws.com/role: {{ .Values.aws.role }}{{ end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "yet-another-cloudwatch-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "yace"
+            - "--config.file=/config/config.yml"
+            {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+          volumeMounts:
+            - name: vol-yet-another-cloudwatch-exporter
+              mountPath: /config
+        {{- if not .Values.aws.role }}
+        {{- if .Values.aws.secret.name }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: access_key
+                  name: {{ .Values.aws.secret.name }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secret_key
+                  name: {{ .Values.aws.secret.name }}
+          {{- if .Values.aws.secret.includesSessionToken }}
+            - name: AWS_SESSION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: security_token
+                  name: {{ .Values.aws.secret.name }}
+          {{- end }}
+          {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+          {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+        name: vol-yet-another-cloudwatch-exporter

--- a/charts/yet-another-cloudwatch-exporter/templates/ingress.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "yet-another-cloudwatch-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,19 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheusRule.enabled ) }}
+{{- $fullName := include "yet-another-cloudwatch-exporter.fullname" . -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+{{- if .Values.prometheusRule.labels }}
+  labels:
+{{ toYaml .Values.prometheusRule.labels | indent 4}}
+{{- end }}
+  name: {{ $fullName }}
+{{- if .Values.prometheusRule.namespace }}
+  namespace: {{ .Values.prometheusRule.namespace }}
+{{- end }}
+spec:
+  groups:
+  - name: {{ $fullName }}
+    rules:
+      {{- toYaml .Values.prometheusRule.rules | nindent 6 }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/prometheusrule.yaml
@@ -1,19 +1,19 @@
 {{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheusRule.enabled ) }}
-{{- $fullName := include "yet-another-cloudwatch-exporter.fullname" . -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-{{- if .Values.prometheusRule.labels }}
-  labels:
-{{ toYaml .Values.prometheusRule.labels | indent 4}}
-{{- end }}
-  name: {{ $fullName }}
+  name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
 {{- if .Values.prometheusRule.namespace }}
   namespace: {{ .Values.prometheusRule.namespace }}
 {{- end }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   groups:
-  - name: {{ $fullName }}
+  - name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
     rules:
       {{- toYaml .Values.prometheusRule.rules | nindent 6 }}
 {{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/secrets.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/secrets.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.aws.aws_access_key_id .Values.aws.aws_secret_access_key }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+type: Opaque
+data:
+  aws_access_key_id: {{ .Values.aws.aws_access_key_id | b64enc | quote }}
+  aws_secret_access_key: {{ .Values.aws.aws_secret_access_key | b64enc | quote }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/service.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "yet-another-cloudwatch-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -2,17 +2,18 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.serviceMonitor.labels }}
-  labels:
-{{ toYaml .Values.serviceMonitor.labels | indent 4}}
-{{- end }}
   name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
 {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ .Values.serviceMonitor.namespace }}
 {{- end }}
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
-  - targetPort: {{ .Values.service.port }}
+  - port: http
 {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
 {{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.port }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+{{ toYaml .Values.serviceMonitor.relabelings | indent 6 }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 6 }}
+{{- end }}
+  jobLabel: {{ template "yet-another-cloudwatch-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/servicemonitor.yaml
@@ -36,5 +36,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 4 }}
+      {{- include "yet-another-cloudwatch-exporter.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/yet-another-cloudwatch-exporter/templates/tests/test-connection.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "yet-another-cloudwatch-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "yet-another-cloudwatch-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "yet-another-cloudwatch-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -1,0 +1,369 @@
+# Default values for yet-another-cloudwatch-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/nerdswords/yet-another-cloudwatch-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraArgs: []
+#   decoupled-scraping: false
+#   scraping-interval: 300
+
+aws:
+  role:
+
+  # The name of a pre-created secret in which AWS credentials are stored. When
+  # set, aws_access_key_id is assumed to be in a field called access_key,
+  # aws_secret_access_key is assumed to be in a field called secret_key, and the
+  # session token, if it exists, is assumed to be in a field called
+  # security_token
+  secret:
+    name:
+    includesSessionToken: false
+
+  # Note: Do not specify the aws_access_key_id and aws_secret_access_key if you specified role or secret.name before
+  aws_access_key_id:
+  aws_secret_access_key:
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to cloudwatch-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set relabelings for the ServiceMonitor, use to apply to samples before scraping
+  # relabelings: []
+  # Set metricRelabelings for the ServiceMonitor, use to apply to samples for ingestion
+  # metricRelabelings: []
+  #
+  # Example - note the Kubernetes convention of camelCase instead of Prometheus' snake_case
+  # metricRelabelings:
+  #   - sourceLabels: [dbinstance_identifier]
+  #     action: replace
+  #     replacement: mydbname
+  #     targetLabel: dbname
+
+prometheusRule:
+  # Specifies whether a PrometheusRule should be created
+  enabled: false
+  # Set the namespace the PrometheusRule should be deployed
+  # namespace: monitoring
+  # Set labels for the PrometheusRule, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Example - note the Kubernetes convention of camelCase instead of Prometheus'
+  # rules:
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 80%.
+  #      expr: aws_ebs_burst_balance_average < 80
+  #      for: 10m
+  #      labels:
+  #        severity: warning
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 50%.
+  #      expr: aws_ebs_burst_balance_average < 50
+  #      for: 10m
+  #      labels:
+  #        severity: warning
+  #    - alert: ELB-Low-BurstBalance
+  #      annotations:
+  #        message: The ELB BurstBalance during the last 10 minutes is lower than 30%.
+  #      expr: aws_ebs_burst_balance_average < 30
+  #      for: 10m
+  #      labels:
+  #        severity: critical
+
+
+config: |-
+  apiVersion: v1alpha1
+  sts-endpoint: eu-west-1
+  discovery:
+    exportedTagsOnMetrics:
+      ec2:
+        - Name
+      ebs:
+        - VolumeId
+    jobs:
+    - type: es
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: type
+          value: ^(easteregg|k8s)$
+      metrics:
+        - name: FreeStorageSpace
+          statistics:
+          - Sum
+          period: 60
+          length: 600
+        - name: ClusterStatus.green
+          statistics:
+          - Minimum
+          period: 60
+          length: 600
+        - name: ClusterStatus.yellow
+          statistics:
+          - Maximum
+          period: 60
+          length: 600
+        - name: ClusterStatus.red
+          statistics:
+          - Maximum
+          period: 60
+          length: 600
+    - type: elb
+      regions:
+        - eu-west-1
+      length: 900
+      delay: 120
+      statistics:
+        - Minimum
+        - Maximum
+        - Sum
+      searchTags:
+        - key: KubernetesCluster
+          value: production-19
+      metrics:
+        - name: HealthyHostCount
+          statistics:
+          - Minimum
+          period: 600
+          length: 600 #(this will be ignored)
+        - name: HTTPCode_Backend_4XX
+          statistics:
+          - Sum
+          period: 60
+          length: 900 #(this will be ignored)
+          delay: 300 #(this will be ignored)
+          nilToZero: true
+        - name: HTTPCode_Backend_5XX
+          period: 60
+    - type: alb
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: kubernetes.io/service-name
+          value: .*
+      metrics:
+        - name: UnHealthyHostCount
+          statistics: [Maximum]
+          period: 60
+          length: 600
+    - type: vpn
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: kubernetes.io/service-name
+          value: .*
+      metrics:
+        - name: TunnelState
+          statistics:
+          - p90
+          period: 60
+          length: 300
+    - type: kinesis
+      regions:
+        - eu-west-1
+      metrics:
+        - name: PutRecords.Success
+          statistics:
+          - Sum
+          period: 60
+          length: 300
+    - type: s3
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: type
+          value: public
+      metrics:
+        - name: NumberOfObjects
+          statistics:
+            - Average
+          period: 86400
+          length: 172800
+        - name: BucketSizeBytes
+          statistics:
+            - Average
+          period: 86400
+          length: 172800
+    - type: ebs
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: type
+          value: public
+      metrics:
+        - name: BurstBalance
+          statistics:
+          - Minimum
+          period: 600
+          length: 600
+          addCloudwatchTimestamp: true
+    - type: kafka
+      regions:
+        - eu-west-1
+      searchTags:
+        - key: env
+          value: dev
+      metrics:
+        - name: BytesOutPerSec
+          statistics:
+          - Average
+          period: 600
+          length: 600
+    - type: appstream
+      regions:
+        - eu-central-1
+      searchTags:
+        - key: saas_monitoring
+          value: true
+      metrics:
+        - name: ActualCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: AvailableCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600      
+        - name: CapacityUtilization
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: DesiredCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: InUseCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: PendingCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: RunningCapacity
+          statistics:
+            - Average
+          period: 600
+          length: 600
+        - name: InsufficientCapacityError
+          statistics:
+            - Average
+          period: 600
+          length: 600		
+    - type: backup
+      regions:
+        - eu-central-1
+      searchTags:
+        - key: saas_monitoring
+          value: true
+      metrics:
+        - name: NumberOfBackupJobsCompleted
+          statistics:
+            - Average
+          period: 600
+          length: 600		
+  static:
+    - namespace: AWS/AutoScaling
+      name: must_be_set
+      regions:
+        - eu-west-1
+      dimensions:
+       - name: AutoScalingGroupName
+         value: Test
+      customTags:
+        - key: CustomTag
+          value: CustomValue
+      metrics:
+        - name: GroupInServiceInstances
+          statistics:
+          - Minimum
+          period: 60
+          length: 300

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+remote: origin
+target-branch: master
+chart-dirs:
+  - charts
+chart-repos:
+  - nerdswords=https://nerdswords.github.io/yet-another-cloudwatch-exporter
+helm-extra-args: --timeout 600s


### PR DESCRIPTION
This PR closes https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/491 https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/5.
This change adds a helm chart.
Code is prepared to use github.io as a helm registry, https://github.com/helm/chart-releaser-action

It is not tested yet.

I would be happy if someone would test it.

https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/605

https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/605#issuecomment-1169554064
>Awesome - Thats nice to see!
>
>Could you please test it yourself first and if you are sure it works, tag me and then I would like to review <3
>
>As I am a private person maintaining this I really depend that I have contributions which take as less private time away from >me as possible.
>
>Is the helm chart based on: https://artifacthub.io/packages/helm/mogaal/prometheus-yace-exporter - If not what are >differences? :) - Thanks!

the message gave me an idea to merge this repo and then update that code.
So now differences are
- renamed chart
- updated README.md
- updated templates according to common helm chart template(helm create)
- fixed notes
- fixed healthcheck
- added imagePullSecrets
- added PrometheusRule
- added pipelines for helm, it cant be tested before the merge.