### PR TITLE
Deprecate jobs of type "custom namespace".

### DIFF
--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -83,6 +83,8 @@ func ScrapeAwsData(
 	}
 
 	for _, customNamespaceJob := range cfg.CustomNamespace {
+		logger.Warn("Jobs of type 'customNamespace' are deprecated and will be removed soon", "job", customNamespaceJob.Name)
+
 		for _, role := range customNamespaceJob.Roles {
 			for _, region := range customNamespaceJob.Regions {
 				wg.Add(1)


### PR DESCRIPTION
The implementation causes a lot of maintenance work due to code duplication. Scraping custom namespaces can be achieved with a static job.