### PR TITLE
Improve perf in discovery jobs metrics to data lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	go build -v -ldflags "$(GO_LDFLAGS)" -o yace ./cmd/yace
 
 test:
-	go test -v -race -count=1 ./...
+	go test -v -bench=^$ -race -count=1 ./...
 
 lint:
 	golangci-lint run -v -c .golangci.yml

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -71,9 +71,6 @@ func runDiscoveryJob(
 	g.SetLimit(concurrencyLimit)
 
 	mu := sync.Mutex{}
-	getMetricDataOutput := make([][]*cloudwatch.MetricDataResult, 0, partitionSize)
-
-	mu := sync.Mutex{}
 	getMetricDataOutput := make([][]cloudwatch.MetricDataResult, 0, partitionSize)
 
 	count := 0
@@ -122,7 +119,7 @@ func runDiscoveryJob(
 // mapResultsToMetricDatas walks over all CW GetMetricData results, and map each one with the corresponding model.CloudwatchData.
 //
 // This has been extracted into a separate function to make benchmarking easier.
-func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*model.CloudwatchData, logger logging.Logger) {
+func mapResultsToMetricDatas(output [][]cloudwatch.MetricDataResult, datas []*model.CloudwatchData, logger logging.Logger) {
 	// metricIDToData is a support structure used easily find via a MetricID, the corresponding
 	// model.CloudatchData.
 	metricIDToData := make(map[string]*model.CloudwatchData, len(datas))
@@ -145,12 +142,12 @@ func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*m
 		}
 		for _, metricDataResult := range data {
 			// find into index
-			metricData, ok := metricIDToData[*metricDataResult.ID]
+			metricData, ok := metricIDToData[metricDataResult.ID]
 			if !ok {
-				logger.Warn("GetMetricData returned unknown metric ID", "metric_id", *metricDataResult.ID)
+				logger.Warn("GetMetricData returned unknown metric ID", "metric_id", metricDataResult.ID)
 				continue
 			}
-			// skip elements that have been already mapped but still exist in datasIndex
+			// skip elements that have been already mapped but still exist in metricIDToData
 			if metricData.MetricID == nil {
 				continue
 			}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -120,7 +120,7 @@ func runDiscoveryJob(
 //
 // This has been extracted into a separate function to make benchmarking easier.
 func mapResultsToMetricDatas(output [][]cloudwatch.MetricDataResult, datas []*model.CloudwatchData, logger logging.Logger) {
-	// metricIDToData is a support structure used easily find via a MetricID, the corresponding
+	// metricIDToData is a support structure used to easily find via a MetricID, the corresponding
 	// model.CloudatchData.
 	metricIDToData := make(map[string]*model.CloudwatchData, len(datas))
 

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -32,7 +32,7 @@ func runDiscoveryJob(
 	clientTag tagging.Client,
 	clientCloudwatch cloudwatch.Client,
 	metricsPerQuery int,
-	concurrencyLimit int,
+	_ int,
 ) ([]*model.TaggedResource, []*model.CloudwatchData) {
 	logger.Debug("Get tagged resources")
 
@@ -154,18 +154,6 @@ func getMetricDataInputLength(metrics []*config.Metric) int64 {
 		}
 	}
 	return length
-}
-
-func findGetMetricDataByID(getMetricDatas []*model.CloudwatchData, value string) int {
-	for i := 0; i < len(getMetricDatas); i++ {
-		if getMetricDatas[i].MetricID == nil {
-			continue // skip elements that have been already marked
-		}
-		if *(getMetricDatas[i].MetricID) == value {
-			return i
-		}
-	}
-	return -1
 }
 
 func getMetricDataForQueries(

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -125,7 +125,7 @@ func runDiscoveryJob(
 func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*model.CloudwatchData, logger logging.Logger) {
 	// datasIndex is a support structure used easily find via a MetricID, the corresponding
 	// model.CloudatchData.
-	datasIndex := make(map[string]*model.CloudwatchData)
+	datasIndex := make(map[string]*model.CloudwatchData, len(datas)
 
 	// load the index
 	for _, data := range datas {
@@ -150,7 +150,7 @@ func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*m
 				logger.Warn("GetMetricData returned unknown metric ID", "metric_id", *metricDataResult.ID)
 				continue
 			}
-			// skip elements that have been already marked
+			// skip elements that have been already mapped but still exist in datasIndex
 			if metricData.MetricID == nil {
 				continue
 			}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -123,13 +123,13 @@ func runDiscoveryJob(
 //
 // This has been extracted into a separate function to make benchmarking easier.
 func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*model.CloudwatchData, logger logging.Logger) {
-	// datasIndex is a support structure used easily find via a MetricID, the corresponding
+	// metricIDToData is a support structure used easily find via a MetricID, the corresponding
 	// model.CloudatchData.
-	datasIndex := make(map[string]*model.CloudwatchData, len(datas)
+	metricIDToData := make(map[string]*model.CloudwatchData, len(datas))
 
 	// load the index
 	for _, data := range datas {
-		datasIndex[*(data.MetricID)] = data
+		metricIDToData[*(data.MetricID)] = data
 	}
 
 	// Update getMetricDatas slice with values and timestamps from API response.
@@ -145,7 +145,7 @@ func mapResultsToMetricDatas(output [][]*cloudwatch.MetricDataResult, datas []*m
 		}
 		for _, metricDataResult := range data {
 			// find into index
-			metricData, ok := datasIndex[*metricDataResult.ID]
+			metricData, ok := metricIDToData[*metricDataResult.ID]
 			if !ok {
 				logger.Warn("GetMetricData returned unknown metric ID", "metric_id", *metricDataResult.ID)
 				continue

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -458,8 +458,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 }
 
-func getSampleMetricDatas(id string) model.CloudwatchData {
-	return model.CloudwatchData{
+func getSampleMetricDatas(id string) *model.CloudwatchData {
+	return &model.CloudwatchData{
 		AccountID:              aws.String("123123123123"),
 		AddCloudwatchTimestamp: aws.Bool(false),
 		Dimensions: []*model.Dimension{
@@ -473,6 +473,7 @@ func getSampleMetricDatas(id string) model.CloudwatchData {
 			},
 		},
 		ID:        aws.String(id),
+		MetricID:  aws.String(id),
 		Metric:    aws.String("StorageBytes"),
 		Namespace: aws.String("efs"),
 		NilToZero: aws.Bool(false),
@@ -503,9 +504,9 @@ func BenchmarkXxx(b *testing.B) {
 
 	var now = time.Now()
 
-	var testResourceIDs = make([]string, 0, testResourcesCount)
+	var testResourceIDs = make([]string, testResourcesCount)
 	for i := 0; i < testResourcesCount; i++ {
-		testResourceIDs = append(testResourceIDs, fmt.Sprintf("test-resource-%d", i))
+		testResourceIDs[i] = fmt.Sprintf("test-resource-%d", i)
 	}
 
 	for batch := 0; batch < metricsPerQuery; batch++ {
@@ -521,13 +522,13 @@ func BenchmarkXxx(b *testing.B) {
 		outputs = append(outputs, newBatchOutputs)
 	}
 
-	datas := make([]*model.CloudwatchData, 0, testResourcesCount)
-	for i := 0; i < testResourcesCount; i++ {
-		var data = getSampleMetricDatas(testResourceIDs[i])
-		datas = append(datas, &data)
-	}
-
 	for i := 0; i < b.N; i++ {
-		xxx(outputs, datas, logging.NewNopLogger())
+		b.StopTimer()
+		datas := []*model.CloudwatchData{}
+		for i := 0; i < testResourcesCount; i++ {
+			datas = append(datas, getSampleMetricDatas(testResourceIDs[i]))
+		}
+		b.StartTimer()
+		mapXXX(outputs, datas, logging.NewNopLogger())
 	}
 }

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -504,14 +504,19 @@ func BenchmarkMapResultsToMetricDatas(b *testing.B) {
 
 	for name, tc := range map[string]testcase{
 		"small case": {
-			metricsPerQuery:    50,
+			metricsPerQuery:    500,
 			testResourcesCount: 10,
-			metricsPerResource: 100,
+			metricsPerResource: 10,
+		},
+		"medium case": {
+			metricsPerQuery:    500,
+			testResourcesCount: 1000,
+			metricsPerResource: 50,
 		},
 		"big case": {
-			metricsPerQuery:    50,
-			testResourcesCount: 100,
-			metricsPerResource: 1000,
+			metricsPerQuery:    500,
+			testResourcesCount: 2000,
+			metricsPerResource: 50,
 		},
 	} {
 		b.Run(name, func(b *testing.B) {

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -526,17 +526,17 @@ func BenchmarkMapResultsToMetricDatas(b *testing.B) {
 }
 
 func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResource int) {
-	var outputs = [][]*cloudwatch.MetricDataResult{}
+	outputs := [][]*cloudwatch.MetricDataResult{}
+	now := time.Now()
+	testResourceIDs := make([]string, testResourcesCount)
 
-	var now = time.Now()
-
-	var testResourceIDs = make([]string, testResourcesCount)
 	for i := 0; i < testResourcesCount; i++ {
 		testResourceIDs[i] = fmt.Sprintf("test-resource-%d", i)
 	}
 
-	var totalMetricsDatapoints = metricsPerResource * testResourcesCount
-	var batchesCount = totalMetricsDatapoints / metricsPerQuery
+	totalMetricsDatapoints := metricsPerResource * testResourcesCount
+	batchesCount := totalMetricsDatapoints / metricsPerQuery
+
 	if batchesCount == 0 {
 		batchesCount = 1
 	}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -526,7 +526,7 @@ func BenchmarkMapResultsToMetricDatas(b *testing.B) {
 }
 
 func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResource int) {
-	outputs := [][]*cloudwatch.MetricDataResult{}
+	outputs := [][]cloudwatch.MetricDataResult{}
 	now := time.Now()
 	testResourceIDs := make([]string, testResourcesCount)
 
@@ -542,13 +542,13 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResour
 	}
 
 	for batch := 0; batch < batchesCount; batch++ {
-		newBatchOutputs := make([]*cloudwatch.MetricDataResult, 0)
+		newBatchOutputs := make([]cloudwatch.MetricDataResult, 0)
 		for i := 0; i < metricsPerQuery; i++ {
 			id := testResourceIDs[(batch*metricsPerQuery+i)%testResourcesCount]
-			newBatchOutputs = append(newBatchOutputs, &cloudwatch.MetricDataResult{
-				ID:        aws.String(id),
-				Datapoint: aws.Float64(1.4 * float64(batch)),
-				Timestamp: aws.Time(now),
+			newBatchOutputs = append(newBatchOutputs, cloudwatch.MetricDataResult{
+				ID:        id,
+				Datapoint: 1.4 * float64(batch),
+				Timestamp: now,
 			})
 		}
 		outputs = append(outputs, newBatchOutputs)

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -537,6 +537,9 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResour
 
 	var totalMetricsDatapoints = metricsPerResource * testResourcesCount
 	var batchesCount = totalMetricsDatapoints / metricsPerQuery
+	if batchesCount == 0 {
+		batchesCount = 1
+	}
 
 	for batch := 0; batch < batchesCount; batch++ {
 		newBatchOutputs := make([]*cloudwatch.MetricDataResult, 0)


### PR DESCRIPTION
This PR addessed some performance issues we've been seeing with running YACE discovery with large enough jobs. We noticed there was a lot of cpu % usage around `findGetMetricDataByID`. This lead us to believe this is a hot path, and as well, performs lots of side-allocations.

This PR re-implements that logic with a map to lookup the corresponding metric data, rather than looping over. Also, a benchmark is added for further development.

The benchstat below shows an improvement of around ~90% in both cpu and memory. 

benchstat
```
goos: darwin
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job
                                      │    main.p     │                pr.p                │
                                      │    sec/op     │   sec/op     vs base               │
MapResultsToMetricDatas/small_case-10    271.13µ ± 3%   10.35µ ± 1%  -96.18% (p=0.002 n=6)
MapResultsToMetricDatas/big_case-10     28916.8µ ± 4%   927.1µ ± 6%  -96.79% (p=0.002 n=6)
geomean                                   2.800m        97.96µ       -96.50%

                                      │     main.p      │                pr.p                 │
                                      │      B/op       │     B/op      vs base               │
MapResultsToMetricDatas/small_case-10     364367.5 ± 0%     444.0 ± 0%  -99.88% (p=0.002 n=6)
MapResultsToMetricDatas/big_case-10     36133.26Ki ± 0%   15.32Ki ± 2%  -99.96% (p=0.002 n=6)
geomean                                    3.502Mi        2.577Ki       -99.93%

                                      │    main.p     │               pr.p                │
                                      │   allocs/op   │ allocs/op   vs base               │
MapResultsToMetricDatas/small_case-10   7921.000 ± 0%   2.000 ± 0%  -99.97% (p=0.002 n=6)
MapResultsToMetricDatas/big_case-10     809687.5 ± 0%   356.0 ± 3%  -99.96% (p=0.002 n=6)
geomean                                   80.08k        26.68       -99.97
```

main
```
goos: darwin
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job
BenchmarkMapResultsToMetricDatas/small_case-10         	    4726	    269036 ns/op	  364367 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	    4749	    276557 ns/op	  364366 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	    4291	    280005 ns/op	  364369 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	    4486	    273217 ns/op	  364368 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	    4452	    268510 ns/op	  364368 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	    4748	    266801 ns/op	  364367 B/op	    7921 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      40	  28897098 ns/op	36997460 B/op	  809555 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      39	  29039734 ns/op	37003479 B/op	  809821 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      39	  29934966 ns/op	37003487 B/op	  809820 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      39	  28842040 ns/op	37003451 B/op	  809820 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      42	  27786820 ns/op	36986299 B/op	  809062 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	      42	  28936529 ns/op	36986283 B/op	  809062 allocs/op
PASS
ok  	github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job	22.906s
```

pr
```
goos: darwin
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job
BenchmarkMapResultsToMetricDatas/small_case-10         	  113601	     10365 ns/op	     444 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	  117096	     10364 ns/op	     444 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	  115774	     10357 ns/op	     444 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	  117190	     10299 ns/op	     445 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	  116364	     10344 ns/op	     444 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/small_case-10         	  116276	     10241 ns/op	     444 B/op	       2 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1191	    955207 ns/op	   15689 B/op	     356 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1153	    925903 ns/op	   15933 B/op	     367 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1154	    923614 ns/op	   15936 B/op	     367 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1190	    928290 ns/op	   15686 B/op	     356 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1198	    925005 ns/op	   15635 B/op	     354 allocs/op
BenchmarkMapResultsToMetricDatas/big_case-10           	    1231	    979040 ns/op	   15436 B/op	     345 allocs/op
PASS
ok  	github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job	50.249s
```