### PR TITLE
Add counter to see if duplicate metrics are still a problem

### DIFF
--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -27,6 +27,7 @@ var Metrics = []prometheus.Collector{
 	promutil.Ec2APICounter,
 	promutil.DmsAPICounter,
 	promutil.StoragegatewayAPICounter,
+	promutil.DuplicateMetricsFilteredCounter,
 }
 
 const (

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -58,6 +58,10 @@ var (
 		Name: "yace_cloudwatch_dmsapi_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	DuplicateMetricsFilteredCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_duplicate_metrics_filtered",
+		Help: "Help is not implemented yet.",
+	})
 )
 
 var replacer = strings.NewReplacer(
@@ -141,6 +145,8 @@ func removeDuplicatedMetrics(metrics []*PrometheusMetric) []*PrometheusMetric {
 		if _, value := keys[check]; !value {
 			keys[check] = true
 			filteredMetrics = append(filteredMetrics, metric)
+		} else {
+			DuplicateMetricsFilteredCounter.Inc()
 		}
 	}
 	return filteredMetrics


### PR DESCRIPTION
At the end of the scraping process there's logic to remove duplicate metrics, https://github.com/kgeckhart/yet-another-cloudwatch-exporter/blob/c480407b659b5fa334bb47cdc1b9ba14ceefbcfa/pkg/promutil/prometheus.go#L140-L166, which has existed for a long time. I lost the exact changeset but it was somewhere in 2018 before PR's were being done. I'm not sure it's needed anymore and the work it's doing is non-trivial.