### PR TITLE
Add docker compose support for easier development

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,21 @@
+## Setting up a local docker-compose environment
+
+This folder contains a [docker-compose](./docker-compose.yaml) configuration file to start a local development environment. 
+This includes:
+- YACE, using as config file [yace-config.yaml](./yace-config.yaml)
+- Prometheus, with a scraping configuration targeting YACE
+- Grafana, wih no login required and the Prometheus datasource configured
+
+Docker will mount the `~/.aws` directory in order to re-utilize the host's AWS credentials. For selecting which region
+and AWS profile to use, fill in the `AWS_REGION` and `AWS_PROFILE` variables passed to the `docker-compose up` command,
+as shown below.
+
+```bash
+# Build the YACE docker image
+docker-compose build
+
+# Start all docker-compose resource
+AWS_REGION=us-east-1 AWS_PROFILE=sandbox docker-compose up -d 
+```
+
+After that, Prometheus will be exposed at [http://localhost:9090](http://localhost:9090), and Grafana in [http://localhost:3000](http://localhost:3000).

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -58,6 +58,5 @@ services:
     command:
       - -listen-address=:8080
       - -config.file=/tmp/config.yml
-      - -enable-feature=encoding-resource-associator
     networks:
       - monitoring

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -1,0 +1,63 @@
+version: '3.8'
+
+networks:
+  monitoring:
+    driver: bridge
+    
+volumes:
+  prometheus_data: {}
+
+services:
+  grafana:
+    image: grafana/grafana:9.4.3
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./grafana/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yml
+    environment:
+      # configure no-login required access
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_BASIC_ENABLED: "false"
+    networks:
+      - monitoring
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    ports:
+      - "9090:9090"
+    expose:
+      - 9090
+    networks:
+      - monitoring
+
+  yace:
+    build: 
+      context: ../
+      dockerfile: Dockerfile
+    restart: always
+    environment:
+      AWS_REGION: ${AWS_REGION}
+      AWS_PROFILE: ${AWS_PROFILE}
+    expose: 
+      - 8080
+    volumes:
+      - ./yace-config.yaml:/tmp/config.yml
+      - $HOME/.aws:/exporter/.aws:ro
+    command:
+      - -listen-address=:8080
+      - -config.file=/tmp/config.yml
+      - -enable-feature=encoding-resource-associator
+    networks:
+      - monitoring

--- a/docker-compose/grafana/datasource.yaml
+++ b/docker-compose/grafana/datasource.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    editable: true

--- a/docker-compose/prometheus.yaml
+++ b/docker-compose/prometheus.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 1m
+
+scrape_configs:
+  - job_name: "prometheus"
+    scrape_interval: 1m
+    static_configs:
+    - targets: ["localhost:9090"]
+
+  - job_name: "yace"
+    static_configs:
+    - targets: ["yace:8080"]

--- a/docker-compose/yace-config.yaml
+++ b/docker-compose/yace-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1alpha1
+sts-region: us-east-1
+discovery:
+  jobs:
+    - type: AWS/ECS
+      regions: [us-east-1]
+      period: 300
+      length: 300
+      metrics:
+        - name: CPUReservation
+          statistics:
+            - Average
+        - name: MemoryReservation
+          statistics:
+            - Average
+        - name: CPUUtilization
+          statistics:
+            - Average
+        - name: MemoryUtilization
+          statistics:
+            - Average
+    - type: AWS/EC2
+      regions: [us-east-1]
+      metrics:
+        - name: CPUUtilization
+          statistics:
+            - Average

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,10 @@ docker run -d --rm \
 
 Do not forget the `v` prefix in the image version tag.
 
+## Docker compose
+
+See the [docker-compose directory](../docker-compose/README.md).
+
 ## Kubernetes
 
 ### Install with HELM


### PR DESCRIPTION
This PR adds a fully fledged docker compose setup, including:
- A YACE container, re-using the local `~/.aws` credentials, and some configurable parameters
- A prometheus container, scraping yace
- a grafana container, to easily visualize results

Also, added docs on how to use it.