### PR TITLE
Fix the `FilterId` label value selection for s3 dashboard

### DIFF
--- a/mixin/dashboards/s3.libsonnet
+++ b/mixin/dashboards/s3.libsonnet
@@ -58,7 +58,7 @@ grafana.dashboard.new(
     name='filter_id',
     label='FilterId',
     datasource='$datasource',
-    query='label_values(aws_s3_all_requests_sum{dimension_BucketName=~"$bucket_name"}, dimension_FilterId)',
+    query='label_values(aws_s3_all_requests_sum{dimension_BucketName=~"$bucket"}, dimension_FilterId)',
     refresh=common.refreshOnTimeRangeChange,
     includeAll=true,
     multi=true,


### PR DESCRIPTION
This PR fixes the `FilterId ` label value selection for the s3 dashboard.