### PR TITLE
Improve FIPS endpoints resolve logic for sdk v1

### DIFF
--- a/pkg/clients/v1/factory.go
+++ b/pkg/clients/v1/factory.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -337,9 +336,7 @@ func createStsSession(sess *session.Session, role config.Role, region string, fi
 	}
 
 	if fips {
-		// https://aws.amazon.com/compliance/fips/
-		endpoint := fmt.Sprintf("https://sts-fips.%s.amazonaws.com", region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -353,9 +350,7 @@ func createCloudwatchSession(sess *session.Session, region *string, role config.
 	config := &aws.Config{Region: region, Retryer: getAwsRetryer()}
 
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/cw_region.html
-		endpoint := fmt.Sprintf("https://monitoring-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -396,9 +391,7 @@ func createStorageGatewaySession(sess *session.Session, region *string, role con
 	config := &aws.Config{Region: region, MaxRetries: &maxStorageGatewayAPIRetries}
 
 	if fips {
-		// https://aws.amazon.com/compliance/fips/
-		endpoint := fmt.Sprintf("https://storagegateway-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -412,9 +405,7 @@ func createEC2Session(sess *session.Session, region *string, role config.Role, f
 	maxEC2APIRetries := 10
 	config := &aws.Config{Region: region, MaxRetries: &maxEC2APIRetries}
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/ec2-service.html
-		endpoint := fmt.Sprintf("https://ec2-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -428,8 +419,7 @@ func createPrometheusSession(sess *session.Session, region *string, role config.
 	maxPrometheusAPIRetries := 10
 	config := &aws.Config{Region: region, MaxRetries: &maxPrometheusAPIRetries}
 	if fips {
-		endpoint := fmt.Sprintf("https://aps-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -443,9 +433,7 @@ func createDMSSession(sess *session.Session, region *string, role config.Role, f
 	maxDMSAPIRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxDMSAPIRetries}
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/dms.html
-		endpoint := fmt.Sprintf("https://dms-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -459,9 +447,7 @@ func createAPIGatewaySession(sess *session.Session, region *string, role config.
 	maxAPIGatewayAPIRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/apigateway.html
-		endpoint := fmt.Sprintf("https://apigateway-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -475,9 +461,7 @@ func createAPIGatewayV2Session(sess *session.Session, region *string, role confi
 	maxAPIGatewayAPIRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/apigateway.html
-		endpoint := fmt.Sprintf("https://apigateway-fips.%s.amazonaws.com", *region)
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {
@@ -491,9 +475,7 @@ func createShieldSession(sess *session.Session, region *string, role config.Role
 	maxShieldAPIRetries := 5
 	config := &aws.Config{Region: region, MaxRetries: &maxShieldAPIRetries}
 	if fips {
-		// https://docs.aws.amazon.com/general/latest/gr/shield.html
-		endpoint := "https://shield-fips.us-east-1.amazonaws.com"
-		config.Endpoint = aws.String(endpoint)
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
 	}
 
 	if isDebugEnabled {

--- a/pkg/clients/v1/factory_test.go
+++ b/pkg/clients/v1/factory_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/awstesting/mock"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/stretchr/testify/require"
 
@@ -1122,9 +1121,6 @@ func TestSTSResolvesFIPSEnabledEndpoints(t *testing.T) {
 
 			sess := createStsSession(mock.Session, config.Role{}, tc.region, true, false)
 			require.NotNil(t, sess)
-
-			_, err := sess.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-			require.NoError(t, err)
 
 			require.True(t, called, "expected endpoint resolver to be called")
 			require.NoError(t, resolverError, "no error expected when resolving endpoint")

--- a/pkg/clients/v1/factory_test.go
+++ b/pkg/clients/v1/factory_test.go
@@ -1096,8 +1096,8 @@ func TestSTSResolvesFIPSEnabledEndpoints(t *testing.T) {
 	} {
 		t.Run(tc.region, func(t *testing.T) {
 			var resolverError error
-			var resolvedEndpoint = endpoints.ResolvedEndpoint{}
-			var called = false
+			resolvedEndpoint := endpoints.ResolvedEndpoint{}
+			called := false
 
 			mockSession := mock.Session
 			mockEndpoint := *mockSession.Config.Endpoint


### PR DESCRIPTION
Worked with @ashrayjain 

AWS SDK v2 currently has some issues with resolving FIPS endpoints. For SDK v1, these are still supported, but there's some border cases with gov-regions that follow a different pattern, for example:

<img width="1017" alt="image" src="https://github.com/nerdswords/yet-another-cloudwatch-exporter/assets/2617411/1124cdce-0ced-4e26-a4ef-dd52706330e7">

This PR re-uses the logic that's used in the AWS SDK for resolving [endpoints](https://github.com/aws/aws-sdk-go/blob/cf2803a8077df0fe77831bd94c6d327f3c982970/aws/endpoints/endpoints.go), since that's handled automatically by using the `AWS_USE_FIPS_ENDPOINT` env var, in YACE.

Implemented the work done on https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/1110, with some tests added to corroborate the FIPS option is applied

## Related
Fixes: 
- https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/944
