### PR TITLE
Fix not to refer to loop variable in a goroutine

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -106,7 +106,7 @@ func scrapeAwsData(
 		for _, role := range customNamespaceJob.Roles {
 			for _, region := range customNamespaceJob.Regions {
 				wg.Add(1)
-				go func(staticJob *CustomNamespace, region string, role Role) {
+				go func(customNamespaceJob *CustomNamespace, region string, role Role) {
 					defer wg.Done()
 					jobLogger := logger.With("custom_metric_namespace", customNamespaceJob.Namespace, "region", region, "arn", role.RoleArn)
 					result, err := cache.GetSTS(role).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})


### PR DESCRIPTION
This PR fixes to refer to the value passed to the argument instead of referencing the loop variable in the goroutine that scrapes custom metrics.
This fix prevents unpredictable behavior such as getting duplicate metrics.