### PR TITLE
GH workflows: run "publish" workflows only in this repo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
+name: Publish Docker image and binaries
+
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
     - 'v*'
 
-name: Build, test and publish
 jobs:
   buildDockerImage:
+    if: github.repository == 'nerdswords/yet-another-cloudwatch-exporter'
     name: Build docker image
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +28,7 @@ jobs:
 
     - name: Build and Publish docker image
       run: docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t ghcr.io/nerdswords/yet-another-cloudwatch-exporter:${{github.ref_name}} --build-arg VERSION=${{github.ref_name}} --push .
-    
+
     - name: Build && release binaries
       uses: docker://goreleaser/goreleaser:v0.179.0
       env:

--- a/.github/workflows/release_helm.yml
+++ b/.github/workflows/release_helm.yml
@@ -1,11 +1,13 @@
+name: Build, test and publish Helm chart
+
 on:
   push:
     tags:
     - 'v*'
 
-name: Build, test and publish
 jobs:
   publishHelmChart:
+    if: github.repository == 'nerdswords/yet-another-cloudwatch-exporter'
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:


### PR DESCRIPTION
This should prevent "publish" workflows (for docker, binaries and helm) that normally run when tagging a new release to run in fork repos.