### PR TITLE
Set max page size for tagging API requests.

### DIFF
--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -92,6 +92,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 	if len(svc.ResourceFilters) > 0 {
 		inputparams := &resourcegroupstaggingapi.GetResourcesInput{
 			ResourceTypeFilters: svc.ResourceFilters,
+			ResourcesPerPage:    aws.Int64(100), // max allowed value according to API docs
 		}
 		c := iface.client
 		pageNum := 0
@@ -121,7 +122,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 					iface.logger.Debug("Skipping resource because search tags do not match")
 				}
 			}
-			return pageNum < 100
+			return !lastPage
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The tagging API allows specifying the number of resources per page to be
returned. Setting it to the max allowed value should reduce the number
of requests issued when fetching large fleets of resources.

Here we also change the iteration logic to stop at the last page.