### PR TITLE
Add Auto Discovery Support For Sagemaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Only the latest version gets security updates. We won't support older versions.
   * route53 (AWS/Route53) - Route53 Health Checks
   * route53-resolver (AWS/Route53Resolver) - Route53 Resolver
   * s3 (AWS/S3) - Object Storage
+  * sagemaker - Sagemaker invocations
+  * sagemaker-endpoints - Sagemaker Endpoints
+  * sagemaker-training - Sagemaker Training Jobs
+  * sagemaker-processing - Sagemaker Processing Jobs
+  * sagemaker-transform - Sagemaker Batch Transform Jobs
+  * sagemaker-inf-rec - Sagemaker Inference Recommender Jobs
+  * sagemaker-model-building - Sagemaker Model Building Pipelines
   * ses (AWS/SES) - Simple Email Service
   * shield (AWS/DDoSProtection) - Distributed Denial of Service (DDoS) protection service
   * sqs (AWS/SQS) - Simple Queue Service

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -726,4 +726,53 @@ var SupportedServices = serviceConfigs{
 			regexp.MustCompile(":collection/(?P<CollectionId>[^/]+)"),
 		},
 	},
+	{
+		Namespace: "AWS/SageMaker",
+		Alias:     "sagemaker",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "/aws/sagemaker/Endpoints",
+		Alias:     "sagemaker-endpoints",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "/aws/sagemaker/TrainingJobs",
+		Alias:     "sagemaker-training",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "/aws/sagemaker/ProcessingJobs",
+		Alias:     "sagemaker-processing",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "/aws/sagemaker/TransformJobs",
+		Alias:     "sagemaker-transform",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "/aws/sagemaker/InferenceRecommendationsJobs",
+		Alias:     "sagemaker-inf-rec",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
+	{
+		Namespace: "AWS/Sagemaker/ModelBuildingPipeline",
+		Alias:     "sagemaker-model-building",
+		ResourceFilters: []*string{
+			aws.String("sagemaker"),
+		},
+	},
 }

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -732,12 +732,18 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("sagemaker"),
 		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":endpoint/(?P<EndpointName>[^/]+)$"),
