### PR TITLE
Implement new concurrency limit mechanism for the CloudWatch client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 **Bugfixes and features**
 
 Features:
-* ...
+* Add new CloudWatch API concurrency limiter by @thepalbi
 
 Bugs:
 * ...

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -134,7 +134,7 @@ func NewYACEApp() *cli.App {
 		&cli.BoolFlag{
 			Name:        "cloudwatch-concurrency.per-api-enabled",
 			Value:       exporter.DefaultCloudwatchConcurrency.PerAPIEnabled,
-			Usage:       "Whether to enable the per API CloudWatch concurrency limiter.",
+			Usage:       "Whether to enable the per API CloudWatch concurrency limiter. When enabled, the concurrency `-cloudwatch-concurrency` flag will be ignored.",
 			Destination: &cloudwatchConcurrency.PerAPIEnabled,
 		},
 		&cli.IntFlag{
@@ -232,6 +232,11 @@ func NewYACEApp() *cli.App {
 
 func startScraper(c *cli.Context) error {
 	logger = logging.NewLogger(logFormat, debug, "version", version)
+
+	// log warning if the two concurrency limiting methods are configured via CLI
+	if c.IsSet("cloudwatch-concurrency") && c.IsSet("cloudwatch-concurrency.per-api-enabled") {
+		logger.Warn("Both `cloudwatch-concurrency` and `cloudwatch-concurrency.per-api-enabled` are set. `cloudwatch-concurrency` will be ignored, and the per-api concurrency limiting strategy will be favoured.")
+	}
 
 	logger.Info("Parsing config")
 	if err := cfg.Load(configFile, logger); err != nil {

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	exporter "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	v1 "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/v1"
 	v2 "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/v2"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -46,7 +47,7 @@ var (
 	debug                 bool
 	logFormat             string
 	fips                  bool
-	cloudwatchConcurrency int
+	cloudwatchConcurrency cloudwatch.ConcurrencyConfig
 	tagConcurrency        int
 	scrapingInterval      int
 	metricsPerQuery       int
@@ -126,9 +127,33 @@ func NewYACEApp() *cli.App {
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency",
-			Value:       exporter.DefaultCloudWatchAPIConcurrency,
+			Value:       exporter.DefaultCloudwatchConcurrency.SingleLimit,
 			Usage:       "Maximum number of concurrent requests to CloudWatch API.",
-			Destination: &cloudwatchConcurrency,
+			Destination: &cloudwatchConcurrency.SingleLimit,
+		},
+		&cli.BoolFlag{
+			Name:        "cloudwatch-concurrency.per-api-enabled",
+			Value:       exporter.DefaultCloudwatchConcurrency.PerAPIEnabled,
+			Usage:       "Whether to enable the per API CloudWatch concurrency limiter.",
+			Destination: &cloudwatchConcurrency.PerAPIEnabled,
+		},
+		&cli.IntFlag{
+			Name:        "cloudwatch-concurrency.list-metrics-limit",
+			Value:       exporter.DefaultCloudwatchConcurrency.ListMetrics,
+			Usage:       "Maximum number of concurrent requests to ListMetrics CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Destination: &cloudwatchConcurrency.ListMetrics,
+		},
+		&cli.IntFlag{
+			Name:        "cloudwatch-concurrency.get-metric-data-limit",
+			Value:       exporter.DefaultCloudwatchConcurrency.GetMetricData,
+			Usage:       "Maximum number of concurrent requests to GetMetricData CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Destination: &cloudwatchConcurrency.GetMetricData,
+		},
+		&cli.IntFlag{
+			Name:        "cloudwatch-concurrency.get-metric-statistics-limit",
+			Value:       exporter.DefaultCloudwatchConcurrency.GetMetricStatistics,
+			Usage:       "Maximum number of concurrent requests to GetMetricStatistics CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Destination: &cloudwatchConcurrency.GetMetricStatistics,
 		},
 		&cli.IntFlag{
 			Name:        "tag-concurrency",

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -132,27 +132,27 @@ func NewYACEApp() *cli.App {
 			Destination: &cloudwatchConcurrency.SingleLimit,
 		},
 		&cli.BoolFlag{
-			Name:        "cloudwatch-concurrency.per-api-enabled",
-			Value:       exporter.DefaultCloudwatchConcurrency.PerAPIEnabled,
+			Name:        "cloudwatch-concurrency.per-api-limit-enabled",
+			Value:       exporter.DefaultCloudwatchConcurrency.PerAPILimitEnabled,
 			Usage:       "Whether to enable the per API CloudWatch concurrency limiter. When enabled, the concurrency `-cloudwatch-concurrency` flag will be ignored.",
-			Destination: &cloudwatchConcurrency.PerAPIEnabled,
+			Destination: &cloudwatchConcurrency.PerAPILimitEnabled,
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency.list-metrics-limit",
 			Value:       exporter.DefaultCloudwatchConcurrency.ListMetrics,
-			Usage:       "Maximum number of concurrent requests to ListMetrics CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Usage:       "Maximum number of concurrent requests to ListMetrics CloudWatch API. Used if the -cloudwatch-concurrency.per-api-limit-enabled concurrency limiter is enabled.",
 			Destination: &cloudwatchConcurrency.ListMetrics,
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency.get-metric-data-limit",
 			Value:       exporter.DefaultCloudwatchConcurrency.GetMetricData,
-			Usage:       "Maximum number of concurrent requests to GetMetricData CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Usage:       "Maximum number of concurrent requests to GetMetricData CloudWatch API. Used if the -cloudwatch-concurrency.per-api-limit-enabled concurrency limiter is enabled.",
 			Destination: &cloudwatchConcurrency.GetMetricData,
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency.get-metric-statistics-limit",
 			Value:       exporter.DefaultCloudwatchConcurrency.GetMetricStatistics,
-			Usage:       "Maximum number of concurrent requests to GetMetricStatistics CloudWatch API. Used if the per-api concurrency limiter is enabled.",
+			Usage:       "Maximum number of concurrent requests to GetMetricStatistics CloudWatch API. Used if the -cloudwatch-concurrency.per-api-limit-enabled concurrency limiter is enabled.",
 			Destination: &cloudwatchConcurrency.GetMetricStatistics,
 		},
 		&cli.IntFlag{
@@ -234,8 +234,8 @@ func startScraper(c *cli.Context) error {
 	logger = logging.NewLogger(logFormat, debug, "version", version)
 
 	// log warning if the two concurrency limiting methods are configured via CLI
-	if c.IsSet("cloudwatch-concurrency") && c.IsSet("cloudwatch-concurrency.per-api-enabled") {
-		logger.Warn("Both `cloudwatch-concurrency` and `cloudwatch-concurrency.per-api-enabled` are set. `cloudwatch-concurrency` will be ignored, and the per-api concurrency limiting strategy will be favoured.")
+	if c.IsSet("cloudwatch-concurrency") && c.IsSet("cloudwatch-concurrency.per-api-limit-enabled") {
+		logger.Warn("Both `cloudwatch-concurrency` and `cloudwatch-concurrency.per-api-limit-enabled` are set. `cloudwatch-concurrency` will be ignored, and the per-api concurrency limiting strategy will be favoured.")
 	}
 
 	logger.Info("Parsing config")

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -82,7 +82,7 @@ func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache cachi
 	cache.Refresh()
 	defer cache.Clear()
 
-	var options = []exporter.OptionsFunc{
+	options := []exporter.OptionsFunc{
 		exporter.MetricsPerQuery(metricsPerQuery),
 		exporter.LabelsSnakeCase(labelsSnakeCase),
 		exporter.EnableFeatureFlag(s.featureFlags...),

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -89,8 +89,8 @@ func (s *scraper) scrape(ctx context.Context, logger logging.Logger, cache cachi
 		exporter.TaggingAPIConcurrency(tagConcurrency),
 	}
 
-	if cloudwatchConcurrency.PerAPIEnabled {
-		options = append(options, exporter.CloudWatchPerAPIConcurrency(cloudwatchConcurrency.ListMetrics, cloudwatchConcurrency.GetMetricData, cloudwatchConcurrency.GetMetricStatistics))
+	if cloudwatchConcurrency.PerAPILimitEnabled {
+		options = append(options, exporter.CloudWatchPerAPILimitConcurrency(cloudwatchConcurrency.ListMetrics, cloudwatchConcurrency.GetMetricData, cloudwatchConcurrency.GetMetricStatistics))
 	} else {
 		options = append(options, exporter.CloudWatchAPIConcurrency(cloudwatchConcurrency.SingleLimit))
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,10 @@ All flags may be prefixed with either one hypen or two (i.e., both `-config.file
 | `-debug` | Log at debug level | `false` |
 | `-fips` | Use FIPS compliant AWS API | `false` |
 | `-cloudwatch-concurrency` | Maximum number of concurrent requests to CloudWatch API | `5` |
+| `-cloudwatch-concurrency.per-api-enabled` | Enables a concurrency limiter, that has a specific limit per CloudWatch API call. | `false` |
+| `-cloudwatch-concurrency.list-metrics-limit` | Maximum number of concurrent requests to CloudWatch `ListMetrics` API. Only applicable if `per-api-enabled` is `true`. | `5` |
+| `-cloudwatch-concurrency.get-metric-data-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricsData` API. Only applicable if `per-api-enabled` is `true`. | `5` |
+| `-cloudwatch-concurrency.get-metric-statistics-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricStatistics` API. Only applicable if `per-api-enabled` is `true`. | `5` |
 | `-tag-concurrency` | Maximum number of concurrent requests to Resource Tagging API | `5` |
 | `-scraping-interval` | Seconds to wait between scraping the AWS metrics | `300` |
 | `-metrics-per-query` | Number of metrics made in a single GetMetricsData request | `500` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,10 +21,10 @@ All flags may be prefixed with either one hypen or two (i.e., both `-config.file
 | `-debug` | Log at debug level | `false` |
 | `-fips` | Use FIPS compliant AWS API | `false` |
 | `-cloudwatch-concurrency` | Maximum number of concurrent requests to CloudWatch API | `5` |
-| `-cloudwatch-concurrency.per-api-enabled` | Enables a concurrency limiter, that has a specific limit per CloudWatch API call. | `false` |
-| `-cloudwatch-concurrency.list-metrics-limit` | Maximum number of concurrent requests to CloudWatch `ListMetrics` API. Only applicable if `per-api-enabled` is `true`. | `5` |
-| `-cloudwatch-concurrency.get-metric-data-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricsData` API. Only applicable if `per-api-enabled` is `true`. | `5` |
-| `-cloudwatch-concurrency.get-metric-statistics-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricStatistics` API. Only applicable if `per-api-enabled` is `true`. | `5` |
+| `-cloudwatch-concurrency.per-api-limit-enabled` | Enables a concurrency limiter, that has a specific limit per CloudWatch API call. | `false` |
+| `-cloudwatch-concurrency.list-metrics-limit` | Maximum number of concurrent requests to CloudWatch `ListMetrics` API. Only applicable if `per-api-limit-enabled` is `true`. | `5` |
+| `-cloudwatch-concurrency.get-metric-data-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricsData` API. Only applicable if `per-api-limit-enabled` is `true`. | `5` |
+| `-cloudwatch-concurrency.get-metric-statistics-limit` | Maximum number of concurrent requests to CloudWatch `GetMetricStatistics` API. Only applicable if `per-api-limit-enabled` is `true`. | `5` |
 | `-tag-concurrency` | Maximum number of concurrent requests to Resource Tagging API | `5` |
 | `-scraping-interval` | Seconds to wait between scraping the AWS metrics | `300` |
 | `-metrics-per-query` | Number of metrics made in a single GetMetricsData request | `500` |

--- a/pkg/clients/cloudwatch/concurrency.go
+++ b/pkg/clients/cloudwatch/concurrency.go
@@ -4,8 +4,8 @@ package cloudwatch
 // one to pick between different limiter implementations: a single limit limiter, or one with a different limit per
 // API call.
 type ConcurrencyConfig struct {
-	// PerAPIEnabled configures wether to have a limit per API call.
-	PerAPIEnabled bool
+	// PerAPIEnabled configures whether to have a limit per API call.
+	PerAPILimitEnabled bool
 
 	// SingleLimit configures the concurrency limit when using a single limiter for api calls.
 	SingleLimit int
@@ -38,7 +38,7 @@ func (s semaphore) Release() {
 
 // NewLimiter creates a new ConcurrencyLimiter, according to the ConcurrencyConfig.
 func (cfg ConcurrencyConfig) NewLimiter() ConcurrencyLimiter {
-	if cfg.PerAPIEnabled {
+	if cfg.PerAPILimitEnabled {
 		return NewPerAPICallLimiter(cfg.ListMetrics, cfg.GetMetricData, cfg.GetMetricStatistics)
 	}
 	return NewSingleLimiter(cfg.SingleLimit)

--- a/pkg/clients/cloudwatch/concurrency.go
+++ b/pkg/clients/cloudwatch/concurrency.go
@@ -24,9 +24,8 @@ type ConcurrencyConfig struct {
 func (cfg ConcurrencyConfig) NewLimiter() ConcurrencyLimiter {
 	if cfg.PerAPIEnabled {
 		return NewPerAPICallLimiter(cfg.ListMetrics, cfg.GetMetricData, cfg.GetMetricStatistics)
-	} else {
-		return NewSingleLimiter(cfg.SingleLimit)
 	}
+	return NewSingleLimiter(cfg.SingleLimit)
 }
 
 // perAPICallLimiter is a ConcurrencyLimiter that keeps a different concurrency limiter per different API call. This allows

--- a/pkg/clients/cloudwatch/concurrency.go
+++ b/pkg/clients/cloudwatch/concurrency.go
@@ -1,0 +1,70 @@
+package cloudwatch
+
+// ConcurrencyConfig configures how concurrency should be limited in a Cloudwatch API client. It allows
+// one to pick between different limiter implementations: a single limit limiter, or one with a different limit per
+// API call.
+type ConcurrencyConfig struct {
+	// PerAPIEnabled configures wether to have a limit per API call.
+	PerAPIEnabled bool
+
+	// SingleLimit configures the concurrency limit when using a single limiter for api calls.
+	SingleLimit int
+
+	// ListMetrics limits the number for ListMetrics API concurrent API calls.
+	ListMetrics int
+
+	// GetMetricData limits the number for GetMetricData API concurrent API calls.
+	GetMetricData int
+
+	// GetMetricStatistics limits the number for GetMetricStatistics API concurrent API calls.
+	GetMetricStatistics int
+}
+
+// NewLimiter creates a new ConcurrencyLimiter, according to the ConcurrencyConfig.
+func (cfg ConcurrencyConfig) NewLimiter() ConcurrencyLimiter {
+	if cfg.PerAPIEnabled {
+		return NewPerAPICallLimiter(cfg.ListMetrics, cfg.GetMetricData, cfg.GetMetricStatistics)
+	} else {
+		return NewSingleLimiter(cfg.SingleLimit)
+	}
+}
+
+// perAPICallLimiter is a ConcurrencyLimiter that keeps a different concurrency limiter per different API call. This allows
+// a more granular control of concurrency, allowing us to take advantage of different api limits. For example, ListMetrics
+// has a limit of 25 TPS, while GetMetricData has none.
+type perAPICallLimiter map[string]chan struct{}
+
+// NewPerAPICallLimiter creates a new PerAPICallLimiter.
+func NewPerAPICallLimiter(listMetrics, getMetricData, getMetricStatistics int) ConcurrencyLimiter {
+	return perAPICallLimiter(map[string]chan struct{}{
+		listMetricsCall:         make(chan struct{}, listMetrics),
+		getMetricDataCall:       make(chan struct{}, getMetricData),
+		getMetricStatisticsCall: make(chan struct{}, getMetricStatistics),
+	})
+}
+
+func (l perAPICallLimiter) Acquire(op string) {
+	l[op] <- struct{}{}
+}
+
+func (l perAPICallLimiter) Release(op string) {
+	<-l[op]
+}
+
+// singleLimiter is the current implementation of ConcurrencyLimiter, which has a single limit for all different API calls.
+type singleLimiter struct {
+	sem chan struct{}
+}
+
+// NewSingleLimiter creates a new SingleLimiter.
+func NewSingleLimiter(limit int) ConcurrencyLimiter {
+	return &singleLimiter{sem: make(chan struct{}, limit)}
+}
+
+func (sl *singleLimiter) Acquire(_ string) {
+	sl.sem <- struct{}{}
+}
+
+func (sl *singleLimiter) Release(_ string) {
+	<-sl.sem
+}

--- a/pkg/clients/factory.go
+++ b/pkg/clients/factory.go
@@ -10,7 +10,7 @@ import (
 // Factory is an interface to abstract away all logic required to produce the different
 // YACE specific clients which wrap AWS clients
 type Factory interface {
-	GetCloudwatchClient(region string, role config.Role, concurrencyLimit int) cloudwatch_client.Client
+	GetCloudwatchClient(region string, role config.Role, concurrency cloudwatch_client.ConcurrencyConfig) cloudwatch_client.Client
 	GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client
 	GetAccountClient(region string, role config.Role) account.Client
 }

--- a/pkg/clients/v1/factory_test.go
+++ b/pkg/clients/v1/factory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 )
@@ -697,7 +698,7 @@ func TestClientCacheGetCloudwatchClient(t *testing.T) {
 	testGetAWSClient(
 		t, "Cloudwatch",
 		func(t *testing.T, cache *CachingFactory, region string, role config.Role) {
-			iface := cache.GetCloudwatchClient(region, role, 1)
+			iface := cache.GetCloudwatchClient(region, role, cloudwatch.ConcurrencyConfig{SingleLimit: 1})
 			if iface == nil {
 				t.Fail()
 				return

--- a/pkg/clients/v2/factory.go
+++ b/pkg/clients/v2/factory.go
@@ -149,17 +149,17 @@ func NewFactory(cfg config.ScrapeConf, fips bool, logger logging.Logger) (*Cachi
 	}, nil
 }
 
-func (c *CachingFactory) GetCloudwatchClient(region string, role config.Role, concurrencyLimit int) cloudwatch_client.Client {
+func (c *CachingFactory) GetCloudwatchClient(region string, role config.Role, concurrency cloudwatch_client.ConcurrencyConfig) cloudwatch_client.Client {
 	if !c.refreshed {
 		// if we have not refreshed then we need to lock in case we are accessing concurrently
 		c.mu.Lock()
 		defer c.mu.Unlock()
 	}
 	if client := c.clients[role][region].cloudwatch; client != nil {
-		return cloudwatch_client.NewLimitedConcurrencyClient(client, concurrencyLimit)
+		return cloudwatch_client.NewLimitedConcurrencyClient(client, concurrency.NewLimiter())
 	}
 	c.clients[role][region].cloudwatch = cloudwatch_v2.NewClient(c.logger, c.createCloudwatchClient(c.clients[role][region].awsConfig))
-	return cloudwatch_client.NewLimitedConcurrencyClient(c.clients[role][region].cloudwatch, concurrencyLimit)
+	return cloudwatch_client.NewLimitedConcurrencyClient(c.clients[role][region].cloudwatch, concurrency.NewLimiter())
 }
 
 func (c *CachingFactory) GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client {

--- a/pkg/clients/v2/factory_test.go
+++ b/pkg/clients/v2/factory_test.go
@@ -289,7 +289,7 @@ func TestClientCache_GetCloudwatchClient(t *testing.T) {
 		clients := output.clients[defaultRole]["region1"]
 		require.NotNil(t, clients)
 		// Can't do equality comparison due to concurrency limiter
-		assert.NotNil(t, output.GetCloudwatchClient("region1", defaultRole, 1))
+		assert.NotNil(t, output.GetCloudwatchClient("region1", defaultRole, cloudwatch_client.ConcurrencyConfig{SingleLimit: 1}))
 	})
 
 	t.Run("unrefreshed cache creates a new client", func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestClientCache_GetCloudwatchClient(t *testing.T) {
 		require.NotNil(t, clients)
 		require.Nil(t, clients.cloudwatch)
 
-		output.GetCloudwatchClient("region1", defaultRole, 1)
+		output.GetCloudwatchClient("region1", defaultRole, cloudwatch_client.ConcurrencyConfig{SingleLimit: 1})
 		assert.NotNil(t, clients.cloudwatch)
 	})
 }

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -36,11 +36,9 @@ const (
 	DefaultTaggingAPIConcurrency = 5
 )
 
-var (
-	DefaultCloudwatchConcurrency = cloudwatch.ConcurrencyConfig{
-		SingleLimit: 5,
-	}
-)
+var DefaultCloudwatchConcurrency = cloudwatch.ConcurrencyConfig{
+	SingleLimit: 5,
+}
 
 // featureFlagsMap is a map that contains the enabled feature flags. If a key is not present, it means the feature flag
 // is disabled.

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -37,10 +37,10 @@ const (
 )
 
 var DefaultCloudwatchConcurrency = cloudwatch.ConcurrencyConfig{
-	SingleLimit:   5,
-	PerAPIEnabled: false,
+	SingleLimit:        5,
+	PerAPILimitEnabled: false,
 
-	// If PerAPIEnabled is enabled, then use the same limit as the single limit by default.
+	// If PerAPILimitEnabled is enabled, then use the same limit as the single limit by default.
 	ListMetrics:         5,
 	GetMetricData:       5,
 	GetMetricStatistics: 5,
@@ -95,7 +95,7 @@ func CloudWatchAPIConcurrency(maxConcurrency int) OptionsFunc {
 	}
 }
 
-func CloudWatchPerAPIConcurrency(listMetrics, getMetricData, getMetricStatistics int) OptionsFunc {
+func CloudWatchPerAPILimitConcurrency(listMetrics, getMetricData, getMetricStatistics int) OptionsFunc {
 	return func(o *options) error {
 		if listMetrics <= 0 {
 			return fmt.Errorf("LitMetrics concurrency limit must be a positive value")
@@ -107,7 +107,7 @@ func CloudWatchPerAPIConcurrency(listMetrics, getMetricData, getMetricStatistics
 			return fmt.Errorf("GetMetricStatistics concurrency limit must be a positive value")
 		}
 
-		o.cloudwatchConcurrency.PerAPIEnabled = true
+		o.cloudwatchConcurrency.PerAPILimitEnabled = true
 		o.cloudwatchConcurrency.ListMetrics = listMetrics
 		o.cloudwatchConcurrency.GetMetricData = getMetricData
 		o.cloudwatchConcurrency.GetMetricStatistics = getMetricStatistics

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
@@ -30,10 +31,15 @@ var Metrics = []prometheus.Collector{
 }
 
 const (
-	DefaultMetricsPerQuery          = 500
-	DefaultLabelsSnakeCase          = false
-	DefaultCloudWatchAPIConcurrency = 5
-	DefaultTaggingAPIConcurrency    = 5
+	DefaultMetricsPerQuery       = 500
+	DefaultLabelsSnakeCase       = false
+	DefaultTaggingAPIConcurrency = 5
+)
+
+var (
+	DefaultCloudwatchConcurrency = cloudwatch.ConcurrencyConfig{
+		SingleLimit: 5,
+	}
 )
 
 // featureFlagsMap is a map that contains the enabled feature flags. If a key is not present, it means the feature flag
@@ -41,11 +47,11 @@ const (
 type featureFlagsMap map[string]struct{}
 
 type options struct {
-	metricsPerQuery          int
-	labelsSnakeCase          bool
-	cloudWatchAPIConcurrency int
-	taggingAPIConcurrency    int
-	featureFlags             featureFlagsMap
+	metricsPerQuery       int
+	labelsSnakeCase       bool
+	taggingAPIConcurrency int
+	featureFlags          featureFlagsMap
+	cloudwatchConcurrency cloudwatch.ConcurrencyConfig
 }
 
 // IsFeatureEnabled implements the FeatureFlags interface, allowing us to inject the options-configure feature flags in the rest of the code.
@@ -80,7 +86,27 @@ func CloudWatchAPIConcurrency(maxConcurrency int) OptionsFunc {
 			return fmt.Errorf("CloudWatchAPIConcurrency must be a positive value")
 		}
 
-		o.cloudWatchAPIConcurrency = maxConcurrency
+		o.cloudwatchConcurrency.SingleLimit = maxConcurrency
+		return nil
+	}
+}
+
+func CloudWatchPerAPIConcurrency(listMetrics, getMetricData, getMetricStatistics int) OptionsFunc {
+	return func(o *options) error {
+		if listMetrics <= 0 {
+			return fmt.Errorf("LitMetrics concurrency limit must be a positive value")
+		}
+		if getMetricData <= 0 {
+			return fmt.Errorf("GetMetricData concurrency limit must be a positive value")
+		}
+		if getMetricStatistics <= 0 {
+			return fmt.Errorf("GetMetricStatistics concurrency limit must be a positive value")
+		}
+
+		o.cloudwatchConcurrency.PerAPIEnabled = true
+		o.cloudwatchConcurrency.ListMetrics = listMetrics
+		o.cloudwatchConcurrency.GetMetricData = getMetricData
+		o.cloudwatchConcurrency.GetMetricStatistics = getMetricStatistics
 		return nil
 	}
 }
@@ -108,11 +134,11 @@ func EnableFeatureFlag(flags ...string) OptionsFunc {
 
 func defaultOptions() options {
 	return options{
-		metricsPerQuery:          DefaultMetricsPerQuery,
-		labelsSnakeCase:          DefaultLabelsSnakeCase,
-		cloudWatchAPIConcurrency: DefaultCloudWatchAPIConcurrency,
-		taggingAPIConcurrency:    DefaultTaggingAPIConcurrency,
-		featureFlags:             make(featureFlagsMap),
+		metricsPerQuery:       DefaultMetricsPerQuery,
+		labelsSnakeCase:       DefaultLabelsSnakeCase,
+		taggingAPIConcurrency: DefaultTaggingAPIConcurrency,
+		featureFlags:          make(featureFlagsMap),
+		cloudwatchConcurrency: DefaultCloudwatchConcurrency,
 	}
 }
 
@@ -154,7 +180,7 @@ func UpdateMetrics(
 		cfg,
 		factory,
 		options.metricsPerQuery,
-		options.cloudWatchAPIConcurrency,
+		options.cloudwatchConcurrency,
 		options.taggingAPIConcurrency,
 	)
 

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -37,7 +37,13 @@ const (
 )
 
 var DefaultCloudwatchConcurrency = cloudwatch.ConcurrencyConfig{
-	SingleLimit: 5,
+	SingleLimit:   5,
+	PerAPIEnabled: false,
+
+	// If PerAPIEnabled is enabled, then use the same limit as the single limit by default.
+	ListMetrics:         5,
+	GetMetricData:       5,
+	GetMetricStatistics: 5,
 }
 
 // featureFlagsMap is a map that contains the enabled feature flags. If a key is not present, it means the feature flag

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -33,7 +33,7 @@ func runDiscoveryJob(
 	clientTag tagging.Client,
 	clientCloudwatch cloudwatch.Client,
 	metricsPerQuery int,
-	concurrencyLimit int,
+	cloudwatchConcurrency cloudwatch.ConcurrencyConfig,
 ) ([]*model.TaggedResource, []*model.CloudwatchData) {
 	logger.Debug("Get tagged resources")
 
@@ -67,7 +67,8 @@ func runDiscoveryJob(
 	logger.Debug("GetMetricData partitions", "size", partitionSize)
 
 	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(concurrencyLimit)
+	// TODO: don't know if this is ok, double check, and should work for either per-api and single cl
+	g.SetLimit(cloudwatchConcurrency.GetMetricData)
 
 	mu := sync.Mutex{}
 	getMetricDataOutput := make([][]cloudwatch.MetricDataResult, 0, partitionSize)

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
@@ -16,7 +17,7 @@ func ScrapeAwsData(
 	cfg config.ScrapeConf,
 	factory clients.Factory,
 	metricsPerQuery int,
-	cloudWatchAPIConcurrency int,
+	cloudwatchConcurrency cloudwatch.ConcurrencyConfig,
 	taggingAPIConcurrency int,
 ) ([][]*model.TaggedResource, []model.CloudwatchMetricResult) {
 	mux := &sync.Mutex{}
@@ -38,7 +39,7 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					resources, metrics := runDiscoveryJob(ctx, jobLogger, discoveryJob, region, cfg.Discovery.ExportedTagsOnMetrics, factory.GetTaggingClient(region, role, taggingAPIConcurrency), factory.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency), metricsPerQuery, cloudWatchAPIConcurrency)
+					resources, metrics := runDiscoveryJob(ctx, jobLogger, discoveryJob, region, cfg.Discovery.ExportedTagsOnMetrics, factory.GetTaggingClient(region, role, taggingAPIConcurrency), factory.GetCloudwatchClient(region, role, cloudwatchConcurrency), metricsPerQuery, cloudwatchConcurrency)
 					metricResult := model.CloudwatchMetricResult{
 						Context: &model.JobContext{
 							Region:     region,
@@ -77,7 +78,7 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					metrics := runStaticJob(ctx, jobLogger, staticJob, factory.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency))
+					metrics := runStaticJob(ctx, jobLogger, staticJob, factory.GetCloudwatchClient(region, role, cloudwatchConcurrency))
 					metricResult := model.CloudwatchMetricResult{
 						Context: &model.JobContext{
 							Region:     region,
@@ -108,7 +109,7 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					metrics := runCustomNamespaceJob(ctx, jobLogger, customNamespaceJob, factory.GetCloudwatchClient(region, role, cloudWatchAPIConcurrency), metricsPerQuery)
+					metrics := runCustomNamespaceJob(ctx, jobLogger, customNamespaceJob, factory.GetCloudwatchClient(region, role, cloudwatchConcurrency), metricsPerQuery)
 					metricResult := model.CloudwatchMetricResult{
 						Context: &model.JobContext{
 							Region:     region,


### PR DESCRIPTION
This PR implements a new concurrency mechanism for the CloudWatch client. For this, the client is decoupled of how the concurrency is limited, and two implementations are provided:
1. a single limit limiter, which is the current implementation
2. one that keeps one limit per api call

The second one will allow us to take full advantage of the rate limits imposed by AWS into each api.