### PR TITLE
Refactor API clients concurrency handling.

### DIFF
--- a/pkg/apicloudwatch/concurrency.go
+++ b/pkg/apicloudwatch/concurrency.go
@@ -1,0 +1,42 @@
+package apicloudwatch
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+)
+
+type MaxConcurrencyClient struct {
+	client *Client
+	sem    chan struct{}
+}
+
+func NewWithMaxConcurrency(client *Client, maxConcurrency int) *MaxConcurrencyClient {
+	return &MaxConcurrencyClient{
+		client: client,
+		sem:    make(chan struct{}, maxConcurrency),
+	}
+}
+
+func (c MaxConcurrencyClient) GetMetricStatistics(ctx context.Context, filter *cloudwatch.GetMetricStatisticsInput) []*cloudwatch.Datapoint {
+	c.sem <- struct{}{}
+	res := c.client.GetMetricStatistics(ctx, filter)
+	<-c.sem
+	return res
+}
+
+func (c MaxConcurrencyClient) GetMetricData(ctx context.Context, filter *cloudwatch.GetMetricDataInput) *cloudwatch.GetMetricDataOutput {
+	c.sem <- struct{}{}
+	res := c.client.GetMetricData(ctx, filter)
+	<-c.sem
+	return res
+}
+
+func (c MaxConcurrencyClient) ListMetrics(ctx context.Context, namespace string, metric *config.Metric) (*cloudwatch.ListMetricsOutput, error) {
+	c.sem <- struct{}{}
+	res, err := c.client.ListMetrics(ctx, namespace, metric)
+	<-c.sem
+	return res, err
+}

