### PR TITLE
main.go refactoring: define cmd action as a separate func.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-config.yml
+config*.yml
 yet-another-cloudwatch-exporter
 !charts/yet-another-cloudwatch-exporter
 vendor
 dist
-yace
+/yace
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GOOS linux
 ENV CGO_ENABLED=0
 
 ARG VERSION
-RUN go build -v -ldflags "-X main.version=$VERSION" -o yace cmd/yace/main.go
+RUN go build -v -ldflags "-X main.version=$VERSION" -o yace ./cmd/yace
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := build
 
 build:
-	go build -o yace cmd/yace/main.go
+	go build -v -o yace ./cmd/yace
 
 test:
 	go test -v -race -count=1 ./...

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/semaphore"
@@ -35,7 +32,6 @@ var (
 )
 
 func init() {
-
 	// Set JSON structured logging as the default log formatter
 	log.SetFormatter(&log.JSONFormatter{})
 
@@ -44,7 +40,6 @@ func init() {
 
 	// Only log Info severity or above.
 	log.SetLevel(log.InfoLevel)
-
 }
 
 func main() {
@@ -70,7 +65,8 @@ func main() {
 	}
 
 	yace.Commands = []*cli.Command{
-		{Name: "verify-config", Aliases: []string{"vc"}, Usage: "Loads and attempts to parse config file, then exits. Useful for CI/CD validation",
+		{
+			Name: "verify-config", Aliases: []string{"vc"}, Usage: "Loads and attempts to parse config file, then exits. Useful for CI/CD validation",
 			Flags: []cli.Flag{
 				&cli.StringFlag{Name: "config.file", Value: "config.yml", Usage: "Path to configuration file.", Destination: &configFile},
 			},
@@ -83,28 +79,33 @@ func main() {
 				log.Info("Config ", configFile, " is valid")
 				os.Exit(0)
 				return nil
-			}},
-		{Name: "version", Aliases: []string{"v"}, Usage: "prints current yace version.",
+			},
+		},
+		{
+			Name: "version", Aliases: []string{"v"}, Usage: "prints current yace version.",
 			Action: func(c *cli.Context) error {
 				fmt.Println(version)
 				os.Exit(0)
 				return nil
-			}},
+			},
+		},
 	}
 
-	err := yace.Run(os.Args)
-	if err != nil {
+	yace.Action = startScraper
+
+	if err := yace.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
+}
 
+func startScraper(_ *cli.Context) error {
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	}
 
 	log.Println("Parse config..")
 	if err := config.Load(&configFile); err != nil {
-		log.Fatal("Couldn't read ", configFile, ": ", err)
-		os.Exit(1)
+		return fmt.Errorf("Couldn't read %s: %w", configFile, err)
 	}
 
 	log.Println("Startup completed")
@@ -150,73 +151,5 @@ func main() {
 		go s.decoupled(ctx, cache)
 	})
 
-	log.Fatal(http.ListenAndServe(addr, nil))
-}
-
-type scraper struct {
-	cloudwatchSemaphore chan struct{}
-	tagSemaphore        chan struct{}
-	registry            *prometheus.Registry
-}
-
-func NewScraper() *scraper {
-	return &scraper{
-		cloudwatchSemaphore: make(chan struct{}, cloudwatchConcurrency),
-		tagSemaphore:        make(chan struct{}, tagConcurrency),
-		registry:            prometheus.NewRegistry(),
-	}
-}
-
-func (s *scraper) makeHandler(ctx context.Context, cache exporter.SessionCache) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		handler := promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{
-			DisableCompression: false,
-		})
-		handler.ServeHTTP(w, r)
-	}
-}
-
-func (s *scraper) decoupled(ctx context.Context, cache exporter.SessionCache) {
-	log.Debug("Starting scraping async")
-	log.Debug("Scrape initially first time")
-	s.scrape(ctx, cache)
-
-	scrapingDuration := time.Duration(scrapingInterval) * time.Second
-	ticker := time.NewTicker(scrapingDuration)
-	log.Debugf("Scraping every %d seconds", scrapingInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			log.Debug("Starting scraping async")
-			go s.scrape(ctx, cache)
-		}
-	}
-}
-
-var observedMetricLabels = map[string]exporter.LabelSet{}
-
-func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
-	if !sem.TryAcquire(1) {
-		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
-		// Let them know by logging a warning.
-		log.Warn("Another scrape is already in process, will not start a new one. " +
-			"Adjust your configuration to ensure the previous scrape completes first.")
-		return
-	}
-	defer sem.Release(1)
-
-	newRegistry := prometheus.NewRegistry()
-	for _, metric := range exporter.Metrics {
-		if err := newRegistry.Register(metric); err != nil {
-			log.Warning("Could not register cloudwatch api metric")
-		}
-	}
-	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels, exporter.NewLogrusLogger(log.StandardLogger()))
-
-	// this might have a data race to access registry
-	s.registry = newRegistry
-	log.Debug("Metrics scraped.")
+	return http.ListenAndServe(addr, nil)
 }

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	log "github.com/sirupsen/logrus"
+
+	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
+)
+
+type scraper struct {
+	cloudwatchSemaphore chan struct{}
+	tagSemaphore        chan struct{}
+	registry            *prometheus.Registry
+}
+
+func NewScraper() *scraper {
+	return &scraper{
+		cloudwatchSemaphore: make(chan struct{}, cloudwatchConcurrency),
+		tagSemaphore:        make(chan struct{}, tagConcurrency),
+		registry:            prometheus.NewRegistry(),
+	}
+}
+
+func (s *scraper) makeHandler(ctx context.Context, cache exporter.SessionCache) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		handler := promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{
+			DisableCompression: false,
+		})
+		handler.ServeHTTP(w, r)
+	}
+}
+
+func (s *scraper) decoupled(ctx context.Context, cache exporter.SessionCache) {
+	log.Debug("Starting scraping async")
+	log.Debug("Scrape initially first time")
+	s.scrape(ctx, cache)
+
+	scrapingDuration := time.Duration(scrapingInterval) * time.Second
+	ticker := time.NewTicker(scrapingDuration)
+	log.Debugf("Scraping every %d seconds", scrapingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			log.Debug("Starting scraping async")
+			go s.scrape(ctx, cache)
+		}
+	}
+}
+
+var observedMetricLabels = map[string]exporter.LabelSet{}
+
+func (s *scraper) scrape(ctx context.Context, cache exporter.SessionCache) {
+	if !sem.TryAcquire(1) {
+		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
+		// Let them know by logging a warning.
+		log.Warn("Another scrape is already in process, will not start a new one. " +
+			"Adjust your configuration to ensure the previous scrape completes first.")
+		return
+	}
+	defer sem.Release(1)
+
+	newRegistry := prometheus.NewRegistry()
+	for _, metric := range exporter.Metrics {
+		if err := newRegistry.Register(metric); err != nil {
+			log.Warning("Could not register cloudwatch api metric")
+		}
+	}
+	exporter.UpdateMetrics(ctx, config, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels, exporter.NewLogrusLogger(log.StandardLogger()))
+
+	// this might have a data race to access registry
+	s.registry = newRegistry
+	log.Debug("Metrics scraped.")
+}


### PR DESCRIPTION
This splits out the scraper code into a separate file next to main.go, and wraps the action code into a separate function that is used as default action of the urfave app. Setting a default action prevents the help being printed out unnecessarily.