### PR TITLE
Add support for AWS Kafka Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ We will contact you as soon as possible.
   * ga (AWS/GlobalAccelerator) - AWS Global Accelerator
   * glue (Glue) - AWS Glue Jobs
   * iot (AWS/IoT) - IoT
+  * kafkaconnect (AWS/KafkaConnect) - AWS MSK Connectors
   * kinesis (AWS/Kinesis) - Kinesis Data Stream
   * nfw (AWS/NetworkFirewall) - Network Firewall
   * ngw (AWS/NATGateway) - NAT Gateway

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -493,6 +493,15 @@ var (
 				aws.String(":cluster/(?P<Cluster_Name>[^/]+)"),
 			},
 		}, {
+			Namespace: "AWS/KafkaConnect",
+			Alias:     "kafkaconnect",
+			ResourceFilters: []*string{
+				aws.String("kafkaconnect"),
+			},
+			DimensionRegexps: []*string{
+				aws.String(":connector/(?P<Connector_Name>[^/]+)"),
+			},
+		}, {
 			Namespace: "AWS/Kinesis",
 			Alias:     "kinesis",
 			ResourceFilters: []*string{


### PR DESCRIPTION
Add Support for [AWS/KafkaConnect](https://docs.aws.amazon.com/MSKC/latest/mskc/Welcome.html) namespace.

Config:

```
apiVersion: v1alpha1
discovery:
  jobs:
  - type: kafkaconnect
    regions: [ us-east-1 ]
    period: 60
    length: 300
    enableMetricData: true
    statistics: [ Sum, Maximum, Average ]
    metrics:
      - name: RebalanceCompletedTotal
      - name: RebalanceTimeSinceLast
      - name: RebalanceTimeSinceLast
```
