### PR TITLE
Validate should fail when no roles are configured

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,6 +189,8 @@ func (j *Job) validateDiscoveryJob(jobIdx int) error {
 				return err
 			}
 		}
+	} else {
+		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
 	}
 	if len(j.Regions) == 0 {
 		return fmt.Errorf("Discovery job [%s/%d]: Regions should not be empty", j.Type, jobIdx)
@@ -220,6 +222,8 @@ func (j *CustomNamespace) validateCustomNamespaceJob(jobIdx int) error {
 				return err
 			}
 		}
+	} else {
+		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
 	}
 	if j.Regions == nil || len(j.Regions) == 0 {
 		return fmt.Errorf("CustomNamespace job [%s/%d]: Regions should not be empty", j.Name, jobIdx)
@@ -251,6 +255,8 @@ func (j *Static) validateStaticJob(jobIdx int) error {
 				return err
 			}
 		}
+	} else {
+		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
 	}
 	if len(j.Regions) == 0 {
 		return fmt.Errorf("Static job [%s/%d]: Regions should not be empty", j.Name, jobIdx)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,7 +190,7 @@ func (j *Job) validateDiscoveryJob(jobIdx int) error {
 			}
 		}
 	} else {
-		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
+		return fmt.Errorf("no IAM roles configured. If the current IAM role is desired, an empty Role should be configured")
 	}
 	if len(j.Regions) == 0 {
 		return fmt.Errorf("Discovery job [%s/%d]: Regions should not be empty", j.Type, jobIdx)
@@ -223,7 +223,7 @@ func (j *CustomNamespace) validateCustomNamespaceJob(jobIdx int) error {
 			}
 		}
 	} else {
-		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
+		return fmt.Errorf("no IAM roles configured. If the current IAM role is desired, an empty Role should be configured")
 	}
 	if j.Regions == nil || len(j.Regions) == 0 {
 		return fmt.Errorf("CustomNamespace job [%s/%d]: Regions should not be empty", j.Name, jobIdx)
@@ -256,7 +256,7 @@ func (j *Static) validateStaticJob(jobIdx int) error {
 			}
 		}
 	} else {
-		return fmt.Errorf("No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.")
+		return fmt.Errorf("no IAM roles configured. If the current IAM role is desired, an empty Role should be configured")
 	}
 	if len(j.Regions) == 0 {
 		return fmt.Errorf("Static job [%s/%d]: Regions should not be empty", j.Name, jobIdx)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/stretchr/testify/require"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
 
 func TestConfLoad(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -97,7 +97,7 @@ func TestValidateConfigFailuresWhenUsingAsLibrary(t *testing.T) {
 					}},
 				},
 			},
-			errorMsg: "No IAM roles configured. If the current IAM role is desired, an empty Role should be configured.",
+			errorMsg: "no IAM roles configured. If the current IAM role is desired, an empty Role should be configured",
 		},
 	}
 


### PR DESCRIPTION
In YACE, when the environment configured role is desired, no `roles` configuration is added in each job. The `Load` function [is responsible](https://github.com/nerdswords/yet-another-cloudwatch-exporter/blob/30aeceb2324763cdd024a1311045f83a09c1df36/pkg/config/config.go#L111) for configuring in the `Roles` field an empty role struct. 

However, when using yace as library, this has to be done manually. Even more, `Validate` succeeds if no roles at all are configured, making YACE to run without even scraping anything due do that main loops iterate over all roles.

This PR makes `Validate` fail when no roles are configured (not even the empty one).