### PR TITLE
fix(kafkaconnect): update resource filter

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -394,7 +394,7 @@ var SupportedServices = serviceConfigs{
 		Namespace: "AWS/KafkaConnect",
 		Alias:     "kafkaconnect",
 		ResourceFilters: []*string{
-			aws.String("kafkaconnect"),
+			aws.String("kafka:cluster"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":connector/(?P<Connector_Name>[^/]+)"),


### PR DESCRIPTION
Signed-off-by: Gowthaman Chinnathambi

Kafka connect does not have tags so using parent service tags for resource filters
