### PR TITLE
Add feature flag to process ListMetrics response during pagination

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -4,12 +4,8 @@ List of features or changes that are disabled by default since they are breaking
 
 You can enable them using the `-enable-feature` flag with a comma separated list of features. They may be enabled by default in future versions.
 
-<!-- 
+## ListMetrics API result processing
 
-## Example
+`-enable-feature=list-metrics-callback`
 
-`-enable-feature=example`
-
-The above is not a real feature, but an example of `feature_flags.md` entry. 
-
--->
+Enables processing of ListMetrics API results page-by-page. This seems to reduce memory usage for high values of `CloudWatchAPIConcurrency`.

--- a/pkg/apicloudwatch/client.go
+++ b/pkg/apicloudwatch/client.go
@@ -13,8 +13,16 @@ import (
 )
 
 type CloudWatchClient interface {
+	// ListMetrics returns the list of metrics and dimensions for a given namespace
+	// and metric name. Results pagination is handled automatically: the caller can
+	// optionally pass a non-nil func in order to handle results pages.
 	ListMetrics(ctx context.Context, namespace string, metric *config.Metric, fn func(page *cloudwatch.ListMetricsOutput)) (*cloudwatch.ListMetricsOutput, error)
+
+	// GetMetricData returns the output of the GetMetricData CloudWatch API.
+	// Results pagination is handled automatically.
 	GetMetricData(ctx context.Context, filter *cloudwatch.GetMetricDataInput) *cloudwatch.GetMetricDataOutput
+
+	// GetMetricStatistics returns the output of the GetMetricStatistics CloudWatch API.
 	GetMetricStatistics(ctx context.Context, filter *cloudwatch.GetMetricStatisticsInput) []*cloudwatch.Datapoint
 }
 

--- a/pkg/config/feature_flags.go
+++ b/pkg/config/feature_flags.go
@@ -7,6 +7,10 @@ var (
 	defaultFeatureFlags = noFeatureFlags{}
 )
 
+// ListMetricsCallback is a feature flag used to enable processing of ListMetrics API
+// results page by page.
+const ListMetricsCallback = "list-metrics-callback"
+
 // FeatureFlags is an interface all objects that can tell wether or not a feature flag is enabled can implement.
 type FeatureFlags interface {
 	// IsFeatureEnabled tells if the feature flag identified by flag is enabled.

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -135,7 +135,7 @@ func getMetricDataForQueriesForCustomNamespace(
 
 		go func(metric *config.Metric) {
 			defer wg.Done()
-			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric)
+			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric, nil)
 			if err != nil {
 				logger.Error(err, "Failed to get full metric list", "metric_name", metric.Name, "namespace", customNamespaceJob.Namespace)
 				return


### PR DESCRIPTION
Allow processing ListMetrics API results page-by-page rather than all at once, which should reduce peak memory usage at the expense of slightly higher processing time.

This is currently opt-in behind a new feature flag.