### PR TITLE
Remove extra error log when no resources are found

### DIFF
--- a/pkg/apitagging/client.go
+++ b/pkg/apitagging/client.go
@@ -73,10 +73,6 @@ func (c Client) GetResources(ctx context.Context, job *config.Job, region string
 			pageNum++
 			promutil.ResourceGroupTaggingAPICounter.Inc()
 
-			if len(page.ResourceTagMappingList) == 0 {
-				c.logger.Error(errors.New("resource tag list is empty"), "Account contained no tagged resource. Tags must be defined for resources to be discovered.")
-			}
-
 			for _, resourceTagMapping := range page.ResourceTagMappingList {
 				resource := model.TaggedResource{
 					ARN:       aws.StringValue(resourceTagMapping.ResourceARN),


### PR DESCRIPTION
After running #856 I noticed we were double logging errors when resources weren't found. I removed the error logging from apitagging/client.go in favor of the newly added logging https://github.com/kgeckhart/yet-another-cloudwatch-exporter/blob/master/pkg/job/discovery.go#L72-L80