+		},
 	},
 	{
 		Namespace: "/aws/sagemaker/Endpoints",
 		Alias:     "sagemaker-endpoints",
 		ResourceFilters: []*string{
 			aws.String("sagemaker"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":endpoint/(?P<EndpointName>[^/]+)$"),
 		},
 	},
 	{
@@ -770,9 +776,12 @@ var SupportedServices = serviceConfigs{
 	},
 	{
 		Namespace: "AWS/Sagemaker/ModelBuildingPipeline",
-		Alias:     "sagemaker-model-building",
+		Alias:     "sagemaker-model-building-pipeline",
 		ResourceFilters: []*string{
 			aws.String("sagemaker"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":pipeline/(?P<PipelineName>[^/]+)"),
 		},
 	},
 }

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -730,7 +730,7 @@ var SupportedServices = serviceConfigs{
 		Namespace: "AWS/SageMaker",
 		Alias:     "sagemaker",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:endpoint"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":endpoint/(?P<EndpointName>[^/]+)$"),
@@ -740,7 +740,7 @@ var SupportedServices = serviceConfigs{
 		Namespace: "/aws/sagemaker/Endpoints",
 		Alias:     "sagemaker-endpoints",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:endpoint"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":endpoint/(?P<EndpointName>[^/]+)$"),
@@ -750,35 +750,38 @@ var SupportedServices = serviceConfigs{
 		Namespace: "/aws/sagemaker/TrainingJobs",
 		Alias:     "sagemaker-training",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:training-job"),
 		},
 	},
 	{
 		Namespace: "/aws/sagemaker/ProcessingJobs",
 		Alias:     "sagemaker-processing",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:processing-job"),
 		},
 	},
 	{
 		Namespace: "/aws/sagemaker/TransformJobs",
 		Alias:     "sagemaker-transform",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:transform-job"),
 		},
 	},
 	{
 		Namespace: "/aws/sagemaker/InferenceRecommendationsJobs",
 		Alias:     "sagemaker-inf-rec",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:inference-recommendations-job"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":inference-recommendations-job/(?P<JobName>[^/]+)"),
 		},
 	},
 	{
 		Namespace: "AWS/Sagemaker/ModelBuildingPipeline",
 		Alias:     "sagemaker-model-building-pipeline",
 		ResourceFilters: []*string{
-			aws.String("sagemaker"),
+			aws.String("sagemaker:pipeline"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":pipeline/(?P<PipelineName>[^/]+)"),

--- a/pkg/job/maxdimassociator/associator.go
+++ b/pkg/job/maxdimassociator/associator.go
@@ -1,7 +1,6 @@
 package maxdimassociator
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -123,7 +122,6 @@ func (assoc Associator) AssociateMetricToResource(cwMetric *model.Metric) (*mode
 	// the dimensions of the mapping to build a labels signature.
 	labels := buildLabelsMap(cwMetric, regexpMapping)
 	signature := prom_model.LabelsToSignature(labels)
-	fmt.Println(labels)
 	if resource, ok := regexpMapping.dimensionsMapping[signature]; ok {
 		return resource, false
 	}
@@ -149,13 +147,6 @@ func buildLabelsMap(cwMetric *model.Metric, regexpMapping *dimensionsRegexpMappi
 				brokerSuffix := regexp.MustCompile("-[0-9]+$")
 				if brokerSuffix.MatchString(value) {
 					value = brokerSuffix.ReplaceAllString(value, "")
-				}
-			}
-
-			if cwMetric.Namespace == "/aws/sagemaker/TrainingJobs" && name == "Host" {
-				hostSuffix := regexp.MustCompile("/algo-[0-9]+$")
-				if hostSuffix.MatchString(value) {
-					value = hostSuffix.ReplaceAllString(value, "")
 				}
 			}
 

--- a/pkg/job/maxdimassociator/associator.go
+++ b/pkg/job/maxdimassociator/associator.go
@@ -1,6 +1,7 @@
 package maxdimassociator
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/grafana/regexp"
@@ -122,7 +123,7 @@ func (assoc Associator) AssociateMetricToResource(cwMetric *model.Metric) (*mode
 	// the dimensions of the mapping to build a labels signature.
 	labels := buildLabelsMap(cwMetric, regexpMapping)
 	signature := prom_model.LabelsToSignature(labels)
-
+	fmt.Println(labels)
 	if resource, ok := regexpMapping.dimensionsMapping[signature]; ok {
 		return resource, false
 	}
@@ -148,6 +149,13 @@ func buildLabelsMap(cwMetric *model.Metric, regexpMapping *dimensionsRegexpMappi
 				brokerSuffix := regexp.MustCompile("-[0-9]+$")
 				if brokerSuffix.MatchString(value) {
 					value = brokerSuffix.ReplaceAllString(value, "")
+				}
+			}
+
+			if cwMetric.Namespace == "/aws/sagemaker/TrainingJobs" && name == "Host" {
+				hostSuffix := regexp.MustCompile("/algo-[0-9]+$")
+				if hostSuffix.MatchString(value) {
+					value = hostSuffix.ReplaceAllString(value, "")
 				}
 			}
 

--- a/pkg/job/maxdimassociator/associator.go
+++ b/pkg/job/maxdimassociator/associator.go
@@ -122,6 +122,7 @@ func (assoc Associator) AssociateMetricToResource(cwMetric *model.Metric) (*mode
 	// the dimensions of the mapping to build a labels signature.
 	labels := buildLabelsMap(cwMetric, regexpMapping)
 	signature := prom_model.LabelsToSignature(labels)
+
 	if resource, ok := regexpMapping.dimensionsMapping[signature]; ok {
 		return resource, false
 	}

--- a/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
@@ -1,0 +1,87 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerEndpointHealthOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:endpoint/example-endpoint-one",
+	Namespace: "/aws/sagemaker/Endpoints",
+}
+
+var sagemakerEndpointHealthTwo = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:endpoint/example-endpoint-two",
+	Namespace: "/aws/sagemaker/Endpoints",
+}
+
+var sagemakerHealthResources = []*model.TaggedResource{
+	sagemakerEndpointHealthOne,
+	sagemakerEndpointHealthTwo,
+}
+
+func TestAssociatorSagemakerEndpoint(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "2 dimenions should match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
+				resources:        sagemakerHealthResources,
+				metric: &model.Metric{
+					MetricName: "MemoryUtilization",
+					Namespace:  "/aws/sagemaker/Endpoints",
+					Dimensions: []*model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-two"},
+						{Name: "VariantName", Value: "example-endpoint-two-variant-one"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerEndpointHealthTwo,
+		},
+		{
+			name: "2 dimenions should not match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
+				resources:        sagemakerHealthResources,
+				metric: &model.Metric{
+					MetricName: "MemoryUtilization",
+					Namespace:  "/aws/sagemaker/Endpoints",
+					Dimensions: []*model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-three"},
+						{Name: "VariantName", Value: "example-endpoint-three-variant-one"},
+					},
+				},
+			},
+			expectedSkip:     true,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
@@ -41,7 +41,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "2 dimenions should match",
+			name: "2 dimensions should match",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
 				resources:        sagemakerHealthResources,
@@ -58,7 +58,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 			expectedResource: sagemakerEndpointHealthTwo,
 		},
 		{
-			name: "2 dimenions should not match",
+			name: "2 dimensions should not match",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
 				resources:        sagemakerHealthResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
@@ -1,0 +1,63 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerInfRecJobOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:inference-recommendations-job/example-inf-rec-job-one",
+	Namespace: "/aws/sagemaker/InferenceRecommendationsJobs",
+}
+
+var sagemakerInfRecJobResources = []*model.TaggedResource{
+	sagemakerInfRecJobOne,
+}
+
+func TestAssociatorSagemakerInfRecJob(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "1 dimenion should not match but not skip",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/InferenceRecommendationsJobs").DimensionRegexps,
+				resources:        sagemakerInfRecJobResources,
+				metric: &model.Metric{
+					MetricName: "ClientInvocations",
+					Namespace:  "/aws/sagemaker/InferenceRecommendationsJobs",
+					Dimensions: []*model.Dimension{
+						{Name: "JobName", Value: "example-inf-rec-job-one"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerInfRecJobOne,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
@@ -35,7 +35,7 @@ func TestAssociatorSagemakerInfRecJob(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "1 dimenion should not match but not skip",
+			name: "1 dimension should not match but not skip",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/InferenceRecommendationsJobs").DimensionRegexps,
 				resources:        sagemakerInfRecJobResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
@@ -58,7 +58,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 			expectedResource: sagemakerPipelineOne,
 		},
 		{
-			name: "1 dimenion should match",
+			name: "1 dimension should match",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
 				resources:        sagemakerPipelineResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
@@ -1,0 +1,103 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerPipelineOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:pipeline/example-pipeline-one",
+	Namespace: "AWS/Sagemaker/ModelBuildingPipeline",
+}
+
+var sagemakerPipelineTwo = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:pipeline/example-pipeline-two",
+	Namespace: "AWS/Sagemaker/ModelBuildingPipeline",
+}
+
+var sagemakerPipelineResources = []*model.TaggedResource{
+	sagemakerPipelineOne,
+	sagemakerPipelineTwo,
+}
+
+func TestAssociatorSagemakerPipeline(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "2 dimensions should match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				resources:        sagemakerPipelineResources,
+				metric: &model.Metric{
+					MetricName: "ExecutionStarted",
+					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
+					Dimensions: []*model.Dimension{
+						{Name: "PipelineName", Value: "example-pipeline-one"},
+						{Name: "StepName", Value: "example-pipeline-one-step-two"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerPipelineOne,
+		},
+		{
+			name: "1 dimenion should match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				resources:        sagemakerPipelineResources,
+				metric: &model.Metric{
+					MetricName: "ExecutionStarted",
+					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
+					Dimensions: []*model.Dimension{
+						{Name: "PipelineName", Value: "example-pipeline-two"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerPipelineTwo,
+		},
+		{
+			name: "2 dimensions should not match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				resources:        sagemakerPipelineResources,
+				metric: &model.Metric{
+					MetricName: "ExecutionStarted",
+					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
+					Dimensions: []*model.Dimension{
+						{Name: "PipelineName", Value: "example-pipeline-three"},
+						{Name: "StepName", Value: "example-pipeline-three-step-two"},
+					},
+				},
+			},
+			expectedSkip:     true,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
@@ -35,7 +35,7 @@ func TestAssociatorSagemakerProcessingJob(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "1 dimenion should not match but not skip",
+			name: "1 dimension should not match but not skip",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/ProcessingJobs").DimensionRegexps,
 				resources:        sagemakerProcessingJobResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
@@ -1,0 +1,63 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerProcessingJobOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:processing-job/example-processing-job-one",
+	Namespace: "/aws/sagemaker/ProcessingJobs",
+}
+
+var sagemakerProcessingJobResources = []*model.TaggedResource{
+	sagemakerProcessingJobOne,
+}
+
+func TestAssociatorSagemakerProcessingJob(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "1 dimenion should not match but not skip",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/ProcessingJobs").DimensionRegexps,
+				resources:        sagemakerProcessingJobResources,
+				metric: &model.Metric{
+					MetricName: "CPUUtilization",
+					Namespace:  "/aws/sagemaker/ProcessingJobs",
+					Dimensions: []*model.Dimension{
+						{Name: "Host", Value: "example-processing-job-one/algo-1"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -76,7 +76,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 			expectedResource: sagemakerEndpointInvocationTwo,
 		},
 		{
-			name: "2 dimenions should not match",
+			name: "2 dimensions should not match",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
 				resources:        sagemakerInvocationResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -1,0 +1,105 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerEndpointInvocationOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:endpoint/example-endpoint-one",
+	Namespace: "AWS/SageMaker",
+}
+
+var sagemakerEndpointInvocationTwo = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:endpoint/example-endpoint-two",
+	Namespace: "AWS/SageMaker",
+}
+
+var sagemakerInvocationResources = []*model.TaggedResource{
+	sagemakerEndpointInvocationOne,
+	sagemakerEndpointInvocationTwo,
+}
+
+func TestAssociatorSagemaker(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "3 dimensions should match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				resources:        sagemakerInvocationResources,
+				metric: &model.Metric{
+					MetricName: "Invocations",
+					Namespace:  "AWS/SageMaker",
+					Dimensions: []*model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-one"},
+						{Name: "VariantName", Value: "example-endpoint-one-variant-one"},
+						{Name: "EndpointConfigName", Value: "example-endpoint-one-endpoint-config"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerEndpointInvocationOne,
+		},
+		{
+			name: "2 dimenions should match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				resources:        sagemakerInvocationResources,
+				metric: &model.Metric{
+					MetricName: "Invocations",
+					Namespace:  "AWS/SageMaker",
+					Dimensions: []*model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-two"},
+						{Name: "VariantName", Value: "example-endpoint-two-variant-one"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerEndpointInvocationTwo,
+		},
+		{
+			name: "2 dimenions should not match",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				resources:        sagemakerInvocationResources,
+				metric: &model.Metric{
+					MetricName: "Invocations",
+					Namespace:  "AWS/SageMaker",
+					Dimensions: []*model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-three"},
+						{Name: "VariantName", Value: "example-endpoint-three-variant-one"},
+					},
+				},
+			},
+			expectedSkip:     true,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -59,7 +59,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 			expectedResource: sagemakerEndpointInvocationOne,
 		},
 		{
-			name: "2 dimenions should match",
+			name: "2 dimensions should match",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
 				resources:        sagemakerInvocationResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
@@ -1,0 +1,63 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerTrainingJobOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:training-job/example-training-job-one",
+	Namespace: "/aws/sagemaker/TrainingJobs",
+}
+
+var sagemakerTrainingJobResources = []*model.TaggedResource{
+	sagemakerTrainingJobOne,
+}
+
+func TestAssociatorSagemakerTrainingJob(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "1 dimenion should not match but not skip",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TrainingJobs").DimensionRegexps,
+				resources:        sagemakerTrainingJobResources,
+				metric: &model.Metric{
+					MetricName: "CPUUtilization",
+					Namespace:  "/aws/sagemaker/TrainingJobs",
+					Dimensions: []*model.Dimension{
+						{Name: "Host", Value: "example-training-job-one/algo-1"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
@@ -35,7 +35,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "1 dimension should not match but not skip",
+			name: "1 dimension should not skip",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TrainingJobs").DimensionRegexps,
 				resources:        sagemakerTrainingJobResources,
@@ -48,7 +48,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 				},
 			},
 			expectedSkip:     false,
-			expectedResource: sagemakerTrainingJobOne,
+			expectedResource: nil,
 		},
 	}
 

--- a/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
@@ -35,7 +35,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "1 dimenion should not match but not skip",
+			name: "1 dimension should not match but not skip",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TrainingJobs").DimensionRegexps,
 				resources:        sagemakerTrainingJobResources,
@@ -48,7 +48,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 				},
 			},
 			expectedSkip:     false,
-			expectedResource: nil,
+			expectedResource: sagemakerTrainingJobOne,
 		},
 	}
 

--- a/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
@@ -35,7 +35,7 @@ func TestAssociatorSagemakerTransformJob(t *testing.T) {
 
 	testcases := []testCase{
 		{
-			name: "1 dimenion should not match but not skip",
+			name: "1 dimension should not match but not skip",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TransformJobs").DimensionRegexps,
 				resources:        sagemakerTransformJobResources,

--- a/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
@@ -1,0 +1,63 @@
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/grafana/regexp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var sagemakerTransformJobOne = &model.TaggedResource{
+	ARN:       "arn:aws:sagemaker:us-west-2:123456789012:transform-job/example-transform-job-one",
+	Namespace: "/aws/sagemaker/TransformJobs",
+}
+
+var sagemakerTransformJobResources = []*model.TaggedResource{
+	sagemakerTransformJobOne,
+}
+
+func TestAssociatorSagemakerTransformJob(t *testing.T) {
+	type args struct {
+		dimensionRegexps []*regexp.Regexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "1 dimenion should not match but not skip",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TransformJobs").DimensionRegexps,
+				resources:        sagemakerTransformJobResources,
+				metric: &model.Metric{
+					MetricName: "CPUUtilization",
+					Namespace:  "/aws/sagemaker/TransformJobs",
+					Dimensions: []*model.Dimension{
+						{Name: "Host", Value: "example-transform-job-one/algo-1"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}


### PR DESCRIPTION
Sagemaker has several tools that generate metrics under different namepsaces. Working based on the AWS [documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/monitoring-cloudwatch.html), adding the following:

- AWS/SageMaker - model invocation and loading metrics 
- /aws/sagemaker/Endpoints - Sagemaker Endpoint health metrics
- /aws/sagemaker/TrainingJobs - Training job metrics
- /aws/sagemaker/ProcessingJobs - Processing job metrics
- /aws/sagemaker/TransformJobs - Batch transform job metrics
- /aws/sagemaker/InferenceRecommendationsJobs - Inference Recommender metrics
- AWS/Sagemaker/ModelBuildingPipeline - Model pipeline metrics
