### PR TITLE
Return aws_*_info metrics for jobs with no cloudwatch metrics

### DIFF
--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -48,7 +48,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", *result.Account)
 
 					resources, metrics := runDiscoveryJob(ctx, jobLogger, cache, metricsPerQuery, tagSemaphore, discoveryJob, region, role, result.Account, cfg.Discovery.ExportedTagsOnMetrics)
-					if len(resources) != 0 && len(metrics) != 0 {
+					if len(resources) != 0 || len(metrics) != 0 {
 						mux.Lock()
 						awsInfoData = append(awsInfoData, resources...)
 						cwData = append(cwData, metrics...)


### PR DESCRIPTION
The `aws_*_info` metrics can be useful even when cloudwatch has no data, e.g. using `aws_nlb_info` for detecting NLBs even with AWS is not reporting any `UnHealthyHostCount` metrics

Fixes #639