### PR TITLE
Bump Go version to 1.19 for CI and docker image.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.18
+        go-version: ^1.19
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.18
+golang 1.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /opt/
 


### PR DESCRIPTION
Build and test with Go 1.19.