### PR TITLE
Fix failing test for the case of empty metric data.

### DIFF
--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -130,37 +130,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					AddCloudwatchTimestamp: aws.Bool(false),
 				},
 			},
-			[]cloudwatchData{
-				{
-					AccountId:              aws.String("123123123123"),
-					AddCloudwatchTimestamp: aws.Bool(false),
-					Dimensions: []*cloudwatch.Dimension{
-						{
-							Name:  aws.String("InstanceId"),
-							Value: aws.String("i-12312312312312312"),
-						},
-					},
-					ID:        aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
-					Metric:    aws.String("CPUUtilization"),
-					Namespace: aws.String("ec2"),
-					NilToZero: aws.Bool(false),
-					Period:    60,
-					Region:    aws.String("us-east-1"),
-					Statistics: []string{
-						"Average",
-					},
-					Tags: []Tag{
-						{
-							Key:   "Value1",
-							Value: "",
-						},
-						{
-							Key:   "Value2",
-							Value: "",
-						},
-					},
-				},
-			},
+			[]cloudwatchData{},
 		},
 		{
 			"ec2",

--- a/pkg/services_test.go
+++ b/pkg/services_test.go
@@ -336,7 +336,6 @@ type dmsClient struct {
 type apiGatewayClient struct {
 	apigatewayiface.APIGatewayAPI
 	getRestApisOutput *apigateway.GetRestApisOutput
-	getRestApisInput  *apigateway.GetRestApisInput
 }
 
 func (apigateway apiGatewayClient) GetRestApisPagesWithContext(context2 aws.Context, input *apigateway.GetRestApisInput, fn func(*apigateway.GetRestApisOutput, bool) bool, opts ...request.Option) error {


### PR DESCRIPTION
This has been failing since [0]: when the dimension name is wrong then metric should be filtered out.

[0] https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/642