### PR TITLE
Change UpdateMetrics signature to accept options and return error.

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/semaphore"
 
+	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/session"
@@ -46,15 +47,62 @@ func main() {
 	}
 
 	yace.Flags = []cli.Flag{
-		&cli.StringFlag{Name: "listen-address", Value: ":5000", Usage: "The address to listen on.", Destination: &addr, EnvVars: []string{"listen-address"}},
-		&cli.StringFlag{Name: "config.file", Value: "config.yml", Usage: "Path to configuration file.", Destination: &configFile, EnvVars: []string{"config.file"}},
-		&cli.BoolFlag{Name: "debug", Value: false, Usage: "Add verbose logging.", Destination: &debug, EnvVars: []string{"debug"}},
-		&cli.BoolFlag{Name: "fips", Value: false, Usage: "Use FIPS compliant aws api.", Destination: &fips},
-		&cli.IntFlag{Name: "cloudwatch-concurrency", Value: 5, Usage: "Maximum number of concurrent requests to CloudWatch API.", Destination: &cloudwatchConcurrency},
-		&cli.IntFlag{Name: "tag-concurrency", Value: 5, Usage: "Maximum number of concurrent requests to Resource Tagging API.", Destination: &tagConcurrency},
-		&cli.IntFlag{Name: "scraping-interval", Value: 300, Usage: "Seconds to wait between scraping the AWS metrics", Destination: &scrapingInterval, EnvVars: []string{"scraping-interval"}},
-		&cli.IntFlag{Name: "metrics-per-query", Value: 500, Usage: "Number of metrics made in a single GetMetricsData request", Destination: &metricsPerQuery, EnvVars: []string{"metrics-per-query"}},
-		&cli.BoolFlag{Name: "labels-snake-case", Value: false, Usage: "If labels should be output in snake case instead of camel case", Destination: &labelsSnakeCase},
+		&cli.StringFlag{
+			Name:        "listen-address",
+			Value:       ":5000",
+			Usage:       "The address to listen on",
+			Destination: &addr,
+			EnvVars:     []string{"listen-address"},
+		},
+		&cli.StringFlag{
+			Name:        "config.file",
+			Value:       "config.yml",
+			Usage:       "Path to configuration file",
+			Destination: &configFile,
+			EnvVars:     []string{"config.file"},
+		},
+		&cli.BoolFlag{
+			Name:        "debug",
+			Value:       false,
+			Usage:       "Verbose logging",
+			Destination: &debug,
+			EnvVars:     []string{"debug"},
+		},
+		&cli.BoolFlag{
+			Name:        "fips",
+			Value:       false,
+			Usage:       "Use FIPS compliant AWS API endpoints",
+			Destination: &fips,
+		},
+		&cli.IntFlag{
+			Name:        "cloudwatch-concurrency",
+			Value:       exporter.DefaultCloudWatchAPIConcurrency,
+			Usage:       "Maximum number of concurrent requests to CloudWatch API.",
+			Destination: &cloudwatchConcurrency,
+		},
+		&cli.IntFlag{
+			Name:        "tag-concurrency",
+			Value:       exporter.DefaultTaggingAPIConcurrency,
+			Usage:       "Maximum number of concurrent requests to Resource Tagging API.",
+			Destination: &tagConcurrency,
+		},
+		&cli.IntFlag{
+			Name:        "scraping-interval",
+			Value:       300,
+			Usage:       "Seconds to wait between scraping the AWS metrics",
+			Destination: &scrapingInterval,
+			EnvVars:     []string{"scraping-interval"},
+		},
+		&cli.IntFlag{
+			Name:        "metrics-per-query",
+			Value:       exporter.DefaultMetricsPerQuery,
+			Usage:       "Number of metrics made in a single GetMetricsData request",
+			Destination: &metricsPerQuery,
+			EnvVars:     []string{"metrics-per-query"},
+		},
+		&cli.BoolFlag{
+			Name: "labels-snake-case", Value: exporter.DefaultLabelsSnakeCase, Usage: "Whether labels should be output in snake case instead of camel case", Destination: &labelsSnakeCase,
+		},
 	}
 
 	yace.Before = func(ctx *cli.Context) error {

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -28,38 +29,108 @@ var Metrics = []prometheus.Collector{
 	promutil.StoragegatewayAPICounter,
 }
 
+const (
+	DefaultMetricsPerQuery          = 500
+	DefaultLabelsSnakeCase          = false
+	DefaultCloudWatchAPIConcurrency = 5
+	DefaultTaggingAPIConcurrency    = 5
+)
+
+type options struct {
+	metricsPerQuery          int
+	labelsSnakeCase          bool
+	cloudWatchAPIConcurrency int
+	taggingAPIConcurrency    int
+}
+
+var defaultOptions = options{
+	metricsPerQuery:          DefaultMetricsPerQuery,
+	labelsSnakeCase:          DefaultLabelsSnakeCase,
+	cloudWatchAPIConcurrency: DefaultCloudWatchAPIConcurrency,
+	taggingAPIConcurrency:    DefaultTaggingAPIConcurrency,
+}
+
+type OptionsFunc func(*options) error
+
+func MetricsPerQuery(metricsPerQuery int) OptionsFunc {
+	return func(o *options) error {
+		if metricsPerQuery <= 0 {
+			return fmt.Errorf("MetricsPerQuery must be a positive value")
+		}
+
+		o.metricsPerQuery = metricsPerQuery
+		return nil
+	}
+}
+
+func LabelsSnakeCase(labelsSnakeCase bool) OptionsFunc {
+	return func(o *options) error {
+		o.labelsSnakeCase = labelsSnakeCase
+		return nil
+	}
+}
+
+func CloudWatchAPIConcurrency(maxConcurrency int) OptionsFunc {
+	return func(o *options) error {
+		if maxConcurrency <= 0 {
+			return fmt.Errorf("CloudWatchAPIConcurrency must be a positive value")
+		}
+
+		o.cloudWatchAPIConcurrency = maxConcurrency
+		return nil
+	}
+}
+
+func TaggingAPIConcurrency(maxConcurrency int) OptionsFunc {
+	return func(o *options) error {
+		if maxConcurrency <= 0 {
+			return fmt.Errorf("TaggingAPIConcurrency must be a positive value")
+		}
+
+		o.taggingAPIConcurrency = maxConcurrency
+		return nil
+	}
+}
+
 // UpdateMetrics can be used to scrape metrics from AWS on demand using the provided parameters. Scraped metrics will be added to the provided registry and
 // any labels discovered during the scrape will be added to observedMetricLabels with their metric name as the key. Any errors encountered are not returned but
 // will be logged and will either fail the scrape or a partial metric result will be added to the registry.
 func UpdateMetrics(
 	ctx context.Context,
+	logger logging.Logger,
 	config config.ScrapeConf,
 	registry *prometheus.Registry,
-	metricsPerQuery int,
-	labelsSnakeCase bool,
-	cloudwatchSemaphore, tagSemaphore chan struct{},
 	cache session.SessionCache,
 	observedMetricLabels map[string]model.LabelSet,
-	logger logging.Logger,
-) {
+	optFuncs ...OptionsFunc,
+) error {
+	options := defaultOptions
+	for _, f := range optFuncs {
+		if err := f(&options); err != nil {
+			return err
+		}
+	}
+
 	tagsData, cloudwatchData := job.ScrapeAwsData(
 		ctx,
-		config,
-		metricsPerQuery,
-		cloudwatchSemaphore,
-		tagSemaphore,
-		cache,
 		logger,
+		config,
+		cache,
+		options.metricsPerQuery,
+		options.cloudWatchAPIConcurrency,
+		options.taggingAPIConcurrency,
 	)
 
-	metrics, observedMetricLabels, err := promutil.MigrateCloudwatchDataToPrometheus(cloudwatchData, labelsSnakeCase, observedMetricLabels, logger)
+	metrics, observedMetricLabels, err := promutil.MigrateCloudwatchDataToPrometheus(cloudwatchData, options.labelsSnakeCase, observedMetricLabels, logger)
 	if err != nil {
 		logger.Error(err, "Error migrating cloudwatch metrics to prometheus metrics")
-		return
+		return nil
 	}
 	metrics = promutil.EnsureLabelConsistencyForMetrics(metrics, observedMetricLabels)
 
-	metrics = append(metrics, promutil.MigrateTagsToPrometheus(tagsData, labelsSnakeCase, logger)...)
+	metrics = append(metrics, promutil.MigrateTagsToPrometheus(tagsData, options.labelsSnakeCase, logger)...)
 
 	registry.MustRegister(promutil.NewPrometheusCollector(metrics))
+
+	return nil
 }

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -14,14 +14,16 @@ import (
 
 func ScrapeAwsData(
 	ctx context.Context,
-	cfg config.ScrapeConf,
-	metricsPerQuery int,
-	cloudwatchSemaphore,
-	tagSemaphore chan struct{},
-	cache session.SessionCache,
 	logger logging.Logger,
+	cfg config.ScrapeConf,
+	cache session.SessionCache,
+	metricsPerQuery int,
+	cloudWatchAPIConcurrency int,
+	taggingAPIConcurrency int,
 ) ([]*model.TaggedResource, []*model.CloudwatchData) {
 	mux := &sync.Mutex{}
+	cloudwatchSemaphore := make(chan struct{}, cloudWatchAPIConcurrency)
+	tagSemaphore := make(chan struct{}, taggingAPIConcurrency)
 
 	cwData := make([]*model.CloudwatchData, 0)
 	awsInfoData := make([]*model.TaggedResource, 0)


### PR DESCRIPTION
Refactor the signature of `UpdateMetrics` (entry point if you use yace as a library) to accept a variadic list of options funcs rather than a lengthy list of parameters, and to return an error (currently always nil, but will be used to bubble up errors from the pkg code).