### PR TITLE
Allow to fetch additional metrics of interest

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,12 @@ The following IAM permissions are required to discover tagged Database Migration
 "dms:DescribeReplicationTasks"
 ```
 
+The following IAM permissions are required to fetch additional metrics for DynamoDB (like number of items):
+```json
+"dynamodb:DescribeTable"
+```
+
+
 ## Override AWS endpoint urls
 to support local testing all AWS urls can be overridden with by setting an environment variable `AWS_ENDPOINT_URL`
 ```shell

--- a/pkg/apitagging/aws_tags.go
+++ b/pkg/apitagging/aws_tags.go
@@ -3,6 +3,7 @@ package apitagging
 import (
 	"context"
 	"errors"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
@@ -26,6 +27,7 @@ type TagsInterface struct {
 	AsgClient            autoscalingiface.AutoScalingAPI
 	APIGatewayClient     apigatewayiface.APIGatewayAPI
 	Ec2Client            ec2iface.EC2API
+	DynamoDBClient       dynamodbiface.DynamoDBAPI
 	DmsClient            databasemigrationserviceiface.DatabaseMigrationServiceAPI
 	PrometheusClient     prometheusserviceiface.PrometheusServiceAPI
 	StoragegatewayClient storagegatewayiface.StorageGatewayAPI

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -42,7 +42,7 @@ func UpdateMetrics(
 	observedMetricLabels map[string]model.LabelSet,
 	logger logging.Logger,
 ) {
-	tagsData, cloudwatchData := job.ScrapeAwsData(
+	tagsData, cloudwatchData, additionalMetrics := job.ScrapeAwsData(
 		ctx,
 		config,
 		metricsPerQuery,
@@ -60,6 +60,7 @@ func UpdateMetrics(
 	metrics = promutil.EnsureLabelConsistencyForMetrics(metrics, observedMetricLabels)
 
 	metrics = append(metrics, promutil.MigrateTagsToPrometheus(tagsData, labelsSnakeCase, logger)...)
+	metrics = append(metrics, additionalMetrics...)
 
 	registry.MustRegister(promutil.NewPrometheusCollector(metrics))
 }

--- a/pkg/job/non_cloudwatch_metrics.go
+++ b/pkg/job/non_cloudwatch_metrics.go
@@ -1,0 +1,67 @@
+package job
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/apitagging"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
+	"regexp"
+)
+
+type additionalAWSMetric struct {
+	additionalAWSMetrics func(resources []*model.TaggedResource, api apitagging.TagsInterface) ([]*promutil.PrometheusMetric, error)
+}
+
+var additionalAWSMetrics = map[string]additionalAWSMetric{
+	"AWS/DynamoDB": {
+		additionalAWSMetrics: func(resources []*model.TaggedResource, api apitagging.TagsInterface) ([]*promutil.PrometheusMetric, error) {
+			additionalMetrics := make([]*promutil.PrometheusMetric, 0)
+			for _, resource := range resources {
+				re := regexp.MustCompile(":table/(.*)")
+				match := re.FindStringSubmatch(resource.ARN)
+				describeTableOutput, err := api.DynamoDBClient.DescribeTable(&dynamodb.DescribeTableInput{
+					TableName: aws.String(match[1]),
+				})
+				if err != nil {
+					return nil, err
+				}
+				labels := make(map[string]string)
+
+				labels["name"] = resource.ARN
+				labels["region"] = resource.Region
+				accountIDSearchString := regexp.MustCompile(".*:(.*):table\\/.*")
+				labels["account_id"] = accountIDSearchString.FindStringSubmatch(resource.ARN)[1]
+
+				tableNameSearchString := regexp.MustCompile(".*:table\\/(.*)")
+				labels["tableName"] = tableNameSearchString.FindStringSubmatch(resource.ARN)[1]
+
+				itemCount := float64(*describeTableOutput.Table.ItemCount)
+				p := promutil.PrometheusMetric{
+					Name:   aws.String("aws_dynamodb_item_count"),
+					Labels: labels,
+					Value:  &itemCount,
+				}
+				additionalMetrics = append(additionalMetrics, &p)
+			}
+			return additionalMetrics, nil
+		},
+	},
+}
+
+func scrapeAdditionalMetrics(job *config.Job, resources []*model.TaggedResource, api apitagging.TagsInterface) ([]*promutil.PrometheusMetric, error) {
+
+	additionalMetrics := make([]*promutil.PrometheusMetric, 0)
+	svc := config.SupportedServices.GetService(job.Type)
+	if ext, ok := additionalAWSMetrics[svc.Namespace]; ok {
+		if ext.additionalAWSMetrics != nil {
+			output, err := ext.additionalAWSMetrics(resources, api)
+			if err != nil {
+				return nil, err
+			}
+			additionalMetrics = append(additionalMetrics, output...)
+		}
+	}
+	return additionalMetrics, nil
+}


### PR DESCRIPTION
This PR is not fully ready, but I suspect it might be a bit controversial 😬 so before I go on to add tests and make it all shiny to then, possibly, not get approved, I'm opening it up in advance to gather some feedback.

This PR will add a mechanism that will allow to use other endpoints in the AWS API to fetch metrics of interest that are not exposed in Cloudwatch.

In this specific case, the need is to fetch the number of items in a DynamoDB table. This value is not exposed in Cloudwatch but it's expose in the ["describe-table" endpoint](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/describe-table.html). According to the docs, this value is only updated every 6 hours (still need to add feature for not scrapping that endpoint all the time tho).
![image](https://user-images.githubusercontent.com/725020/227967582-ab83baf6-c5d1-4b72-b847-81d094c04803.png)

The result is something like this:
```
aws_dynamodb_item_count{account_id="687577111111",name="arn:aws:dynamodb:eu-west-1:687577111111:table/foobar",region="eu-west-1",tableName="foobar"} 981
aws_dynamodb_item_count{account_id="687577111111",name="arn:aws:dynamodb:eu-west-1:687577111111:table/some-table",region="eu-west-1",tableName="some-table"} 482
```

Additional IAM permissions are required.

I'm keenly aware that fetching metrics from other places that is not Cloudwatch, goes a bit against what the name of the tool says, but I decided to give it a try anyhow 🤷 

Let me know if you are willing to accept something like this. If yes, I'll work on make this PR all nice and shiny (write tests, handle errors, etc.), if not, no hard feelings 😄 