### PR TITLE
Refactor CW metrics to resource association logic and add tests

### DIFF
--- a/pkg/job/associator.go
+++ b/pkg/job/associator.go
@@ -1,0 +1,56 @@
+package job
+
+import (
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"regexp"
+	"strings"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+type valueToResource map[string]*model.TaggedResource
+type metricsToResourceAssociator map[string]valueToResource
+
+func newMetricsToResourceAssociator(dimensionRegexps []*regexp.Regexp, resources []*model.TaggedResource) metricsToResourceAssociator {
+	dimensionsFilter := make(map[string]valueToResource)
+	for _, dimensionRegexp := range dimensionRegexps {
+		names := dimensionRegexp.SubexpNames()
+		for i, dimensionName := range names {
+			if i != 0 {
+				names[i] = strings.ReplaceAll(dimensionName, "_", " ")
+				if _, ok := dimensionsFilter[names[i]]; !ok {
+					dimensionsFilter[names[i]] = make(valueToResource)
+				}
+			}
+		}
+		for _, r := range resources {
+			if dimensionRegexp.Match([]byte(r.ARN)) {
+				dimensionMatch := dimensionRegexp.FindStringSubmatch(r.ARN)
+				for i, value := range dimensionMatch {
+					if i != 0 {
+						dimensionsFilter[names[i]][value] = r
+					}
+				}
+			}
+		}
+	}
+	return dimensionsFilter
+}
+
+func (asoc metricsToResourceAssociator) associateMetricsToResources(namespace string, cwMetric *cloudwatch.Metric) (r *model.TaggedResource, skip bool) {
+	alreadyFound := false
+	for _, dimension := range cwMetric.Dimensions {
+		if dimensionFilterValues, ok := asoc[*dimension.Name]; ok {
+			if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
+				if !alreadyFound {
+					skip = true
+				}
+				break
+			} else {
+				alreadyFound = true
+				r = d
+			}
+		}
+	}
+	return r, skip
+}

