### PR TITLE
Fix to set logging level correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,8 +706,8 @@ The entrypoint to use YACE as a library is the `UpdateMetrics` func in [update.g
   - This map will track all labels observed and ensure they are exported on all metrics with the same key in the provided `registry`
   - You should provide the same instance of this map if you intend to re-use the `registry` between calls
 - `logger`
-  - Any implementation of the [Logger Interface](./pkg/logger/logruslogger.go#L13)
-  - `logger.NewLogrusLogger(log.StandardLogger())` is an acceptable default
+  - Any implementation of the [Logger Interface](./pkg/logging/logger.go#L13)
+  - `logging.NewLogger(logrus.StandardLogger())` is an acceptable default
 
 The update definition also includes an exported slice of [Metrics](./pkg/exporter.go#L18) which includes AWS API call metrics. These can be registered with the provided `registry` if you want them
 included in the AWS scrape results. If you are using multiple instances of `registry` it might make more sense to register these metrics in the application using YACE as a library to better

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	log "github.com/sirupsen/logrus"
 
 	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
@@ -38,33 +38,33 @@ func (s *scraper) makeHandler(ctx context.Context, cache session.SessionCache) f
 	}
 }
 
-func (s *scraper) decoupled(ctx context.Context, cache session.SessionCache) {
-	log.Debug("Starting scraping async")
-	log.Debug("Scrape initially first time")
-	s.scrape(ctx, cache)
+func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache session.SessionCache) {
+	logger.Debug("Starting scraping async")
+	logger.Debug("Scrape initially first time")
+	s.scrape(ctx, logger, cache)
 
 	scrapingDuration := time.Duration(scrapingInterval) * time.Second
 	ticker := time.NewTicker(scrapingDuration)
-	log.Debugf("Scraping every %d seconds", scrapingInterval)
+	logger.Debug(fmt.Sprintf("Scraping every %d seconds", scrapingInterval))
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			log.Debug("Starting scraping async")
-			go s.scrape(ctx, cache)
+			logger.Debug("Starting scraping async")
+			go s.scrape(ctx, logger, cache)
 		}
 	}
 }
 
 var observedMetricLabels = map[string]model.LabelSet{}
 
