### PR TITLE
Remove fmt.Println logging.

### DIFF
--- a/pkg/sessions.go
+++ b/pkg/sessions.go
@@ -287,7 +287,6 @@ func (s *sessionCache) GetPrometheus(region *string, role Role) prometheusservic
 	}
 
 	s.clients[role][*region].prometheus = createPrometheusSession(s.session, region, role, s.fips, s.logger.IsDebugEnabled())
-	fmt.Println("Created Prometheus client")
 	return s.clients[role][*region].prometheus
 }
 
@@ -479,7 +478,6 @@ func createEC2Session(sess *session.Session, region *string, role Role, fips boo
 }
 
 func createPrometheusSession(sess *session.Session, region *string, role Role, fips bool, isDebugEnabled bool) prometheusserviceiface.PrometheusServiceAPI {
-	fmt.Println("Creating prometheus sessions")
 	maxPrometheusAPIRetries := 10
 	config := &aws.Config{Region: region, MaxRetries: &maxPrometheusAPIRetries}
 	if fips {


### PR DESCRIPTION
Should stop breaking json structured log parsing.