### PR TITLE
ddos protection: Discover resources outside us-east-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,7 @@ This permission is required to discover resources for the AWS/TransitGateway nam
 
 This permission is required to discover protected resources for the AWS/DDoSProtection namespace
 ```json
-"storagegateway:ListGateways",
-"storagegateway:ListTagsForResource"
+"shield:ListProtections"
 ```
 
 If running YACE inside an AWS EC2 instance, the exporter will automatically attempt to assume the associated IAM Role. If this is undesirable behavior turn off the use the metadata endpoint by setting the environment variable `AWS_EC2_METADATA_DISABLED=true`.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ As a quick start, the following IAM policy can be used to grant the all permissi
         "dms:DescribeReplicationTasks",
         "ec2:DescribeTransitGatewayAttachments",
         "ec2:DescribeSpotFleetRequests",
+        "shield:ListProtections",
         "storagegateway:ListGateways",
         "storagegateway:ListTagsForResource"
       ],
@@ -202,6 +203,12 @@ These permissions are required to discover resources for the AWS/StorageGateway 
 This permission is required to discover resources for the AWS/TransitGateway namespace
 ```json
 "ec2:DescribeTransitGatewayAttachments"
+```
+
+This permission is required to discover protected resources for the AWS/DDoSProtection namespace
+```json
+"storagegateway:ListGateways",
+"storagegateway:ListTagsForResource"
 ```
 
 If running YACE inside an AWS EC2 instance, the exporter will automatically attempt to assume the associated IAM Role. If this is undesirable behavior turn off the use the metadata endpoint by setting the environment variable `AWS_EC2_METADATA_DISABLED=true`.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.25.7
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.102.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.14
+	github.com/aws/aws-sdk-go-v2/service/shield v1.18.12
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.18.14
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/smithy-go v1.13.5

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28 h1:bkRyG4a92
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.28/go.mod h1:jj7znCIg05jXlaGBlFMGP8+7UN3VtCkRBG2spnmRQkU=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.14 h1:6AuIiaZ+oRhprPZw2/siZQcaZRvmKipjGbmGI0BSGsA=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.14.14/go.mod h1:w4zYOP9Y8sYBattA+ysl0tDy72+aO6a3d6FrkK2FgZc=
+github.com/aws/aws-sdk-go-v2/service/shield v1.18.12 h1:iRC4Poa5Du3y9HtY1doQIQWnVxN4HrNY/ytvPws+TKU=
+github.com/aws/aws-sdk-go-v2/service/shield v1.18.12/go.mod h1:nE8wrh0UlW7aQsO6paSvpLwskeHwgcMmFx6YToctTsg=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.12 h1:nneMBM2p79PGWBQovYO/6Xnc2ryRMw3InnDJq1FHkSY=
 github.com/aws/aws-sdk-go-v2/service/sso v1.12.12/go.mod h1:HuCOxYsF21eKrerARYO6HapNeh9GBNq7fius2AcwodY=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.12 h1:2qTR7IFk7/0IN/adSFhYu9Xthr0zVFTgBrmPldILn80=

--- a/pkg/clients/tagging/implementation_test.go
+++ b/pkg/clients/tagging/implementation_test.go
@@ -1,0 +1,33 @@
+package tagging_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging/v1"
+	v2 "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging/v2"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+)
+
+func Test_Services_Have_Filters_In_V1_and_V2(t *testing.T) {
+	for _, service := range config.SupportedServices {
+		namespace := service.Namespace
+		t.Run(fmt.Sprintf("%s has filter definitions in v1 and v2", namespace), func(t *testing.T) {
+			v1Filters, v1Exists := v1.ServiceFilters[namespace]
+			v2Filters, v2Exists := v2.ServiceFilters[namespace]
+
+			require.Equal(t, v1Exists, v2Exists, "Service filters are only implemented for v1 or v2 but should be implemented for both")
+
+			v1FilterFuncNil := v1Filters.FilterFunc == nil
+			v2FilterFuncNil := v2Filters.FilterFunc == nil
+			assert.Equal(t, v1FilterFuncNil, v2FilterFuncNil, "FilterFunc is only implemented for v1 or v2 but should be implemented for both")
+
+			v1ResourceFuncNil := v1Filters.ResourceFunc == nil
+			v2ResourceFuncNil := v2Filters.ResourceFunc == nil
+			assert.Equal(t, v1ResourceFuncNil, v2ResourceFuncNil, "ResourceFunc is only implemented for v1 or v2 but should be implemented for both")
+		})
+	}
+}

