### PR TITLE
Fix searchTags and bad dimension name

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -307,19 +307,24 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 		if len(dimensionNameList) > 0 && !metricDimensionsMatchNames(cwMetric, dimensionNameList) {
 			continue
 		}
-		for _, dimension := range cwMetric.Dimensions {
-			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok {
-				if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
+
+		for _, dimension := range cwMetric.Dimensions { // loop over the returned dimensions for our current metric
+			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok { // if the name of the metric matches the name of a dimension we're filtering against, continue
+				if d, ok := dimensionFilterValues[*dimension.Value]; !ok { // if the value of our metric doesn't match the value of the dimension we're looking for and we haven't already found our metric in the previous iteration of the loop, skip
 					if !alreadyFound {
 						skip = true
 					}
 					break
-				} else {
+				} else { // if the value of the dimension we're filtering on matches the value attached to our current metric, set alreadyFound to true, and set our metric
 					alreadyFound = true
 					r = d
 				}
+			} else { // If the dimension name doesn't match the name of a dimension we're filtering on, skip
+				skip = true
+				break
 			}
 		}
+
 		if !skip {
 			for _, stats := range m.Statistics {
 				id := fmt.Sprintf("id_%d", rand.Int())

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -119,7 +119,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 				if resource.filterThroughTags(job.SearchTags) {
 					resources = append(resources, &resource)
 				} else {
-					iface.logger.Debug("Skipping resource because search tags do not match")
+					iface.logger.Debug("Skipping resource because search tags do not match", "arn", resource.ARN)
 				}
 			}
 			return !lastPage


### PR DESCRIPTION
This commit resolves https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/365.

In cases in which the name of the dimensions for a given metric didn't
match a dimension in our searchTags list, we would pass a default global query
for all metrics under a given namespace into our list, returning metrics
we meant to filter. A test case was added to cover.

In addition, I decorated a debug log entry that was useful in finding
this bug.