### PR TITLE
Add dimensions regex for AmazonMQ.

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -126,6 +126,9 @@ var (
 			ResourceFilters: []*string{
 				aws.String("mq"),
 			},
+			DimensionRegexps: []*string{
+				aws.String("broker:(?P<Broker>[^:]+)"),
+			},
 		}, {
 			Namespace: "AWS/AppSync",
 			Alias:     "appsync",


### PR DESCRIPTION
This should fix an issue with AmazonMQ when using `searchTags` which makes unwanted metrics being included in the scrape even though the corresponding resource was filtered out due to `searchTags` constraints.

Due to the current implementation, ideally all services should have regexs defined. I'll followup with further PRs for those services that need be updated.

Fixes #643