### PR TITLE
Support recentlyActive parameter in Cloudwatch API to reduce number of old metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ dimensionNameRequirements:
 # This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes). For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.
 [ roundingPeriod: <int> ]
 
+# Passes down the flag `--recently-active PT3H` to the CloudWatch API. This will only return metrics that have been active in the last 3 hours.
+# This is useful for reducing the number of metrics returned by CloudWatch, which can be very large for some services. See AWS Cloudwatch API docs for [ListMetrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) for more details.
+[ recentlyActiveOnly: <boolean> ]
+
 # List of statistic types, e.g. "Minimum", "Maximum", etc (General Setting for all metrics in this job)
 statistics:
   [ - <string> ... ]
@@ -237,6 +241,10 @@ dimensionNameRequirements:
 # This rounding is optimize performance of the CloudWatch request.
 # This setting only makes sense to use if, for example, you specify a very long period (such as 1 day) but want your times rounded to a shorter time (such as 5 minutes). For example, a value of 300 will round the current time to the nearest 5 minutes. If not specified, the roundingPeriod defaults to the same value as shortest period in the job.
 [ roundingPeriod: <int> ]
+
+# Passes down the flag `--recently-active PT3H` to the CloudWatch API. This will only return metrics that have been active in the last 3 hours.
+# This is useful for reducing the number of metrics returned by CloudWatch, which can be very large for some services. See AWS Cloudwatch API docs for [ListMetrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html) for more details.
+[ recentlyActiveOnly: <boolean> ]
 
 # List of statistic types, e.g. "Minimum", "Maximum", etc (General Setting for all metrics in this job)
 statistics:

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -43,7 +43,7 @@ func NewClient(logger logging.Logger, cloudwatchAPI cloudwatchiface.CloudWatchAP
 	}
 }
 
