### PR TITLE
Fix to use length of metrics level on customNamespace.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,6 +220,9 @@ func (j *CustomNamespace) validateCustomNamespaceJob(jobIdx int) error {
 	if j.Regions == nil || len(j.Regions) == 0 {
 		return fmt.Errorf("CustomNamespace job [%s/%d]: Regions should not be empty", j.Name, jobIdx)
 	}
+	if len(j.Metrics) == 0 {
+		return fmt.Errorf("CustomNamespace job [%s/%d]: Metrics should not be empty", j.Name, jobIdx)
+	}
 	for metricIdx, metric := range j.Metrics {
 		err := metric.validateMetric(metricIdx, parent, &j.JobLevelMetricFields)
 		if err != nil {

--- a/pkg/job/abstract.go
+++ b/pkg/job/abstract.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/services"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
@@ -199,13 +198,8 @@ func scrapeStaticJob(ctx context.Context, resource *config.Static, region string
 	return cw
 }
 
-func getMetricDataInputLength(job *config.Job) int64 {
-	length := model.DefaultLengthSeconds
-
-	if job.Length > 0 {
-		length = job.Length
-	}
-	for _, metric := range job.Metrics {
+func getMetricDataInputLength(metrics []*config.Metric) (length int64) {
+	for _, metric := range metrics {
 		if metric.Length > length {
 			length = metric.Length
 		}
@@ -286,7 +280,7 @@ func scrapeDiscoveryJobUsingMetricData(
 	}
 
 	maxMetricCount := metricsPerQuery
-	length := getMetricDataInputLength(job)
+	length := getMetricDataInputLength(job.Metrics)
 	partition := int(math.Ceil(float64(metricDataLength) / float64(maxMetricCount)))
 
 	mux := &sync.Mutex{}
@@ -348,6 +342,7 @@ func scrapeCustomNamespaceJobUsingMetricData(
 	}
 
 	maxMetricCount := metricsPerQuery
+	length := getMetricDataInputLength(customNamespaceJob.Metrics)
 	partition := int(math.Ceil(float64(metricDataLength) / float64(maxMetricCount)))
 
 	wg.Add(partition)
@@ -366,7 +361,7 @@ func scrapeCustomNamespaceJobUsingMetricData(
 				end = metricDataLength
 			}
 			input := getMetricDatas[i:end]
-			filter := createGetMetricDataInput(input, &customNamespaceJob.Namespace, customNamespaceJob.Length, customNamespaceJob.Delay, customNamespaceJob.RoundingPeriod, logger)
+			filter := createGetMetricDataInput(input, &customNamespaceJob.Namespace, length, customNamespaceJob.Delay, customNamespaceJob.RoundingPeriod, logger)
 			data := clientCloudwatch.getMetricData(ctx, filter)
 			if data != nil {
 				output := make([]*cloudwatchData, 0)

--- a/pkg/job/abstract.go
+++ b/pkg/job/abstract.go
@@ -198,7 +198,8 @@ func scrapeStaticJob(ctx context.Context, resource *config.Static, region string
 	return cw
 }
 
-func getMetricDataInputLength(metrics []*config.Metric) (length int64) {
+func getMetricDataInputLength(metrics []*config.Metric) int64 {
+	var length int64 = 0
 	for _, metric := range metrics {
 		if metric.Length > length {
 			length = metric.Length


### PR DESCRIPTION
This PR fixes #729
customNamespaces always used length on job level and not respect length on metrics level.
With this change, use specified metrics level length.

Fixed with the following two commits:
- Fix to use length of metrics level on customNamespace
- Set default values for metric parameters (fix [this](https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/729#issuecomment-1374349002))

And other:
- Log a error message when metrics are not specified on customNamespace

If #752 is merged, I'm going to rebase this branch.