### PR TITLE
MediaTailor - Correct dimension regex for MT

### DIFF
--- a/pkg/services.go
+++ b/pkg/services.go
@@ -539,7 +539,7 @@ var (
 				aws.String("mediatailor:playbackConfiguration"),
 			},
 			DimensionRegexps: []*string{
-				aws.String(":playbackConfiguration:(?P<ConfigurationName>[^/]+)"),
+				aws.String("playbackConfiguration/(?P<ConfigurationName>[^/]+)"),
 			},
 		}, {
 			Namespace: "AWS/Neptune",


### PR DESCRIPTION
Metrics for MediaTialor were not being pulled in as expected, after testing this solution, metrics are now scraped successfully 