--- a/pkg/clients/tagging/v1/client.go
+++ b/pkg/clients/tagging/v1/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/prometheusservice/prometheusserviceiface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
+	"github.com/aws/aws-sdk-go/service/shield/shieldiface"
 	"github.com/aws/aws-sdk-go/service/storagegateway/storagegatewayiface"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging"
@@ -32,6 +33,7 @@ type client struct {
 	dmsAPI            databasemigrationserviceiface.DatabaseMigrationServiceAPI
 	prometheusSvcAPI  prometheusserviceiface.PrometheusServiceAPI
 	storageGatewayAPI storagegatewayiface.StorageGatewayAPI
+	shieldAPI         shieldiface.ShieldAPI
 }
 
 func NewClient(
@@ -44,6 +46,7 @@ func NewClient(
 	dmsClient databasemigrationserviceiface.DatabaseMigrationServiceAPI,
 	prometheusClient prometheusserviceiface.PrometheusServiceAPI,
 	storageGatewayAPI storagegatewayiface.StorageGatewayAPI,
+	shieldAPI shieldiface.ShieldAPI,
 ) tagging.Client {
 	return &client{
 		logger:            logger,
@@ -55,6 +58,7 @@ func NewClient(
 		dmsAPI:            dmsClient,
 		prometheusSvcAPI:  prometheusClient,
 		storageGatewayAPI: storageGatewayAPI,
+		shieldAPI:         shieldAPI,
 	}
 }
 
@@ -102,7 +106,7 @@ func (c client) GetResources(ctx context.Context, job *config.Job, region string
 		c.logger.Debug("GetResourcesPages finished", "total", len(resources))
 	}
 
-	if ext, ok := serviceFilters[svc.Namespace]; ok {
+	if ext, ok := ServiceFilters[svc.Namespace]; ok {
 		if ext.ResourceFunc != nil {
 			shouldHaveDiscoveredResources = true
 			newResources, err := ext.ResourceFunc(ctx, c, job, region)

--- a/pkg/clients/tagging/v1/filters_test.go
+++ b/pkg/clients/tagging/v1/filters_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestValidServiceNames(t *testing.T) {
-	for svc, filter := range serviceFilters {
+	for svc, filter := range ServiceFilters {
 		if config.SupportedServices.GetService(svc) == nil {
 			t.Errorf("invalid service name '%s'", svc)
 			t.Fail()
@@ -176,7 +176,7 @@ func TestApiGatewayFilterFunc(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			apigateway := serviceFilters["AWS/ApiGateway"]
+			apigateway := ServiceFilters["AWS/ApiGateway"]
 
 			outputResources, err := apigateway.FilterFunc(context.Background(), test.iface, test.inputResources)
 			if err != nil {
@@ -391,7 +391,7 @@ func TestDMSFilterFunc(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			dms := serviceFilters["AWS/DMS"]
+			dms := ServiceFilters["AWS/DMS"]
 
 			outputResources, err := dms.FilterFunc(context.Background(), test.iface, test.inputResources)
 			if err != nil {

--- a/pkg/clients/tagging/v2/client.go
+++ b/pkg/clients/tagging/v2/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/aws/aws-sdk-go-v2/service/storagegateway"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging"
@@ -31,6 +32,7 @@ type client struct {
 	dmsAPI            *databasemigrationservice.Client
 	prometheusSvcAPI  *amp.Client
 	storageGatewayAPI *storagegateway.Client
+	shieldAPI         *shield.Client
 }
 
 func NewClient(
@@ -43,6 +45,7 @@ func NewClient(
 	dmsClient *databasemigrationservice.Client,
 	prometheusClient *amp.Client,
 	storageGatewayAPI *storagegateway.Client,
+	shieldAPI *shield.Client,
 ) tagging.Client {
 	return &client{
 		logger:            logger,
@@ -54,6 +57,7 @@ func NewClient(
 		dmsAPI:            dmsClient,
 		prometheusSvcAPI:  prometheusClient,
 		storageGatewayAPI: storageGatewayAPI,
+		shieldAPI:         shieldAPI,
 	}
 }
 

--- a/pkg/clients/tagging/v2/client.go
+++ b/pkg/clients/tagging/v2/client.go
@@ -110,7 +110,7 @@ func (c client) GetResources(ctx context.Context, job *config.Job, region string
 		c.logger.Debug("GetResourcesPages finished", "total", len(resources))
 	}
 
-	if ext, ok := serviceFilters[svc.Namespace]; ok {
+	if ext, ok := ServiceFilters[svc.Namespace]; ok {
 		if ext.ResourceFunc != nil {
 			shouldHaveDiscoveredResources = true
 			newResources, err := ext.ResourceFunc(ctx, c, job, region)

--- a/pkg/clients/tagging/v2/filters.go
+++ b/pkg/clients/tagging/v2/filters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/shield"
 	"github.com/aws/aws-sdk-go-v2/service/storagegateway"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/grafana/regexp"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -329,7 +330,9 @@ var serviceFilters = map[string]serviceFilter{
 			// Outside us-east-1 no resources are going to be found, but we would like to discover the ProtectedResources associated
 			// with a Protection and add those as TaggedResources in any other region
 			if region != "us-east-1" {
-				paginator := shield.NewListProtectionsPaginator(c.shieldAPI, &shield.ListProtectionsInput{}, func(options *shield.ListProtectionsPaginatorOptions) {
+				// Default page size is only 20 which can easily lead to throttling
+				request := &shield.ListProtectionsInput{MaxResults: aws.Int32(1000)}
+				paginator := shield.NewListProtectionsPaginator(c.shieldAPI, request, func(options *shield.ListProtectionsPaginatorOptions) {
 					options.StopOnDuplicateToken = true
 				})
 				pageNum := 0

--- a/pkg/clients/tagging/v2/filters.go
+++ b/pkg/clients/tagging/v2/filters.go
@@ -22,7 +22,7 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
-type serviceFilter struct {
+type ServiceFilter struct {
 	// ResourceFunc can be used to fetch additional resources
 	ResourceFunc func(context.Context, client, *config.Job, string) ([]*model.TaggedResource, error)
 
@@ -30,8 +30,8 @@ type serviceFilter struct {
 	FilterFunc func(context.Context, client, []*model.TaggedResource) ([]*model.TaggedResource, error)
 }
 
-// serviceFilters maps a service namespace to (optional) serviceFilter
-var serviceFilters = map[string]serviceFilter{
+// ServiceFilters maps a service namespace to (optional) ServiceFilter
+var ServiceFilters = map[string]ServiceFilter{
 	"AWS/ApiGateway": {
 		FilterFunc: func(ctx context.Context, client client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
 			var limit int32 = 500 // max number of results per page. default=25, max=500

--- a/pkg/clients/v1/cache.go
+++ b/pkg/clients/v1/cache.go
@@ -486,8 +486,8 @@ func createAPIGatewayV2Session(sess *session.Session, region *string, role confi
 }
 
 func createShieldSession(sess *session.Session, region *string, role config.Role, fips bool, isDebugEnabled bool) shieldiface.ShieldAPI {
-	maxAPIGatewayAPIRetries := 5
-	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
+	maxShieldAPIRetries := 5
+	config := &aws.Config{Region: region, MaxRetries: &maxShieldAPIRetries}
 	if fips {
 		// https://docs.aws.amazon.com/general/latest/gr/shield.html
 		endpoint := "https://shield-fips.us-east-1.amazonaws.com"

--- a/pkg/clients/v1/cache.go
+++ b/pkg/clients/v1/cache.go
@@ -25,6 +25,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/prometheusservice"
 	"github.com/aws/aws-sdk-go/service/prometheusservice/prometheusserviceiface"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/shield"
+	"github.com/aws/aws-sdk-go/service/shield/shieldiface"
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/aws/aws-sdk-go/service/storagegateway/storagegatewayiface"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -232,6 +234,7 @@ func createTaggingClient(logger logging.Logger, session *session.Session, region
 		createDMSSession(session, region, role, fips, logger.IsDebugEnabled()),
 		createPrometheusSession(session, region, role, fips, logger.IsDebugEnabled()),
 		createStorageGatewaySession(session, region, role, fips, logger.IsDebugEnabled()),
+		createShieldSession(session, region, role, fips, logger.IsDebugEnabled()),
 	)
 }
 
@@ -480,4 +483,20 @@ func createAPIGatewayV2Session(sess *session.Session, region *string, role confi
 	}
 
 	return apigatewayv2.New(sess, setSTSCreds(sess, config, role))
+}
+
+func createShieldSession(sess *session.Session, region *string, role config.Role, fips bool, isDebugEnabled bool) shieldiface.ShieldAPI {
+	maxAPIGatewayAPIRetries := 5
+	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
+	if fips {
+		// https://docs.aws.amazon.com/general/latest/gr/shield.html
+		endpoint := "https://shield-fips.us-east-1.amazonaws.com"
+		config.Endpoint = aws.String(endpoint)
+	}
+
+	if isDebugEnabled {
+		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
+	}
+
+	return shield.New(sess, setSTSCreds(sess, config, role))
 }

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -211,6 +211,9 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("shield:protection"),
 		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("(?P<ResourceArn>.+)"),
+		},
 	},
 	{
 		Namespace: "AWS/DocDB",

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -48,6 +48,10 @@ var (
 		Name: "yace_cloudwatch_ec2api_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	ShieldAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_shieldapi_requests_total",
+		Help: "Help is not implemented yet.",
+	})
 	ManagedPrometheusAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_managedprometheusapi_requests_total",
 		Help: "Help is not implemented yet.",


### PR DESCRIPTION
AWS Shield (`AWS/DDoSProtection` namespace in cloudwatch) has some non-standard scenarios when it comes to resources and metrics in cloudwatch. Shield allows you to create "global" protections and those global resources exist in us-east-1. Metrics for the global protection also end up in us-east-1 as noted by, https://docs.aws.amazon.com/waf/latest/developerguide/monitoring-cloudwatch.html.

Shield Advanced reports metrics in the US East (N. Virginia) Region, us-east-1 for the following:
- The global services Amazon CloudFront and Amazon Route 53.
- Protection groups

Resource discovery for `AWS/DDoSProtection` currently discovers the protection groups using the ResourceFilter `"shield:protection"`. This setup allows for discovery of the global protection resources and any metrics associated with them. Attempting to pull `AWS/DDoSProtection` metrics outside of us-east-1 is not possible because resource discovery does not work outside of us-east-1. The problem with this is that `AWS/DDoSProtection` also publishes metrics for all protected resources. It's unlikely those resources all exist in us-east-1 so you cannot pull any `AWS/DDoSProtection` metrics outside of us-east-1 as noted by, #800.

After talking with @cristiangreco a bit about options we landed on using a custom `ResourceFunc` for `AWS/DDoSProtection`. The implmentation uses the `shield.ListProtections` API to discover protected resources outside of us-east-1. These resources are added to the collection of `TaggedResources`. The ARN is the protected resource arn and there's a tag for the protection arn the resource is associated with. 

This solves the initial issues as well as giving a path to associate metrics. Most of the `AWS/DDoSProtection` metrics include a Dimension, `ResourceArn`, which is joinable to the new series produced by the custom `ResourceFunc`. Using some label replace it's possible to join back to the protection info metric and see protection tags as well,

```
aws_ddosprotection_ddo_sattack_requests_per_second_average + on (name) group_left(tag_ProtectionArn) aws_ddosprotection_info{tag_ProtectionArn!=""} + on (tag_ProtectionArn) group_left(tag_<your_protection_tag_here>) label_replace(aws_ddosprotection_info{tag_ProtectionArn=""}, "tag_ProtectionArn", "$1", "name", "(.+)")
```

Ideally, we could create a more simplified `aws_ddosprotection_info` series to avoid this but YACE wasn't built with this scenario in mind. I'll make a follow up ticket to describe the challenge and possible solution as solving this initial problem is complicated enough by itself.

Resolves: #800 