-func GetListMetricsInput(metricName string, namespace string, recentlyActiveOnly bool) *cloudwatch.ListMetricsInput {
+func getListMetricsInput(metricName string, namespace string, recentlyActiveOnly bool) *cloudwatch.ListMetricsInput {
 	if !recentlyActiveOnly {
 		return &cloudwatch.ListMetricsInput{
 			MetricName: aws.String(metricName),
@@ -59,7 +59,7 @@ func GetListMetricsInput(metricName string, namespace string, recentlyActiveOnly
 }
 
 func (c client) ListMetrics(ctx context.Context, namespace string, metric *config.Metric, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
-	filter := GetListMetricsInput(metric.Name, namespace, recentlyActiveOnly)
+	filter := getListMetricsInput(metric.Name, namespace, recentlyActiveOnly)
 
 	if c.logger.IsDebugEnabled() {
 		c.logger.Debug("ListMetrics", "input", filter)

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -2,11 +2,13 @@ package cloudwatch
 
 import (
 	"context"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
+
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
-	"time"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -43,21 +43,6 @@ func NewClient(logger logging.Logger, cloudwatchAPI cloudwatchiface.CloudWatchAP
 	}
 }
 
-func getListMetricsInput(metricName string, namespace string, recentlyActiveOnly bool) *cloudwatch.ListMetricsInput {
-	if !recentlyActiveOnly {
-		return &cloudwatch.ListMetricsInput{
-			MetricName: aws.String(metricName),
-			Namespace:  aws.String(namespace),
-		}
-	}
-	recentActiveString := "PT3H"
-	return &cloudwatch.ListMetricsInput{
-		MetricName:     aws.String(metricName),
-		Namespace:      aws.String(namespace),
-		RecentlyActive: &recentActiveString,
-	}
-}
-
 func (c client) ListMetrics(ctx context.Context, namespace string, metric *config.Metric, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
 	filter := getListMetricsInput(metric.Name, namespace, recentlyActiveOnly)
 
@@ -88,6 +73,19 @@ func (c client) ListMetrics(ctx context.Context, namespace string, metric *confi
 	}
 
 	return metrics, nil
+}
+
+func getListMetricsInput(metricName string, namespace string, recentlyActiveOnly bool) *cloudwatch.ListMetricsInput {
+	var recentlyActive *string
+	if recentlyActiveOnly {
+		recentlyActive = aws.String("PT3H")
+	}
+
+	return &cloudwatch.ListMetricsInput{
+		MetricName:     aws.String(metricName),
+		Namespace:      aws.String(namespace),
+		RecentlyActive: recentlyActive,
+	}
 }
 
 func toModelMetric(page *cloudwatch.ListMetricsOutput) []*model.Metric {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type Job struct {
 	DimensionNameRequirements []string    `yaml:"dimensionNameRequirements"`
 	Metrics                   []*Metric   `yaml:"metrics"`
 	RoundingPeriod            *int64      `yaml:"roundingPeriod"`
+	RecentlyActiveOnly        bool        `yaml:"recentlyActiveOnly"`
 	JobLevelMetricFields      `yaml:",inline"`
 }
 
@@ -61,6 +62,7 @@ type CustomNamespace struct {
 	Regions                   []string    `yaml:"regions"`
 	Name                      string      `yaml:"name"`
 	Namespace                 string      `yaml:"namespace"`
+	RecentlyActiveOnly        bool        `yaml:"recentlyActiveOnly"`
 	Roles                     []Role      `yaml:"roles"`
 	Metrics                   []*Metric   `yaml:"metrics"`
 	CustomTags                []model.Tag `yaml:"customTags"`

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -102,8 +102,7 @@ func getMetricDataForQueriesForCustomNamespace(
 
 		go func(metric *config.Metric) {
 			defer wg.Done()
-			listMetricsInput := cloudwatch.GetListMetricsInput(customNamespaceJob.Namespace, metric.Name, customNamespaceJob.RecentlyActiveOnly)
-			metricsList, err := clientCloudwatch.ListMetrics(ctx, listMetricsInput, nil)
+			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric, customNamespaceJob.RecentlyActiveOnly, nil)
 			if err != nil {
 				logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", customNamespaceJob.Namespace)
 				return

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -102,7 +102,8 @@ func getMetricDataForQueriesForCustomNamespace(
 
 		go func(metric *config.Metric) {
 			defer wg.Done()
-			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric, nil)
+			listMetricsInput := cloudwatch.GetListMetricsInput(customNamespaceJob.Namespace, metric.Name, customNamespaceJob.RecentlyActiveOnly)
+			metricsList, err := clientCloudwatch.ListMetrics(ctx, listMetricsInput, nil)
 			if err != nil {
 				logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", customNamespaceJob.Namespace)
 				return

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -176,7 +176,7 @@ func getMetricDataForQueries(
 					logger.Debug("associator", assoc)
 				}
 
-				_, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric, func(page []*model.Metric) {
+				_, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric, discoveryJob.RecentlyActiveOnly, func(page []*model.Metric) {
 					data := getFilteredMetricDatas(logger, region, accountID, discoveryJob.Type, discoveryJob.CustomTags, tagsOnMetrics, page, discoveryJob.DimensionNameRequirements, metric, assoc)
 
 					mux.Lock()
@@ -204,7 +204,7 @@ func getMetricDataForQueries(
 					logger.Debug("associator", assoc)
 				}
 
-				metricsList, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric, nil)
+				metricsList, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric.Name, discoveryJob.RecentlyActiveOnly, nil)
 				if err != nil {
 					logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", svc.Namespace)
 					return

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -204,7 +204,7 @@ func getMetricDataForQueries(
 					logger.Debug("associator", assoc)
 				}
 
-				metricsList, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric.Name, discoveryJob.RecentlyActiveOnly, nil)
+				metricsList, err := clientCloudwatch.ListMetrics(ctx, svc.Namespace, metric, discoveryJob.RecentlyActiveOnly, nil)
 				if err != nil {
 					logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", svc.Namespace)
 					return


### PR DESCRIPTION
For certain installations with a lot of instances and a lot of churn in resources (for example EC2 instances), it could be the case that old metrics are not desirable or completely irrelevant. But for the most part, they will still be present in the API if the flag `recentlyActive` is not passed.

This PR adds new configuration to a job in the form of the parameter `recentlyActiveOnly: boolean` - see [AWS docs for cloudwatch](https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/list-metrics.html#options) (scroll for `recentlyActive` parameter).

In some cases the amount of data dropped can be very significant. Example (only change is flipping the `recentlyActiveOnly` flag):

#### recentlyActiveOnly is false
```
$ curl localhost:5001/metrics | wc -l
  528826
  ```
  
#### recentlyActiveOnly is true
```
$ curl localhost:5001/metrics | wc -l
  34028
  ```

Is this addition something you can consider including in YACE?
Thanks