### PR TITLE
Fix maxdimassociator to loop through all mappings

### DIFF
--- a/pkg/job/maxdimassociator/associator_api_gateway_test.go
+++ b/pkg/job/maxdimassociator/associator_api_gateway_test.go
@@ -115,7 +115,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 			expectedResource: apiGatewayV1Stage,
 		},
 		{
-			name: "no match",
+			name: "should match API Gateway V1 with ApiName (Stage is not matched)",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
 				resources:        apiGatewayResources,
@@ -128,7 +128,8 @@ func TestAssociatorAPIGateway(t *testing.T) {
 					},
 				},
 			},
-			expectedSkip: true,
+			expectedSkip:     false,
+			expectedResource: apiGatewayV1,
 		},
 	}
 


### PR DESCRIPTION
Mappings in the new associator are sorted by decreasing number of dimensions, e.g.

`[ Mapping_Dim_A_Dim_B, Mapping_Dim_A_Dim_C, Mapping_Dim_A ]`

If trying to map a metric with `Dim_A`, `Dim_B` and `Dim_C`, the current implementation would pic the first mapping (`Mapping_Dim_A_Dim_B`) because it already matches part of the metric dimensions and would try to find a match for dimensions names and values. However, if values don't match it would give up and mark the metric to be skipped.

The new implementation continues to loop through the regex mappings to check if there another one that contains the metric dimensions. In the example above, `Mapping_Dim_A_Dim_C` would match again and the algo would try again to find a match for dimensions names and values.

This should fix cases where ListMetrics returns metrics with more dimensions than can be extracted from the ARN regex. E.g. for ApiGateway the ARN contains only the `ApiId` dimension, but we should now be able to match metrics that contains both `ApiId` and `Method` (as long as the `ApiId` value matches).