### PR TITLE
Add feature flags support

### DIFF
--- a/cmd/yace/main_test.go
+++ b/cmd/yace/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestYACEApp_FeatureFlagsParsedCorrectly(t *testing.T) {
+	app := NewYACEApp()
+
+	// two feature flags
+	app.Action = func(c *cli.Context) error {
+		featureFlags := c.StringSlice(enableFeatureFlag)
+		require.Equal(t, []string{"feature1", "feature2"}, featureFlags)
+		return nil
+	}
+
+	require.NoError(t, app.Run([]string{"yace", "-enable-feature=feature1,feature2"}), "error running test command")
+
+	// empty feature flags
+	app.Action = func(c *cli.Context) error {
+		featureFlags := c.StringSlice(enableFeatureFlag)
+		require.Len(t, featureFlags, 0)
+		return nil
+	}
+
+	require.NoError(t, app.Run([]string{"yace"}), "error running test command")
+}

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -15,12 +15,14 @@ import (
 )
 
 type scraper struct {
-	registry *prometheus.Registry
+	registry     *prometheus.Registry
+	featureFlags []string
 }
 
-func NewScraper() *scraper { //nolint:revive
+func NewScraper(featureFlags []string) *scraper { //nolint:revive
 	return &scraper{
-		registry: prometheus.NewRegistry(),
+		registry:     prometheus.NewRegistry(),
+		featureFlags: featureFlags,
 	}
 }
 
@@ -82,6 +84,7 @@ func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache sessi
 		exporter.LabelsSnakeCase(labelsSnakeCase),
 		exporter.CloudWatchAPIConcurrency(cloudwatchConcurrency),
 		exporter.TaggingAPIConcurrency(tagConcurrency),
+		exporter.EnableFeatureFlag(s.featureFlags...),
 	)
 	if err != nil {
 		logger.Error(err, "error updating metrics")

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -36,11 +36,16 @@ const (
 	DefaultTaggingAPIConcurrency    = 5
 )
 
+// featureFlagsMap is a map that contains the enabled feature flags. If a key is not present, it means the feature flag
+// is disabled.
+type featureFlagsMap map[string]struct{}
+
 type options struct {
 	metricsPerQuery          int
 	labelsSnakeCase          bool
 	cloudWatchAPIConcurrency int
 	taggingAPIConcurrency    int
+	featureFlags             featureFlagsMap
 }
 
 var defaultOptions = options{
@@ -48,6 +53,7 @@ var defaultOptions = options{
 	labelsSnakeCase:          DefaultLabelsSnakeCase,
 	cloudWatchAPIConcurrency: DefaultCloudWatchAPIConcurrency,
 	taggingAPIConcurrency:    DefaultTaggingAPIConcurrency,
+	featureFlags:             make(featureFlagsMap),
 }
 
 type OptionsFunc func(*options) error
@@ -88,6 +94,16 @@ func TaggingAPIConcurrency(maxConcurrency int) OptionsFunc {
 		}
 
 		o.taggingAPIConcurrency = maxConcurrency
+		return nil
+	}
+}
+
+// EnableFeatureFlag is an option that enables a feature flag on the YACE's entrypoint.
+func EnableFeatureFlag(flags ...string) OptionsFunc {
+	return func(o *options) error {
+		for _, flag := range flags {
+			o.featureFlags[flag] = struct{}{}
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
This PR implements feature flags support to YACE. It follows the same approach [Prometheus uses](https://prometheus.io/docs/prometheus/latest/feature_flags/), and hooks them into the library entrypoint using a custom `Option` that enables feature flags.

Also, moves around a little bit the `main.go` code to allow some light testing.