### PR TITLE
Validate tags when converting to prometheus labels.

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -374,14 +374,26 @@ func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool) map[strin
 
 	// Inject the sfn name back as a label
 	for _, dimension := range cwd.Dimensions {
-		labels["dimension_"+promStringTag(*dimension.Name, labelsSnakeCase)] = *dimension.Value
+		ok, promTag := promStringTag(*dimension.Name, labelsSnakeCase)
+		if !ok {
+			continue
+		}
+		labels["dimension_"+promTag] = *dimension.Value
 	}
 
 	for _, label := range cwd.CustomTags {
-		labels["custom_tag_"+promStringTag(label.Key, labelsSnakeCase)] = label.Value
+		ok, promTag := promStringTag(label.Key, labelsSnakeCase)
+		if !ok {
+			continue
+		}
+		labels["custom_tag_"+promTag] = label.Value
 	}
 	for _, tag := range cwd.Tags {
-		labels["tag_"+promStringTag(tag.Key, labelsSnakeCase)] = tag.Value
+		ok, promTag := promStringTag(tag.Key, labelsSnakeCase)
+		if !ok {
+			continue
+		}
+		labels["tag_"+promTag] = tag.Value
 	}
 
 	return labels

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -152,7 +152,7 @@ func (iface tagsInterface) get(ctx context.Context, job *Job, region string) ([]
 	return resources, nil
 }
 
-func migrateTagsToPrometheus(tagData []*taggedResource, labelsSnakeCase bool) []*PrometheusMetric {
+func migrateTagsToPrometheus(tagData []*taggedResource, labelsSnakeCase bool, logger Logger) []*PrometheusMetric {
 	output := make([]*PrometheusMetric, 0)
 
 	tagList := make(map[string][]string)
@@ -177,6 +177,7 @@ func migrateTagsToPrometheus(tagData []*taggedResource, labelsSnakeCase bool) []
 		for _, entry := range tagList[d.Namespace] {
 			ok, promTag := promStringTag(entry, labelsSnakeCase)
 			if !ok {
+				logger.Warn("tag name is an invalid prometheus label name", "tag", entry)
 				continue
 			}
 

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -175,7 +175,12 @@ func migrateTagsToPrometheus(tagData []*taggedResource, labelsSnakeCase bool) []
 		promLabels["name"] = d.ARN
 
 		for _, entry := range tagList[d.Namespace] {
-			labelKey := "tag_" + promStringTag(entry, labelsSnakeCase)
+			ok, promTag := promStringTag(entry, labelsSnakeCase)
+			if !ok {
+				continue
+			}
+
+			labelKey := "tag_" + promTag
 			promLabels[labelKey] = ""
 
 			for _, rTag := range d.Tags {

--- a/pkg/aws_tags_test.go
+++ b/pkg/aws_tags_test.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -308,7 +309,7 @@ func Test_MigrateTagsToPrometheus(t *testing.T) {
 		value: &metricValue,
 	}}
 
-	actual := migrateTagsToPrometheus(resources, false)
+	actual := migrateTagsToPrometheus(resources, false, NewLogrusLogger(log.StandardLogger()))
 
 	require.Equal(t, expected, actual)
 }

--- a/pkg/prometheus.go
+++ b/pkg/prometheus.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 )
 
 var (
@@ -163,11 +164,14 @@ func promString(text string) string {
 	return strings.ToLower(sanitize(text))
 }
 
-func promStringTag(text string, labelsSnakeCase bool) string {
+func promStringTag(text string, labelsSnakeCase bool) (bool, string) {
+	var s string
 	if labelsSnakeCase {
-		return promString(text)
+		s = promString(text)
+	} else {
+		s = sanitize(text)
 	}
-	return sanitize(text)
+	return model.LabelName(s).IsValid(), s
 }
 
 func sanitize(text string) string {

--- a/pkg/prometheus_test.go
+++ b/pkg/prometheus_test.go
@@ -196,3 +196,66 @@ func TestRemoveDuplicateMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestPromStringTag(t *testing.T) {
+	testCases := []struct {
+		name        string
+		label       string
+		toSnakeCase bool
+		ok          bool
+		out         string
+	}{
+		{
+			name:        "valid",
+			label:       "labelName",
+			toSnakeCase: false,
+			ok:          true,
+			out:         "labelName",
+		},
+		{
+			name:        "valid, convert to snake case",
+			label:       "labelName",
+			toSnakeCase: true,
+			ok:          true,
+			out:         "label_name",
+		},
+		{
+			name:        "valid (snake case)",
+			label:       "label_name",
+			toSnakeCase: false,
+			ok:          true,
+			out:         "label_name",
+		},
+		{
+			name:        "valid (snake case) unchanged",
+			label:       "label_name",
+			toSnakeCase: true,
+			ok:          true,
+			out:         "label_name",
+		},
+		{
+			name:        "invalid chars",
+			label:       "invalidChars@$",
+			toSnakeCase: false,
+			ok:          false,
+			out:         "",
+		},
+		{
+			name:        "invalid chars, convert to snake case",
+			label:       "invalidChars@$",
+			toSnakeCase: true,
+			ok:          false,
+			out:         "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, out := promStringTag(tc.label, tc.toSnakeCase)
+			assert.Equal(t, tc.ok, ok)
+			if ok {
+				assert.Equal(t, tc.out, out)
+			}
+		})
+	}
+}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -35,14 +35,14 @@ func UpdateMetrics(
 		logger,
 	)
 
-	metrics, observedMetricLabels, err := migrateCloudwatchToPrometheus(cloudwatchData, labelsSnakeCase, observedMetricLabels)
+	metrics, observedMetricLabels, err := migrateCloudwatchToPrometheus(cloudwatchData, labelsSnakeCase, observedMetricLabels, logger)
 	if err != nil {
 		logger.Error(err, "Error migrating cloudwatch metrics to prometheus metrics")
 		return
 	}
 	metrics = ensureLabelConsistencyForMetrics(metrics, observedMetricLabels)
 
-	metrics = append(metrics, migrateTagsToPrometheus(tagsData, labelsSnakeCase)...)
+	metrics = append(metrics, migrateTagsToPrometheus(tagsData, labelsSnakeCase, logger)...)
 
 	registry.MustRegister(NewPrometheusCollector(metrics))
 }


### PR DESCRIPTION
Prometheus label names allow a limited set of chars, and attempting to create a metric with invalid label names will panic.

With this change, we validate aws tags when converting them to labels, and skip the label if it is invalid.

Fixes #723