-func (s *scraper) scrape(ctx context.Context, cache session.SessionCache) {
+func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache session.SessionCache) {
 	if !sem.TryAcquire(1) {
 		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
 		// Let them know by logging a warning.
-		log.Warn("Another scrape is already in process, will not start a new one. " +
+		logger.Warn("Another scrape is already in process, will not start a new one. " +
 			"Adjust your configuration to ensure the previous scrape completes first.")
 		return
 	}
@@ -73,12 +73,12 @@ func (s *scraper) scrape(ctx context.Context, cache session.SessionCache) {
 	newRegistry := prometheus.NewRegistry()
 	for _, metric := range exporter.Metrics {
 		if err := newRegistry.Register(metric); err != nil {
-			log.Warning("Could not register cloudwatch api metric")
+			logger.Warn("Could not register cloudwatch api metric")
 		}
 	}
-	exporter.UpdateMetrics(ctx, cfg, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels, logger.NewLogrusLogger(log.StandardLogger()))
+	exporter.UpdateMetrics(ctx, cfg, newRegistry, metricsPerQuery, labelsSnakeCase, s.cloudwatchSemaphore, s.tagSemaphore, cache, observedMetricLabels, logger)
 
 	// this might have a data race to access registry
 	s.registry = newRegistry
-	log.Debug("Metrics scraped.")
+	logger.Debug("Metrics scraped.")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
 
@@ -99,7 +99,7 @@ func (r *Role) ValidateRole(roleIdx int, parent string) error {
 	return nil
 }
 
-func (c *ScrapeConf) Load(file string, logrusLogger logger.Logger) error {
+func (c *ScrapeConf) Load(file string, logger logging.Logger) error {
 	yamlFile, err := os.ReadFile(file)
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (c *ScrapeConf) Load(file string, logrusLogger logger.Logger) error {
 		return err
 	}
 
-	LogConfigErrors(yamlFile, logrusLogger)
+	logConfigErrors(yamlFile, logger)
 
 	for _, job := range c.Discovery.Jobs {
 		if len(job.Roles) == 0 {
@@ -341,8 +341,8 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *JobLeve
 	return nil
 }
 
-// LogConfigErrors logs as warning any config unmarshalling error.
-func LogConfigErrors(cfg []byte, logrusLogger logger.Logger) {
+// logConfigErrors logs as warning any config unmarshalling error.
+func logConfigErrors(cfg []byte, logger logging.Logger) {
 	var sc ScrapeConf
 	var errMsgs []string
 	if err := yaml.UnmarshalStrict(cfg, &sc); err != nil {
@@ -360,8 +360,8 @@ func LogConfigErrors(cfg []byte, logrusLogger logger.Logger) {
 
 	if len(errMsgs) > 0 {
 		for _, msg := range errMsgs {
-			logrusLogger.Warn("config file syntax error", "err", msg)
+			logger.Warn("config file syntax error", "err", msg)
 		}
-		logrusLogger.Warn(`Config file error(s) detected: Yace might not work as expected. Future versions of Yace might fail to run with an invalid config file.`)
+		logger.Warn(`Config file error(s) detected: Yace might not work as expected. Future versions of Yace might fail to run with an invalid config file.`)
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,9 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
 func TestConfLoad(t *testing.T) {
@@ -23,7 +21,7 @@ func TestConfLoad(t *testing.T) {
 	for _, tc := range testCases {
 		config := ScrapeConf{}
 		configFile := fmt.Sprintf("testdata/%s", tc.configFile)
-		if err := config.Load(configFile, logger.NewLogrusLogger(logrus.New())); err != nil {
+		if err := config.Load(configFile, logging.NewNopLogger()); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -64,7 +62,7 @@ func TestBadConfigs(t *testing.T) {
 	for _, tc := range testCases {
 		config := ScrapeConf{}
 		configFile := fmt.Sprintf("testdata/%s", tc.configFile)
-		if err := config.Load(configFile, logger.NewLogrusLogger(logrus.New())); err != nil {
+		if err := config.Load(configFile, logging.NewNopLogger()); err != nil {
 			if !strings.Contains(err.Error(), tc.errorMsg) {
 				t.Errorf("expecter error for config file %q to contain %q but got: %s", tc.configFile, tc.errorMsg, err)
 				t.FailNow()

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/services"
@@ -41,7 +41,7 @@ func UpdateMetrics(
 	cloudwatchSemaphore, tagSemaphore chan struct{},
 	cache session.SessionCache,
 	observedMetricLabels map[string]model.LabelSet,
-	logger logger.Logger,
+	logger logging.Logger,
 ) {
 	tagsData, cloudwatchData := job.ScrapeAwsData(
 		ctx,

--- a/pkg/job/abstract.go
+++ b/pkg/job/abstract.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/services"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
 )
@@ -22,7 +22,7 @@ func ScrapeAwsData(
 	cloudwatchSemaphore,
 	tagSemaphore chan struct{},
 	cache session.SessionCache,
-	logger logger.Logger,
+	logger logging.Logger,
 ) ([]*services.TaggedResource, []*cloudwatchData) { //nolint:revive
 	mux := &sync.Mutex{}
 
@@ -149,7 +149,7 @@ func ScrapeAwsData(
 	return awsInfoData, cwData
 }
 
-func scrapeStaticJob(ctx context.Context, resource *config.Static, region string, accountID *string, clientCloudwatch cloudwatchInterface, cloudwatchSemaphore chan struct{}, logger logger.Logger) (cw []*cloudwatchData) {
+func scrapeStaticJob(ctx context.Context, resource *config.Static, region string, accountID *string, clientCloudwatch cloudwatchInterface, cloudwatchSemaphore chan struct{}, logger logging.Logger) (cw []*cloudwatchData) {
 	mux := &sync.Mutex{}
 	var wg sync.WaitGroup
 
@@ -218,7 +218,7 @@ func getMetricDataForQueries(
 	clientCloudwatch cloudwatchInterface,
 	resources []*services.TaggedResource,
 	tagSemaphore chan struct{},
-	logger logger.Logger,
+	logger logging.Logger,
 ) []cloudwatchData {
 	var getMetricDatas []cloudwatchData
 
@@ -256,7 +256,7 @@ func scrapeDiscoveryJobUsingMetricData(
 	metricsPerQuery int,
 	roundingPeriod *int64,
 	tagSemaphore chan struct{},
-	logger logger.Logger,
+	logger logging.Logger,
 ) (resources []*services.TaggedResource, cw []*cloudwatchData) {
 	// Add the info tags of all the resources
 	tagSemaphore <- struct{}{}
@@ -329,7 +329,7 @@ func scrapeCustomNamespaceJobUsingMetricData(
 	clientCloudwatch cloudwatchInterface,
 	cloudwatchSemaphore chan struct{},
 	tagSemaphore chan struct{},
-	logger logger.Logger,
+	logger logging.Logger,
 	metricsPerQuery int,
 ) (cw []*cloudwatchData) {
 	mux := &sync.Mutex{}
@@ -394,7 +394,7 @@ func getMetricDataForQueriesForCustomNamespace(
 	accountID *string,
 	clientCloudwatch cloudwatchInterface,
 	tagSemaphore chan struct{},
-	logger logger.Logger,
+	logger logging.Logger,
 ) []cloudwatchData {
 	var getMetricDatas []cloudwatchData
 

--- a/pkg/job/aws_cloudwatch.go
+++ b/pkg/job/aws_cloudwatch.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/services"
@@ -28,7 +28,7 @@ const timeFormat = "2006-01-02T15:04:05.999999-07:00"
 
 type cloudwatchInterface struct {
 	client cloudwatchiface.CloudWatchAPI
-	logger logger.Logger
+	logger logging.Logger
 }
 
 type cloudwatchData struct {
@@ -50,7 +50,7 @@ type cloudwatchData struct {
 	Period                  int64
 }
 
-func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespace *string, metric *config.Metric, logger logger.Logger) (output *cloudwatch.GetMetricStatisticsInput) {
+func createGetMetricStatisticsInput(dimensions []*cloudwatch.Dimension, namespace *string, metric *config.Metric, logger logging.Logger) (output *cloudwatch.GetMetricStatisticsInput) {
 	period := metric.Period
 	length := metric.Length
 	delay := metric.Delay
@@ -105,7 +105,7 @@ func findGetMetricDataByID(getMetricDatas []cloudwatchData, value string) (cloud
 	return g, fmt.Errorf("metric with id %s not found", value)
 }
 
-func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string, length int64, delay int64, configuredRoundingPeriod *int64, logger logger.Logger) (output *cloudwatch.GetMetricDataInput) {
+func createGetMetricDataInput(getMetricData []cloudwatchData, namespace *string, length int64, delay int64, configuredRoundingPeriod *int64, logger logging.Logger) (output *cloudwatch.GetMetricDataInput) {
 	var metricsDataQuery []*cloudwatch.MetricDataQuery
 	roundingPeriod := model.DefaultPeriodSeconds
 	for _, data := range getMetricData {
@@ -377,7 +377,7 @@ func metricDimensionsMatchNames(metric *cloudwatch.Metric, dimensionNameRequirem
 	return true
 }
 
-func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool, logger logger.Logger) map[string]string {
+func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool, logger logging.Logger) map[string]string {
 	labels := make(map[string]string)
 	labels["name"] = *cwd.ID
 	labels["region"] = *cwd.Region
@@ -504,7 +504,7 @@ func getDatapoint(cwd *cloudwatchData, statistic string) (*float64, time.Time, e
 	return nil, time.Time{}, nil
 }
 
-func MigrateCloudwatchToPrometheus(cwd []*cloudwatchData, labelsSnakeCase bool, observedMetricLabels map[string]model.LabelSet, logger logger.Logger) ([]*promutil.PrometheusMetric, map[string]model.LabelSet, error) {
+func MigrateCloudwatchToPrometheus(cwd []*cloudwatchData, labelsSnakeCase bool, observedMetricLabels map[string]model.LabelSet, logger logging.Logger) ([]*promutil.PrometheusMetric, map[string]model.LabelSet, error) {
 	output := make([]*promutil.PrometheusMetric, 0)
 
 	for _, c := range cwd {

--- a/pkg/services/aws_tags.go
+++ b/pkg/services/aws_tags.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway/storagegatewayiface"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
@@ -91,7 +91,7 @@ type TagsInterface struct {
 	DmsClient            databasemigrationserviceiface.DatabaseMigrationServiceAPI
 	PrometheusClient     prometheusserviceiface.PrometheusServiceAPI
 	StoragegatewayClient storagegatewayiface.StorageGatewayAPI
-	Logger               logger.Logger
+	Logger               logging.Logger
 }
 
 func (iface TagsInterface) Get(ctx context.Context, job *config.Job, region string) ([]*TaggedResource, error) {
@@ -159,7 +159,7 @@ func (iface TagsInterface) Get(ctx context.Context, job *config.Job, region stri
 	return resources, nil
 }
 
-func MigrateTagsToPrometheus(tagData []*TaggedResource, labelsSnakeCase bool, logger logger.Logger) []*promutil.PrometheusMetric {
+func MigrateTagsToPrometheus(tagData []*TaggedResource, labelsSnakeCase bool, logger logging.Logger) []*promutil.PrometheusMetric {
 	output := make([]*promutil.PrometheusMetric, 0)
 
 	tagList := make(map[string][]string)

--- a/pkg/services/aws_tags_test.go
+++ b/pkg/services/aws_tags_test.go
@@ -3,11 +3,10 @@ package services
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
@@ -314,7 +313,7 @@ func Test_MigrateTagsToPrometheus(t *testing.T) {
 		Value: &metricValue,
 	}}
 
-	actual := MigrateTagsToPrometheus(resources, false, logger.NewLogrusLogger(log.StandardLogger()))
+	actual := MigrateTagsToPrometheus(resources, false, logging.NewNopLogger())
 
 	require.Equal(t, expected, actual)
 }

--- a/pkg/session/sessions.go
+++ b/pkg/session/sessions.go
@@ -31,7 +31,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
 // SessionCache is an interface to a cache of sessions and clients for all the
@@ -61,7 +61,7 @@ type sessionCache struct {
 	refreshed        bool
 	mu               sync.Mutex
 	fips             bool
-	logger           logger.Logger
+	logger           logging.Logger
 }
 
 type clientCache struct {
@@ -81,7 +81,7 @@ type clientCache struct {
 
 // NewSessionCache creates a new session cache to use when fetching data from
 // AWS.
-func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logger.Logger) SessionCache {
+func NewSessionCache(cfg config.ScrapeConf, fips bool, logger logging.Logger) SessionCache {
 	stscache := map[config.Role]stsiface.STSAPI{}
 	roleCache := map[config.Role]map[string]*clientCache{}
 

--- a/pkg/session/sessions_test.go
+++ b/pkg/session/sessions_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/awstesting/mock"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logger"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
 func cmpCache(t *testing.T, initialCache *sessionCache, cache *sessionCache) {
@@ -69,7 +68,7 @@ func TestNewSessionCache(t *testing.T) {
 			"an empty config gives an empty cache",
 			config.ScrapeConf{},
 			false,
-			&sessionCache{logger: logger.NewLogrusLogger(log.StandardLogger())},
+			&sessionCache{logger: logging.NewNopLogger()},
 		},
 		{
 			"if fips is set then the session has fips",
@@ -77,7 +76,7 @@ func TestNewSessionCache(t *testing.T) {
 			true,
 			&sessionCache{
 				fips:   true,
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 		{
@@ -142,7 +141,7 @@ func TestNewSessionCache(t *testing.T) {
 						"ap-northeast-3": &clientCache{},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 		{
@@ -228,7 +227,7 @@ func TestNewSessionCache(t *testing.T) {
 						"ap-northeast-1": &clientCache{onlyStatic: true},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 		{
@@ -353,7 +352,7 @@ func TestNewSessionCache(t *testing.T) {
 						"ap-northeast-3": &clientCache{},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 		{
@@ -442,7 +441,7 @@ func TestNewSessionCache(t *testing.T) {
 						"ap-northeast-1": &clientCache{onlyStatic: true},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 	}
@@ -451,7 +450,7 @@ func TestNewSessionCache(t *testing.T) {
 		test := l
 		t.Run(test.descrip, func(t *testing.T) {
 			t.Parallel()
-			cache := NewSessionCache(test.config, test.fips, logger.NewLogrusLogger(log.StandardLogger())).(*sessionCache)
+			cache := NewSessionCache(test.config, test.fips, logging.NewNopLogger()).(*sessionCache)
 			t.Logf("the cache is: %v", cache)
 
 			if test.cache.cleared != cache.cleared {
@@ -508,7 +507,7 @@ func TestClear(t *testing.T) {
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 		{
@@ -533,7 +532,7 @@ func TestClear(t *testing.T) {
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 		},
 	}
@@ -630,7 +629,7 @@ func TestRefresh(t *testing.T) {
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			false,
 		},
@@ -658,7 +657,7 @@ func TestRefresh(t *testing.T) {
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			true,
 		},
@@ -685,7 +684,7 @@ func TestRefresh(t *testing.T) {
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			false,
 		},
@@ -888,7 +887,7 @@ func testGetAWSClient(
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			true,
 		},
@@ -915,7 +914,7 @@ func testGetAWSClient(
 						},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			false,
 		},
@@ -933,7 +932,7 @@ func testGetAWSClient(
 						"us-east-1": &clientCache{},
 					},
 				},
-				logger: logger.NewLogrusLogger(log.StandardLogger()),
+				logger: logging.NewNopLogger(),
 			},
 			false,
 		},


### PR DESCRIPTION
Set logging level before command execution, and propagate the logger correctly.

Fixes https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/785