### PR TITLE
Helm chart update for optional test-connection pod

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/tests/test-connection.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.testConnection -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['{{ include "yet-another-cloudwatch-exporter.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+{{- end }}

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -42,6 +42,8 @@ service:
   type: ClusterIP
   port: 80
 
+testConnection: true
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
Add Helm chart support for disabling the `test-connection` pod.

We don't use Helm directly, but rather consume the charts with Tanka. We'd like the option to remove this test pod. Please let me know if there's a preferred method for doing so - thanks!