### PR TITLE
Linting: fix revive issues.

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -111,7 +111,7 @@ func startScraper(_ *cli.Context) error {
 	ctx, cancelRunningScrape := context.WithCancel(context.Background())
 	go s.decoupled(ctx, logger, cache)
 
-	http.HandleFunc("/metrics", s.makeHandler(ctx, cache))
+	http.HandleFunc("/metrics", s.makeHandler())
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(fmt.Sprintf(`<html>

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -28,7 +28,7 @@ func NewScraper() *scraper { //nolint:revive
 	}
 }
 
-func (s *scraper) makeHandler(ctx context.Context, cache session.SessionCache) func(http.ResponseWriter, *http.Request) {
+func (s *scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		handler := promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{
 			DisableCompression: false,

--- a/pkg/apitagging/filters_test.go
+++ b/pkg/apitagging/filters_test.go
@@ -350,12 +350,12 @@ type dmsClient struct {
 	describeReplicationTasksOutput     *databasemigrationservice.DescribeReplicationTasksOutput
 }
 
-func (dms dmsClient) DescribeReplicationInstancesPagesWithContext(_ aws.Context, input *databasemigrationservice.DescribeReplicationInstancesInput, fn func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool, opts ...request.Option) error {
+func (dms dmsClient) DescribeReplicationInstancesPagesWithContext(_ aws.Context, _ *databasemigrationservice.DescribeReplicationInstancesInput, fn func(*databasemigrationservice.DescribeReplicationInstancesOutput, bool) bool, _ ...request.Option) error {
 	fn(dms.describeReplicationInstancesOutput, true)
 	return nil
 }
 
-func (dms dmsClient) DescribeReplicationTasksPagesWithContext(_ aws.Context, input *databasemigrationservice.DescribeReplicationTasksInput, fn func(*databasemigrationservice.DescribeReplicationTasksOutput, bool) bool, opts ...request.Option) error {
+func (dms dmsClient) DescribeReplicationTasksPagesWithContext(_ aws.Context, _ *databasemigrationservice.DescribeReplicationTasksInput, fn func(*databasemigrationservice.DescribeReplicationTasksOutput, bool) bool, _ ...request.Option) error {
 	fn(dms.describeReplicationTasksOutput, true)
 	return nil
 }
@@ -365,7 +365,7 @@ type apiGatewayClient struct {
 	getRestApisOutput *apigateway.GetRestApisOutput
 }
 
-func (apigateway apiGatewayClient) GetRestApisPagesWithContext(_ aws.Context, input *apigateway.GetRestApisInput, fn func(*apigateway.GetRestApisOutput, bool) bool, opts ...request.Option) error {
+func (apigateway apiGatewayClient) GetRestApisPagesWithContext(_ aws.Context, _ *apigateway.GetRestApisInput, fn func(*apigateway.GetRestApisOutput, bool) bool, _ ...request.Option) error {
 	fn(apigateway.getRestApisOutput, true)
 	return nil
 }

--- a/pkg/job/associator.go
+++ b/pkg/job/associator.go
@@ -57,7 +57,7 @@ func (asoc metricsToResourceAssociator) associateMetricsToResources(cwMetric *cl
 					skip = true
 				}
 				break
-			} else {
+			} else { //nolint:revive
 				alreadyFound = true
 				r = d
 			}

--- a/pkg/session/sessions_test.go
+++ b/pkg/session/sessions_test.go
@@ -940,7 +940,7 @@ func testGetAWSClient(
 
 	for _, l := range tests {
 		test := l
-		t.Run(test.descrip, func(t *testing.T) {
+		t.Run(name+" "+test.descrip, func(t *testing.T) {
 			t.Parallel()
 			if test.parallelRun {
 				go testClientGet(t, test.cache, &region, role)


### PR DESCRIPTION
golangci-lint 1.52.0 has an up-to-date version of revive which complains about unused variables.