### PR TITLE
Match FIPS implementation between sdk v1 and sdk v2

### DIFF
--- a/pkg/clients/v1/factory_test.go
+++ b/pkg/clients/v1/factory_test.go
@@ -1030,7 +1030,7 @@ func TestCreatePrometheusSession(t *testing.T) {
 		t,
 		"Prometheus",
 		func(t *testing.T, s *session.Session, region *string, role config.Role, fips bool) {
-			iface := createPrometheusSession(s, region, role, fips, false)
+			iface := createPrometheusSession(s, region, role, false)
 			if iface == nil {
 				t.Fail()
 			}


### PR DESCRIPTION
This PR mirrors the aws sdk v1 FIPS implementation to sdk v2. FIPS is enabled per client when running with FIPS enabled. I originally tried keeping the FIPS setting at the root config and explicitly disabling it for clients which did not support it. But testing showed the root config value takes precedence over client specific values.

As a part of double checking FIPS support on the services, I noticed Amazon Managed Prometheus does not appear to have any FIPS support on https://aws.amazon.com/compliance/fips/. I removed support for enabling FIPS is sdk v1 and v2.

~~The base branch is https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/1115 ATM since both PRs touch the sdk v2 client configs. I'll rebase this one after the retry setting is merged.~~

Resolves: https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/966