### PR TITLE
Add support for Amazon EMR Serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ We will contact you as soon as possible.
   * efs (AWS/EFS) - Elastic File System
   * elb (AWS/ELB) - Elastic Load Balancer
   * emr (AWS/ElasticMapReduce) - Elastic MapReduce
+  * emr-serverless (AWS/EMRServerless) - Amazon EMR Serverless
   * es (AWS/ES) - ElasticSearch
   * fsx (AWS/FSx) - FSx File System
   * gamelift (AWS/GameLift) - GameLift

--- a/pkg/services.go
+++ b/pkg/services.go
@@ -416,6 +416,15 @@ var (
 				aws.String("cluster/(?P<JobFlowId>[^/]+)"),
 			},
 		}, {
+			Namespace: "AWS/EMRServerless",
+			Alias:     "emr-serverless",
+			ResourceFilters: []*string{
+				aws.String("emr-serverless:applications"),
+			},
+			DimensionRegexps: []*string{
+				aws.String("applications/(?P<ApplicationId>[^/]+)"),
+			},
+		}, {
 			Namespace: "AWS/ES",
 			Alias:     "es",
 			ResourceFilters: []*string{


### PR DESCRIPTION
Add Support for [AWS/EMRServerless](https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/emr-serverless.html) namespace.

Config:
```

apiVersion: v1alpha1
discovery:
  jobs:
  - type: emr-serverless
    regions: [ us-east-1 ]
    period: 60
    length: 300
    enableMetricData: true
    statistics: [ Sum, Maximum, Average ]
    metrics:
      - name: MemoryAllocated
      - name: StorageAllocated
      - name: StorageAllocated
```