### PR TITLE
Helm chart update to set priorityClassName

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -101,6 +101,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -72,6 +72,8 @@ resources: {}
 
 nodeSelector: {}
 
+priorityClassName:
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
Allow Helm users to set a non-default `priorityClassName` for the YACE deployment.