### PR TITLE
Support extraEnv in Helm chart

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -45,9 +45,13 @@ spec:
           volumeMounts:
             - name: vol-yet-another-cloudwatch-exporter
               mountPath: /config
+        {{- if or (.Values.aws.secret.name) (and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id) (and (.Values.extraEnv)) }}
+          env:
+        {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+        {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -66,7 +70,6 @@ spec:
                   name: {{ .Values.aws.secret.name }}
           {{- end }}
           {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -77,6 +80,7 @@ spec:
                 secretKeyRef:
                   key: aws_secret_access_key
                   name: {{ include "yet-another-cloudwatch-exporter.fullname" . }}
+          {{- end }}
           {{- end }}
           {{- end }}
           ports:

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -38,6 +38,11 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+extraEnv: []
+  # When using EKS IAM roles ensure consistent naming for multi-role AWS STS sessions
+  # - name: AWS_ROLE_SESSION_NAME
+  #   value: yace
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This PR adds support for defining extra environment variables.

A use-case where this is necessary is when using `eks.amazonaws.com/role-arn` service account annotation to define the "default" identity the Deployment, which is used to assume various other IAM roles to support multiple accounts. 

In that case, the IAM policies and trust policy must be configured such that the "default" role the deployment is running as can assume other roles. For this, the AWS session name must be deterministic. AWS Session names can be defined via the `AWS_ROLE_SESSION_NAME` env var. 

Example trust policy:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "AllowAssumingRole",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:sts::<AccountID>:assumed-role/<Role Name>/<Session Name>"
            },
            "Action": "sts:AssumeRole"
        }
    ]
}
```

The corresponding [AWS reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html) `Assumed-role session principals` section explains it as:

> When you specify an assumed-role session in a Principal element, you cannot use a wildcard "*" to mean all sessions. Principals must always name a specific session.

