### PR TITLE
AWS/DX: add more dimension regexps.

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -189,6 +189,8 @@ var SupportedServices = serviceConfigs{
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":dxcon/(?P<ConnectionId>[^/]+)"),
+			regexp.MustCompile(":dxlag/(?P<LagId>[^/]+)"),
+			regexp.MustCompile(":dxvif/(?P<VirtualInterfaceId>[^/]+)"),
 		},
 	},
 	{


### PR DESCRIPTION
Add regexps for Lag and VirtualInterface.

Relates to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/775