### PR TITLE
Add support for extra env variables

### DIFF
--- a/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
+++ b/charts/yet-another-cloudwatch-exporter/templates/deployment.yaml
@@ -45,9 +45,12 @@ spec:
           volumeMounts:
             - name: vol-yet-another-cloudwatch-exporter
               mountPath: /config
+          env:
+        {{- if .Values.extraEnv }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+        {{- end }}
         {{- if not .Values.aws.role }}
         {{- if .Values.aws.secret.name }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -66,7 +69,6 @@ spec:
                   name: {{ .Values.aws.secret.name }}
           {{- end }}
           {{- else if and .Values.aws.aws_secret_access_key .Values.aws.aws_access_key_id }}
-          env:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -86,10 +86,10 @@ extraArgs: []
 #   decoupled-scraping: false
 #   scraping-interval: 300
 
-# Define extra environmental variables list
-extraEnv: 
+# Define extra environmental variables list as follows
   # - name : key1,
   #   value: value1
+extraEnv: []
 
 aws:
   role:

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -88,8 +88,8 @@ extraArgs: []
 
 # Define extra environmental variables list
 extraEnv: 
-  - name : key1,
-    value: 'value1'
+  # - name : key1,
+  #   value: value1
 
 aws:
   role:

--- a/charts/yet-another-cloudwatch-exporter/values.yaml
+++ b/charts/yet-another-cloudwatch-exporter/values.yaml
@@ -86,6 +86,11 @@ extraArgs: []
 #   decoupled-scraping: false
 #   scraping-interval: 300
 
+# Define extra environmental variables list
+extraEnv: 
+  - name : key1,
+    value: 'value1'
+
 aws:
   role:
 


### PR DESCRIPTION
Adds support for adding extra env variables. This is required under different conditions, i.e adding proxy settings etc

If there are no values defined, it will keep empty env: block