--- a/pkg/apitagging/client.go
+++ b/pkg/apitagging/client.go
@@ -43,8 +43,8 @@ func NewClient(
 	dmsClient databasemigrationserviceiface.DatabaseMigrationServiceAPI,
 	prometheusClient prometheusserviceiface.PrometheusServiceAPI,
 	storageGatewayAPI storagegatewayiface.StorageGatewayAPI,
-) Client {
-	return Client{
+) *Client {
+	return &Client{
 		logger:            logger,
 		taggingAPI:        taggingAPI,
 		autoscalingAPI:    autoscalingAPI,

--- a/pkg/apitagging/concurrency.go
+++ b/pkg/apitagging/concurrency.go
@@ -1,0 +1,27 @@
+package apitagging
+
+import (
+	"context"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+type MaxConcurrencyClient struct {
+	client *Client
+	sem    chan struct{}
+}
+
+func NewWithMaxConcurrency(client *Client, maxConcurrency int) *MaxConcurrencyClient {
+	return &MaxConcurrencyClient{
+		client: client,
+		sem:    make(chan struct{}, maxConcurrency),
+	}
+}
+
+func (c MaxConcurrencyClient) GetResources(ctx context.Context, job *config.Job, region string) ([]*model.TaggedResource, error) {
+	c.sem <- struct{}{}
+	res, err := c.client.GetResources(ctx, job, region)
+	<-c.sem
+	return res, err
+}

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -19,16 +19,18 @@ func runCustomNamespaceJob(
 	logger logging.Logger,
 	cache session.SessionCache,
 	metricsPerQuery int,
-	cloudwatchSemaphore chan struct{},
-	tagSemaphore chan struct{},
 	job *config.CustomNamespace,
 	region string,
 	role config.Role,
 	account *string,
+	cloudwatchAPIConcurrency int,
 ) []*model.CloudwatchData {
-	clientCloudwatch := apicloudwatch.NewClient(
-		logger,
-		cache.GetCloudwatch(&region, role),
+	clientCloudwatch := apicloudwatch.NewWithMaxConcurrency(
+		apicloudwatch.NewClient(
+			logger,
+			cache.GetCloudwatch(&region, role),
+		),
+		cloudwatchAPIConcurrency,
 	)
 
 	return scrapeCustomNamespaceJobUsingMetricData(
@@ -37,8 +39,6 @@ func runCustomNamespaceJob(
 		region,
 		account,
 		clientCloudwatch,
-		cloudwatchSemaphore,
-		tagSemaphore,
 		logger,
 		metricsPerQuery,
 	)
@@ -49,16 +49,14 @@ func scrapeCustomNamespaceJobUsingMetricData(
 	job *config.CustomNamespace,
 	region string,
 	accountID *string,
-	clientCloudwatch *apicloudwatch.Client,
-	cloudwatchSemaphore chan struct{},
-	tagSemaphore chan struct{},
+	clientCloudwatch *apicloudwatch.MaxConcurrencyClient,
 	logger logging.Logger,
 	metricsPerQuery int,
 ) (cw []*model.CloudwatchData) {
 	mux := &sync.Mutex{}
 	var wg sync.WaitGroup
 
-	getMetricDatas := getMetricDataForQueriesForCustomNamespace(ctx, job, region, accountID, clientCloudwatch, tagSemaphore, logger)
+	getMetricDatas := getMetricDataForQueriesForCustomNamespace(ctx, job, region, accountID, clientCloudwatch, logger)
 	metricDataLength := len(getMetricDatas)
 	if metricDataLength == 0 {
 		logger.Debug("No metrics data found")
@@ -73,12 +71,7 @@ func scrapeCustomNamespaceJobUsingMetricData(
 
 	for i := 0; i < metricDataLength; i += maxMetricCount {
 		go func(i int) {
-			cloudwatchSemaphore <- struct{}{}
-
-			defer func() {
-				defer wg.Done()
-				<-cloudwatchSemaphore
-			}()
+			defer wg.Done()
 
 			end := i + maxMetricCount
 			if end > metricDataLength {
@@ -115,50 +108,60 @@ func getMetricDataForQueriesForCustomNamespace(
 	customNamespaceJob *config.CustomNamespace,
 	region string,
 	accountID *string,
-	clientCloudwatch *apicloudwatch.Client,
-	tagSemaphore chan struct{},
+	clientCloudwatch *apicloudwatch.MaxConcurrencyClient,
 	logger logging.Logger,
 ) []model.CloudwatchData {
+	mux := &sync.Mutex{}
 	var getMetricDatas []model.CloudwatchData
 
-	// For every metric of the job
+	var wg sync.WaitGroup
+	wg.Add(len(customNamespaceJob.Metrics))
+
 	for _, metric := range customNamespaceJob.Metrics {
-		// Get the full list of metrics
+		// For every metric of the job get the full list of metrics.
 		// This includes, for this metric the possible combinations
-		// of dimensions and value of dimensions with data
-		tagSemaphore <- struct{}{}
+		// of dimensions and value of dimensions with data.
 
-		metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric)
-		<-tagSemaphore
-
-		if err != nil {
-			logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", customNamespaceJob.Namespace)
-			continue
-		}
-
-		for _, cwMetric := range metricsList.Metrics {
-			if len(customNamespaceJob.DimensionNameRequirements) > 0 && !metricDimensionsMatchNames(cwMetric, customNamespaceJob.DimensionNameRequirements) {
-				continue
+		go func(metric *config.Metric) {
+			defer wg.Done()
+			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric)
+			if err != nil {
+				logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", customNamespaceJob.Namespace)
+				return
 			}
 
-			for _, stats := range metric.Statistics {
-				id := fmt.Sprintf("id_%d", rand.Int())
-				getMetricDatas = append(getMetricDatas, model.CloudwatchData{
-					ID:                     &customNamespaceJob.Name,
-					MetricID:               &id,
-					Metric:                 &metric.Name,
-					Namespace:              &customNamespaceJob.Namespace,
-					Statistics:             []string{stats},
-					NilToZero:              metric.NilToZero,
-					AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
-					CustomTags:             customNamespaceJob.CustomTags,
-					Dimensions:             cwMetric.Dimensions,
-					Region:                 &region,
-					AccountID:              accountID,
-					Period:                 metric.Period,
-				})
+			var data []model.CloudwatchData
+
+			for _, cwMetric := range metricsList.Metrics {
+				if len(customNamespaceJob.DimensionNameRequirements) > 0 && !metricDimensionsMatchNames(cwMetric, customNamespaceJob.DimensionNameRequirements) {
+					continue
+				}
+
+				for _, stats := range metric.Statistics {
+					id := fmt.Sprintf("id_%d", rand.Int())
+					data = append(data, model.CloudwatchData{
+						ID:                     &customNamespaceJob.Name,
+						MetricID:               &id,
+						Metric:                 &metric.Name,
+						Namespace:              &customNamespaceJob.Namespace,
+						Statistics:             []string{stats},
+						NilToZero:              metric.NilToZero,
+						AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
+						CustomTags:             customNamespaceJob.CustomTags,
+						Dimensions:             cwMetric.Dimensions,
+						Region:                 &region,
+						AccountID:              accountID,
+						Period:                 metric.Period,
+					})
+				}
 			}
-		}
+
+			mux.Lock()
+			getMetricDatas = append(getMetricDatas, data...)
+			mux.Unlock()
+		}(metric)
 	}
+
+	wg.Wait()
 	return getMetricDatas
 }


### PR DESCRIPTION
API clients (tagging and cloudwatch) use buffered channels to limit the max number of in-flight requests at any time.

With this PR:
- concurrency handling is moved from code related to jobs to wrapper around client methods
- fixed ListMetrics requests to use the setting for cloudwatch max concurrency rather than tagging max concurrency
- introduce a workgroup for parallelising ListMetrics requests up to the number of metrics