### PR TITLE
Allow discovery jobs to return result even if there are no resources

### DIFF
--- a/pkg/apitagging/client.go
+++ b/pkg/apitagging/client.go
@@ -21,6 +21,8 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
+var ErrExpectedToFindResources = errors.New("expected to discover resources but none were found")
+
 type Client struct {
 	logger            logging.Logger
 	taggingAPI        resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
@@ -128,5 +130,3 @@ func (c Client) GetResources(ctx context.Context, job *config.Job, region string
 
 	return resources, nil
 }
-
-var ErrExpectedToFindResources = errors.New("expected to discover resources but none were found")

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -62,18 +62,12 @@ func scrapeDiscoveryJobUsingMetricData(
 	tagSemaphore chan struct{},
 	logger logging.Logger,
 ) (resources []*model.TaggedResource, cw []*model.CloudwatchData) {
-	// Add the info tags of all the resources
 	logger.Debug("Get tagged resources")
 	tagSemaphore <- struct{}{}
 	resources, err := clientTag.GetResources(ctx, job, region)
 	<-tagSemaphore
 	if err != nil {
 		logger.Error(err, "Couldn't describe resources")
-		return
-	}
-
-	if len(resources) == 0 {
-		logger.Info("No tagged resources made it through filtering")
 		return
 	}
 

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -67,7 +68,11 @@ func scrapeDiscoveryJobUsingMetricData(
 	resources, err := clientTag.GetResources(ctx, job, region)
 	<-tagSemaphore
 	if err != nil {
-		logger.Error(err, "Couldn't describe resources")
+		if errors.Is(err, apitagging.ErrExpectedToFindResources) {
+			logger.Error(err, "No tagged resources made it through filtering")
+		} else {
+			logger.Error(err, "Couldn't describe resources")
+		}
 		return
 	}
 

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -48,7 +48,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", *result.Account)
 
 					resources, metrics := runDiscoveryJob(ctx, jobLogger, cache, metricsPerQuery, tagSemaphore, discoveryJob, region, role, result.Account, cfg.Discovery.ExportedTagsOnMetrics)
-					if len(resources) != 0 && len(metrics) != 0 {
+					if len(metrics) != 0 {
 						mux.Lock()
 						awsInfoData = append(awsInfoData, resources...)
 						cwData = append(cwData, metrics...)


### PR DESCRIPTION
There are a few services such as `AWS/Billing`, and `AWS/SES` which are not resources based. This excludes them from being able to be run via a discovery job. This PR attempts to fix that via removing some early exits in the event resources are not found. 

Resource discovery and metrics discovery are only tied together via a loose ability to associate data between the two. If a metric can't be linked back to a resource it's tagged as "global" already, https://github.com/kgeckhart/yet-another-cloudwatch-exporter/blob/1159de1154138efffc224447c552a54618391f3c/pkg/job/discovery.go#L190-L199. This to me indicates, as long as we didn't expect to find resources it's okay that none were found.

Resolves #738
Resolves #257