### PR TITLE
Refactor clients.Cache -> clients.Factory

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -192,13 +192,13 @@ func startScraper(c *cli.Context) error {
 	featureFlags := c.StringSlice(enableFeatureFlag)
 
 	s := NewScraper(featureFlags)
-	cache := v1.NewClientCache(cfg, fips, logger)
+	var cache cachingFactory = v1.NewFactory(cfg, fips, logger)
 	for _, featureFlag := range featureFlags {
 		if featureFlag == config.AwsSdkV2 {
 			logger.Info("Using aws sdk v2")
 			var err error
 			// Can't override cache while also creating err
-			cache, err = v2.NewCache(cfg, fips, logger)
+			cache, err = v2.NewFactory(cfg, fips, logger)
 			if err != nil {
 				return fmt.Errorf("failed to construct aws sdk v2 client cache: %w", err)
 			}
@@ -246,13 +246,13 @@ func startScraper(c *cli.Context) error {
 		}
 
 		logger.Info("Reset clients cache")
-		cache = v1.NewClientCache(cfg, fips, logger)
+		cache = v1.NewFactory(cfg, fips, logger)
 		for _, featureFlag := range featureFlags {
 			if featureFlag == config.AwsSdkV2 {
 				logger.Info("Using aws sdk v2")
 				var err error
 				// Can't override cache while also creating err
-				cache, err = v2.NewCache(cfg, fips, logger)
+				cache, err = v2.NewFactory(cfg, fips, logger)
 				if err != nil {
 					logger.Error(err, "Failed to construct aws sdk v2 client cache", "path", configFile)
 					return

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -18,6 +18,12 @@ type scraper struct {
 	featureFlags []string
 }
 
+type cachingFactory interface {
+	clients.Factory
+	Refresh()
+	Clear()
+}
+
 func NewScraper(featureFlags []string) *scraper { //nolint:revive
 	return &scraper{
 		registry:     prometheus.NewRegistry(),
@@ -34,7 +40,7 @@ func (s *scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache clients.Cache) {
+func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache cachingFactory) {
 	logger.Debug("Starting scraping async")
 	s.scrape(ctx, logger, cache)
 
@@ -53,7 +59,7 @@ func (s *scraper) decoupled(ctx context.Context, logger logging.Logger, cache cl
 	}
 }
 
-func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache clients.Cache) {
+func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache cachingFactory) {
 	if !sem.TryAcquire(1) {
 		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
 		// Let them know by logging a warning.
@@ -70,6 +76,11 @@ func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache clien
 		}
 	}
 
+	// since we have called refresh, we have loaded all the credentials
+	// into the clients and it is now safe to call concurrently. Defer the
+	// clearing, so we always clear credentials before the next scrape
+	cache.Refresh()
+	defer cache.Clear()
 	err := exporter.UpdateMetrics(
 		ctx,
 		logger,

--- a/pkg/clients/README.md
+++ b/pkg/clients/README.md
@@ -26,7 +26,7 @@ the differences in implementation are largely superficial.
 
 # Ensuring v1 and v2 stay in sync
 Since we are in a transition state from sdk v1 to sdk v2 it's very important that we maintain as much feature parity as possible
-between the two implementations. Cache/client interface changes are relatively easy to keep in sync since changes need to be
+between the two implementations. Factory/client interface changes are relatively easy to keep in sync since changes need to be
 made to v1 and v2 implementations. Other areas are not quite so obvious such as
 
 ## /clients/tagging/v_/filters.go serviceFilters

--- a/pkg/clients/factory.go
+++ b/pkg/clients/factory.go
@@ -7,14 +7,10 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 )
 
-// Cache is an interface to a cache aws clients for all the
-// roles specified by the exporter. For jobs with many duplicate roles, this provides
-// relief to the AWS API and prevents timeouts by excessive credential requesting.
-type Cache interface {
+// Factory is an interface to abstract away all logic required to produce the different
+// YACE specific clients which wrap AWS clients
+type Factory interface {
 	GetCloudwatchClient(region string, role config.Role, concurrencyLimit int) cloudwatch_client.Client
 	GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client
 	GetAccountClient(region string, role config.Role) account.Client
-
-	Refresh()
-	Clear()
 }

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -121,12 +121,12 @@ func defaultOptions() options {
 // Parameters are:
 // - `ctx`: a context for the request
 // - `config`: this is the struct representation of the configuration defined in top-level configuration
-// - `logger`: any implementation of the `Logger` interface
+// - `logger`: any implementation of the `logging.Logger` interface
 // - `registry`: any prometheus compatible registry where scraped AWS metrics will be written
-// - `cache`: any implementation of the `Cache`
+// - `factory`: any implementation of the `clients.Factory` interface
 // - `optFuncs`: (optional) any number of options funcs
 //
-// You can pre-register any of the default metrics with the provided `registry` if you want them
+// You can pre-register any of the default metrics from `Metrics` with the provided `registry` if you want them
 // included in the AWS scrape results. If you are using multiple instances of `registry` it
 // might make more sense to register these metrics in the application using YACE as a library to better
 // track them over the lifetime of the application.
@@ -135,7 +135,7 @@ func UpdateMetrics(
 	logger logging.Logger,
 	cfg config.ScrapeConf,
 	registry *prometheus.Registry,
-	cache clients.Cache,
+	factory clients.Factory,
 	optFuncs ...OptionsFunc,
 ) error {
 	options := defaultOptions()
@@ -152,7 +152,7 @@ func UpdateMetrics(
 		ctx,
 		logger,
 		cfg,
-		cache,
+		factory,
 		options.metricsPerQuery,
 		options.cloudWatchAPIConcurrency,
 		options.taggingAPIConcurrency,


### PR DESCRIPTION
This change refactors `clients.Cache` to `clients.Factory` and removes the cache specific functions of `Refresh` and `Clear`.

As a part of using YACE as a library someone might choose to provide a custom implementation of `clients.Cache` when calling `UpdateMetrics`. I don't think the code in `UpdateMetrics` cares if the implementation of this interface actually caches them. I think it only cares that the implementation can provide the clients. This seems to lend itself more to a factory at this level with the "caching" requirement coming from YACE calling the library entrypoint. 

The only requirement for it to be a cache comes from the fact that `UpdateMetrics` is eventually responsible for calling `Refresh` and `Clear`. I don't think there's any particular reason `UpdateMetrics` needs to be responsible for this and I moved those calls wrap the call to `UpdateMetrics` instead.

I think this is technically a breaking change to the library entrypoint since any consumer providing a cache based implementation is now required to handle that before calling the entrypoint.