### PR TITLE
Filter api gateway resources to skip "stages"

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -106,7 +107,8 @@ var (
 				})
 				for _, resource := range inputResources {
 					for i, gw := range output.Items {
-						if strings.Contains(resource.ARN, *gw.Id) {
+						searchString := regexp.MustCompile(fmt.Sprintf(".*apis/%s$", *gw.Id))
+						if searchString.MatchString(resource.ARN) {
 							r := resource
 							r.ARN = strings.ReplaceAll(resource.ARN, *gw.Id, *gw.Name)
 							outputResources = append(outputResources, r)

--- a/pkg/services_test.go
+++ b/pkg/services_test.go
@@ -7,9 +7,110 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
 )
+
+func TestApiGatewayFilterFunc(t *testing.T) {
+	tests := []struct {
+		name            string
+		iface           tagsInterface
+		inputResources  []*taggedResource
+		outputResources []*taggedResource
+	}{
+		{
+			"api gateway resources skip stages",
+			tagsInterface{
+				apiGatewayClient: apiGatewayClient{
+					getRestApisOutput: &apigateway.GetRestApisOutput{
+						Items: []*apigateway.RestApi{
+							{
+								ApiKeySource:              nil,
+								BinaryMediaTypes:          nil,
+								CreatedDate:               nil,
+								Description:               nil,
+								DisableExecuteApiEndpoint: nil,
+								EndpointConfiguration:     nil,
+								Id:                        aws.String("gwid1234"),
+								MinimumCompressionSize:    nil,
+								Name:                      aws.String("apiname"),
+								Policy:                    nil,
+								Tags:                      nil,
+								Version:                   nil,
+								Warnings:                  nil,
+							},
+						},
+						Position: nil,
+					},
+				},
+			},
+			[]*taggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/gwid1234/stages/main",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/gwid1234",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+			[]*taggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/apiname",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			apigateway := SupportedServices.GetService("apigateway")
+
+			outputResources, err := apigateway.FilterFunc(context.Background(), test.iface, test.inputResources)
+			if err != nil {
+				t.Logf("Error from FilterFunc: %v", err)
+				t.FailNow()
+			}
+			if len(outputResources) != len(test.outputResources) {
+				t.Logf("len(outputResources) = %d, want %d", len(outputResources), len(test.outputResources))
+				t.Fail()
+			}
+			for i, resource := range outputResources {
+				if len(test.outputResources) <= i {
+					break
+				}
+				wantResource := *test.outputResources[i]
+				if !reflect.DeepEqual(*resource, wantResource) {
+					t.Errorf("outputResources[%d] = %+v, want %+v", i, *resource, wantResource)
+				}
+			}
+		})
+	}
+}
 
 func TestDMSFilterFunc(t *testing.T) {
 	tests := []struct {
@@ -230,6 +331,17 @@ type dmsClient struct {
 	databasemigrationserviceiface.DatabaseMigrationServiceAPI
 	describeReplicationInstancesOutput *databasemigrationservice.DescribeReplicationInstancesOutput
 	describeReplicationTasksOutput     *databasemigrationservice.DescribeReplicationTasksOutput
+}
+
+type apiGatewayClient struct {
+	apigatewayiface.APIGatewayAPI
+	getRestApisOutput *apigateway.GetRestApisOutput
+	getRestApisInput  *apigateway.GetRestApisInput
+}
+
+func (apigateway apiGatewayClient) GetRestApisPagesWithContext(context2 aws.Context, input *apigateway.GetRestApisInput, fn func(*apigateway.GetRestApisOutput, bool) bool, opts ...request.Option) error {
+	fn(apigateway.getRestApisOutput, true)
+	return nil
 }
 
 func (dms dmsClient) DescribeReplicationInstancesPagesWithContext(ctx aws.Context, input *databasemigrationservice.DescribeReplicationInstancesInput, fn func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool, opts ...request.Option) error {


### PR DESCRIPTION
When the API Gateway API is queried, it will return resources in which the ARN has `/stages/main` included.
If that happens, you can get mismatched Api names to ARN.

In our case, we have 3 APIs:
webhook-api-dev
webhook-api-stg
webhook-api-prd

Output before the fix:
```
$ curl -s localhost:5000/metrics |grep info
# HELP aws_apigateway_info Help is not implemented yet.
# TYPE aws_apigateway_info gauge
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-dev/stages/main"} 0
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-prd"} 0
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-stg/stages/main"} 0
```

Output after the fix:
```
$ curl -s localhost:5000/metrics |grep info
# HELP aws_apigateway_info Help is not implemented yet.
# TYPE aws_apigateway_info gauge
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-dev"} 0
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-prd"} 0
aws_apigateway_info{name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-stg"} 0
```

I chose to use the `info` output as it is very terse.  If you look at metrics like `aws_apigateway_5_xxerror_maximum`, the same mixup is occurring. One example line of a mixed up label:

```
aws_apigateway_5_xxerror_maximum{account_id="12341234412",dimension_ApiName="webhook-api-prd",dimension_Method="GET",dimension_Resource="/health",dimension_Stage="main",name="arn:aws:apigateway:us-east-1::/restapis/webhook-api-dev/stages/main",region="us-east-1"} 0
```

As you can see, the ApiName dimension references `prd` but the name/arn references `dev`