--- a/pkg/job/associator_test.go
+++ b/pkg/job/associator_test.go
@@ -17,7 +17,9 @@ var someEC2Instance = &model.TaggedResource{
 	ARN:       "arn:aws:ec2:us-east-1:123456789012:instance/i-bla",
 	Namespace: "AWS/EC2",
 	Region:    "us-east-2",
-	Tags:      []model.Tag{{"name", "test-instance"}},
+	Tags: []model.Tag{
+		{Key: "name", Value: "test-instance"},
+	},
 }
 
 var globalAcceleratorAccelerator = &model.TaggedResource{
@@ -25,16 +27,19 @@ var globalAcceleratorAccelerator = &model.TaggedResource{
 	Namespace: "AWS/GlobalAccelerator",
 	Region:    "us-east-2",
 }
+
 var globalAcceleratorListener = &model.TaggedResource{
 	ARN:       "arn:aws:globalaccelerator::012345678901:accelerator/super-accelerator/listener/some_listener",
 	Namespace: "AWS/GlobalAccelerator",
 	Region:    "us-east-2",
 }
+
 var globalAcceleratorEndpointGroup = &model.TaggedResource{
 	ARN:       "arn:aws:globalaccelerator::012345678901:accelerator/super-accelerator/listener/some_listener/endpoint-group/eg1",
 	Namespace: "AWS/GlobalAccelerator",
 	Region:    "us-east-2",
 }
+
 var globalAcceleratorResources = []*model.TaggedResource{
 	globalAcceleratorAccelerator,
 	globalAcceleratorListener,
@@ -46,6 +51,7 @@ var ecsCluster = &model.TaggedResource{
 	Namespace: "AWS/ECS",
 	Region:    "af-south-1",
 }
+
 var ecsService1 = &model.TaggedResource{
 	ARN:       "arn:aws:ecs:af-south-1:123456789222:service/sampleCluster/service1",
 	Namespace: "AWS/ECS",
@@ -57,6 +63,7 @@ var ecsService2 = &model.TaggedResource{
 	Namespace: "AWS/ECS",
 	Region:    "af-south-1",
 }
+
 var ecsResources = []*model.TaggedResource{
 	ecsCluster,
 	ecsService1,
@@ -283,7 +290,7 @@ func TestAssociator(t *testing.T) {
 				return
 			}
 			associator := newMetricsToResourceAssociator(tc.args.dimensionRegexps, tc.args.resources)
-			res, skip := associator.associateMetricsToResources(*tc.args.metric.Namespace, tc.args.metric)
+			res, skip := associator.associateMetricsToResources(tc.args.metric)
 			require.Equal(t, tc.expectedSkip, skip)
 			require.Equal(t, tc.expectedResource, res)
 		})

--- a/pkg/job/associator_test.go
+++ b/pkg/job/associator_test.go
@@ -2,11 +2,11 @@ package job
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"

--- a/pkg/job/associator_test.go
+++ b/pkg/job/associator_test.go
@@ -1,0 +1,291 @@
+package job
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var someEC2Instance = &model.TaggedResource{
+	ARN:       "arn:aws:ec2:us-east-1:123456789012:instance/i-bla",
+	Namespace: "AWS/EC2",
+	Region:    "us-east-2",
+	Tags:      []model.Tag{{"name", "test-instance"}},
+}
+
+var globalAcceleratorAccelerator = &model.TaggedResource{
+	ARN:       "arn:aws:globalaccelerator::012345678901:accelerator/super-accelerator",
+	Namespace: "AWS/GlobalAccelerator",
+	Region:    "us-east-2",
+}
+var globalAcceleratorListener = &model.TaggedResource{
+	ARN:       "arn:aws:globalaccelerator::012345678901:accelerator/super-accelerator/listener/some_listener",
+	Namespace: "AWS/GlobalAccelerator",
+	Region:    "us-east-2",
+}
+var globalAcceleratorEndpointGroup = &model.TaggedResource{
+	ARN:       "arn:aws:globalaccelerator::012345678901:accelerator/super-accelerator/listener/some_listener/endpoint-group/eg1",
+	Namespace: "AWS/GlobalAccelerator",
+	Region:    "us-east-2",
+}
+var globalAcceleratorResources = []*model.TaggedResource{
+	globalAcceleratorAccelerator,
+	globalAcceleratorListener,
+	globalAcceleratorEndpointGroup,
+}
+
+var ecsCluster = &model.TaggedResource{
+	ARN:       "arn:aws:ecs:af-south-1:123456789222:cluster/sampleCluster",
+	Namespace: "AWS/ECS",
+	Region:    "af-south-1",
+}
+var ecsService1 = &model.TaggedResource{
+	ARN:       "arn:aws:ecs:af-south-1:123456789222:service/sampleCluster/service1",
+	Namespace: "AWS/ECS",
+	Region:    "af-south-1",
+}
+
+var ecsService2 = &model.TaggedResource{
+	ARN:       "arn:aws:ecs:af-south-1:123456789222:service/sampleCluster/service1",
+	Namespace: "AWS/ECS",
+	Region:    "af-south-1",
+}
+var ecsResources = []*model.TaggedResource{
+	ecsCluster,
+	ecsService1,
+	ecsService2,
+}
+
+func generateEC2Resources(region string, instanceIDs ...string) (res []*model.TaggedResource) {
+	for _, id := range instanceIDs {
+		res = append(res, &model.TaggedResource{
+			ARN:       fmt.Sprintf("arn:aws:ec2:%s:123456789012:instance/%s", region, id),
+			Namespace: "AWS/EC2",
+			Region:    region,
+		})
+	}
+	return
+}
+
+func TestAssociator(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *cloudwatch.Metric
+	}
+	type testCase struct {
+		// Some tests are expected to fail due to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/821
+		// Remove this safe-guard after the issue is fixed
+		expectFailure    bool
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+	for _, tc := range []testCase{
+		{
+			name: "no resource match found if there are no regex filters",
+			args: args{
+				dimensionRegexps: nil,
+				resources: []*model.TaggedResource{
+					someEC2Instance,
+				},
+				metric: &cloudwatch.Metric{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("InstanceId"),
+							Value: aws.String("i-bla"),
+						},
+					},
+				},
+			},
+			expectedSkip: false,
+		},
+		{
+			name: "pass through",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				resources: []*model.TaggedResource{
+					someEC2Instance,
+				},
+				metric: &cloudwatch.Metric{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("InstanceId"),
+							Value: aws.String("i-bla"),
+						},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: someEC2Instance,
+		},
+		{
+			name: "filtering ec2 instances by id",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				resources:        generateEC2Resources("us-east-2", "i-1", "i-2", "i-3"),
+				metric: &cloudwatch.Metric{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("InstanceId"),
+							Value: aws.String("i-2"),
+						},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: generateEC2Resources("us-east-2", "i-2")[0],
+		},
+		{
+			name: "metric dropped",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				resources: []*model.TaggedResource{
+					someEC2Instance,
+				},
+				metric: &cloudwatch.Metric{
+					Namespace:  aws.String("AWS/EC2"),
+					MetricName: aws.String("CPUUtilization"),
+					Dimensions: []*cloudwatch.Dimension{
+						{
+							Name:  aws.String("InstanceId"),
+							Value: aws.String("i-not-bla"),
+						},
+					},
+				},
+			},
+			expectedSkip: true,
+		},
+		// The tests below exercise cases in which there's a metrics that might apply to more than one resource
+		// depending on the set of dimensions it has.
+		{
+			expectFailure: true,
+			name:          "multiple ga resources, should match accelerator",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				resources:        globalAcceleratorResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("ProcessedBytesOut"),
+					Namespace:  aws.String("AWS/GlobalAccelerator"),
+					Dimensions: []*cloudwatch.Dimension{{
+						Name: aws.String("Accelerator"), Value: aws.String("super-accelerator"),
+					}},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: globalAcceleratorAccelerator,
+		},
+		{
+			expectFailure: true,
+			name:          "multiple ga resources, should match listener",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				resources:        globalAcceleratorResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("ProcessedBytesOut"),
+					Namespace:  aws.String("AWS/GlobalAccelerator"),
+					Dimensions: []*cloudwatch.Dimension{
+						{Name: aws.String("Accelerator"), Value: aws.String("super-accelerator")},
+						{Name: aws.String("Listener"), Value: aws.String("some_listener")},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: globalAcceleratorListener,
+		},
+		{
+			name: "multiple ga resources, should match endpoint group",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				resources:        globalAcceleratorResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("ProcessedBytesOut"),
+					Namespace:  aws.String("AWS/GlobalAccelerator"),
+					Dimensions: []*cloudwatch.Dimension{
+						{Name: aws.String("Accelerator"), Value: aws.String("super-accelerator")},
+						{Name: aws.String("Listener"), Value: aws.String("some_listener")},
+						{Name: aws.String("EndpointGroup"), Value: aws.String("eg1")},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: globalAcceleratorEndpointGroup,
+		},
+		{
+			expectFailure: true,
+			name:          "multiple ecs resources, cluster metric should be assigned cluster resource",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				resources:        ecsResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("MemoryReservation"),
+					Namespace:  aws.String("AWS/ECS"),
+					Dimensions: []*cloudwatch.Dimension{
+						{Name: aws.String("ClusterName"), Value: aws.String("sampleCluster")},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: ecsCluster,
+		},
+		{
+			name: "multiple ecs resources, service metric should be assigned service1 resource",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				resources:        ecsResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("CPUUtilization"),
+					Namespace:  aws.String("AWS/ECS"),
+					Dimensions: []*cloudwatch.Dimension{
+						{Name: aws.String("ClusterName"), Value: aws.String("sampleCluster")},
+						{Name: aws.String("ServiceName"), Value: aws.String("service1")},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: ecsService1,
+		},
+		{
+			name: "multiple ecs resources, service metric should be assigned service2 resource",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				resources:        ecsResources,
+				metric: &cloudwatch.Metric{
+					MetricName: aws.String("CPUUtilization"),
+					Namespace:  aws.String("AWS/ECS"),
+					Dimensions: []*cloudwatch.Dimension{
+						{Name: aws.String("ClusterName"), Value: aws.String("sampleCluster")},
+						{Name: aws.String("ServiceName"), Value: aws.String("service2")},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: ecsService2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectFailure {
+				t.Skip("failure is expected. Remove skip after https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/821 is fixed.")
+				return
+			}
+			associator := newMetricsToResourceAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.associateMetricsToResources(*tc.args.metric.Namespace, tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -199,7 +199,7 @@ func getFilteredMetricDatas(logger logging.Logger, region string, accountID *str
 		}
 
 		// TODO: refactor this logic after failing scenarios are fixed
-		matchedResource, skip := associator.associateMetricsToResources(namespace, cwMetric)
+		matchedResource, skip := associator.associateMetricsToResources(cwMetric)
 		if matchedResource != nil {
 			resource = matchedResource
 		}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
-	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -185,63 +184,32 @@ func getMetricDataForQueries(
 }
 
 func getFilteredMetricDatas(logger logging.Logger, region string, accountID *string, namespace string, customTags []model.Tag, tagsOnMetrics model.ExportedTagsOnMetrics, dimensionRegexps []*regexp.Regexp, resources []*model.TaggedResource, metricsList []*cloudwatch.Metric, dimensionNameList []string, m *config.Metric) (getMetricsData []model.CloudwatchData) {
-	type filterValues map[string]*model.TaggedResource
-	dimensionsFilter := make(map[string]filterValues)
-	for _, dimensionRegexp := range dimensionRegexps {
-		names := dimensionRegexp.SubexpNames()
-		for i, dimensionName := range names {
-			if i != 0 {
-				names[i] = strings.ReplaceAll(dimensionName, "_", " ")
-				if _, ok := dimensionsFilter[names[i]]; !ok {
-					dimensionsFilter[names[i]] = make(filterValues)
-				}
-			}
-		}
-		for _, r := range resources {
-			if dimensionRegexp.Match([]byte(r.ARN)) {
-				dimensionMatch := dimensionRegexp.FindStringSubmatch(r.ARN)
-				for i, value := range dimensionMatch {
-					if i != 0 {
-						dimensionsFilter[names[i]][value] = r
-					}
-				}
-			}
-		}
-	}
+	associator := newMetricsToResourceAssociator(dimensionRegexps, resources)
 
-	logger.Debug("FilterMetricData DimensionsFilter", "dimensionsFilter", dimensionsFilter)
+	logger.Debug("FilterMetricData DimensionsFilter", "dimensionsFilter", associator)
 
 	for _, cwMetric := range metricsList {
-		skip := false
-		alreadyFound := false
-		r := &model.TaggedResource{
-			ARN:       "global",
-			Namespace: namespace,
-		}
 		if len(dimensionNameList) > 0 && !metricDimensionsMatchNames(cwMetric, dimensionNameList) {
 			continue
 		}
 
-		for _, dimension := range cwMetric.Dimensions {
-			if dimensionFilterValues, ok := dimensionsFilter[*dimension.Name]; ok {
-				if d, ok := dimensionFilterValues[*dimension.Value]; !ok {
-					if !alreadyFound {
-						skip = true
-					}
-					break
-				} else {
-					alreadyFound = true
-					r = d
-				}
-			}
+		resource := &model.TaggedResource{
+			ARN:       "global",
+			Namespace: namespace,
+		}
+
+		// TODO: refactor this logic after failing scenarios are fixed
+		matchedResource, skip := associator.associateMetricsToResources(namespace, cwMetric)
+		if matchedResource != nil {
+			resource = matchedResource
 		}
 
 		if !skip {
 			for _, stats := range m.Statistics {
 				id := fmt.Sprintf("id_%d", rand.Int())
-				metricTags := r.MetricTags(tagsOnMetrics)
+				metricTags := resource.MetricTags(tagsOnMetrics)
 				getMetricsData = append(getMetricsData, model.CloudwatchData{
-					ID:                     &r.ARN,
+					ID:                     &resource.ARN,
 					MetricID:               &id,
 					Metric:                 &m.Name,
 					Namespace:              &namespace,


### PR DESCRIPTION
This PR is the first of two that will fix https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/821. This first PR refactors the logic to contain the actual fix, and adds the failing test scenarios so we can track when the issue is fixed.