### PR TITLE
Remove tagged resource requirement from TrustedAdvisor 

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -704,12 +704,6 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/TrustedAdvisor",
 		Alias:     "trustedadvisor",
-		ResourceFilters: []*string{
-			aws.String("trustedadvisor"),
-		},
-		DimensionRegexps: []*regexp.Regexp{
-			regexp.MustCompile(":checks/(?P<CategoryCode>[^/]+)/(?P<CheckId>)$"),
-		},
 	},
 	{
 		Namespace: "AWS/VPN",


### PR DESCRIPTION
This PR removes the tagged resource requirement from the Trusted Advisor discovery implementation According to the resource tagging API docs, https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/supported-services.html, Trusted Advisor does not support tagged resources and calling the API with a resource filter of `trustedadvisor` causes an error. 