### PR TITLE
Route feature flags to rest of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Only the latest version gets security updates. We won't support older versions.
 
 ## Feature flags
 
-To provide backwards compatibility, some new of YACE's features or changes might be guarded under a feature flag. Refer to [docs/feature_flags.md](./docs/feature_flags.md) for deatils.
+To provide backwards compatibility, some of YACE's new features or breaking changes might be guarded under a feature flag. Refer to [docs/feature_flags.md](./docs/feature_flags.md) for details.
 
 ## Installing and running
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Only the latest version gets security updates. We won't support older versions.
   * wafv2 (AWS/WAFV2) - Web Application Firewall v2
   * workspaces (AWS/WorkSpaces) - Workspaces
 
+## Feature flags
+
+To provide backwards compatibility, some new of YACE's features or changes might be guarded under a feature flag. Refer to [docs/feature_flags.md](./docs/feature_flags.md) for deatils.
+
 ## Installing and running
 
 Refer to the [installing guide](docs/install.md).

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -1,0 +1,15 @@
+# Feature flags
+
+List of features or changes that are disabled by default since they are breaking changes or are considered experimental. Their behavior can change in future releases which will be communicated via the release changelog.
+
+You can enable them using the `-enable-feature` flag with a comma separated list of features. They may be enabled by default in future versions.
+
+<!-- 
+
+## Example
+
+`-enable-feature=example`
+
+The above is not a real feature, but an example of `feature_flags.md` entry. 
+
+-->

--- a/pkg/config/feature_flags.go
+++ b/pkg/config/feature_flags.go
@@ -1,0 +1,34 @@
+package config
+
+import "context"
+
+var (
+	flagsCtxKey         = struct{}{}
+	defaultFeatureFlags = noFeatureFlags{}
+)
+
+// FeatureFlags is an interface all objects that can tell wether or not a feature flag is enabled can implement.
+type FeatureFlags interface {
+	// IsFeatureEnabled tells if the feature flag identified by flag is enabled.
+	IsFeatureEnabled(flag string) bool
+}
+
+// CtxWithFlags injects a FeatureFlags inside a given context.Context, so that they are easily communicated through layers.
+func CtxWithFlags(ctx context.Context, ctrl FeatureFlags) context.Context {
+	return context.WithValue(ctx, flagsCtxKey, ctrl)
+}
+
+// FlagsFromCtx retrieves a FeatureFlags from a given context.Context, defaulting to one with all feature flags disabled if none is found.
+func FlagsFromCtx(ctx context.Context) FeatureFlags {
+	if ctrl := ctx.Value(flagsCtxKey); ctrl != nil {
+		return ctrl.(FeatureFlags)
+	}
+	return defaultFeatureFlags
+}
+
+// noFeatureFlags implements a no-op FeatureFlags
+type noFeatureFlags struct{}
+
+func (nff noFeatureFlags) IsFeatureEnabled(_ string) bool {
+	return false
+}

--- a/pkg/config/feature_flags_test.go
+++ b/pkg/config/feature_flags_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureFlagsInContext_DefaultsToNonEnabled(t *testing.T) {
+	flags := FlagsFromCtx(context.Background())
+	require.False(t, flags.IsFeatureEnabled("some-feature"))
+	require.False(t, flags.IsFeatureEnabled("some-other-feature"))
+}
+
+type flags struct{}
+
+func (f flags) IsFeatureEnabled(_ string) bool {
+	return true
+}
+
+func TestFeatureFlagsInContext_RetrievesFlagsFromContext(t *testing.T) {
+	ctx := CtxWithFlags(context.Background(), flags{})
+	require.True(t, FlagsFromCtx(ctx).IsFeatureEnabled("some-feature"))
+	require.True(t, FlagsFromCtx(ctx).IsFeatureEnabled("some-other-feature"))
+}


### PR DESCRIPTION
This PR routes feature flags configure through the option implemented in https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/866, to the rest of the code. To do so, it injects the configured feature flags in the context that's passed down through every layer. That way we avoid passing them manually through arguments.