### PR TITLE
Release helm chart 0.12.0

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/Chart.yaml
+++ b/charts/yet-another-cloudwatch-exporter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: yet-another-cloudwatch-exporter
 description: Yet Another Cloudwatch Exporter
 type: application
-version: 0.11.0
-appVersion: "v0.45.0-alpha"
+version: 0.12.0
+appVersion: "v0.46.0-alpha"
 home: https://github.com/nerdswords/yet-another-cloudwatch-exporter
 sources:
 - https://github.com/nerdswords/yet-another-cloudwatch-exporter


### PR DESCRIPTION
Uses Yace v0.46.0-alpha.