### PR TITLE
main: Initialise logger when exiting if needed

### DIFF
--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -36,6 +36,10 @@ var version = "custom-build"
 
 var sem = semaphore.NewWeighted(1)
 
+const (
+	defaultLogFormat = "json"
+)
+
 var (
 	addr                  string
 	configFile            string
@@ -57,6 +61,10 @@ var (
 func main() {
 	app := NewYACEApp()
 	if err := app.Run(os.Args); err != nil {
+		// if we exit very early we'll not have set up the logger yet
+		if logger == nil {
+			logger = logging.NewLogger(defaultLogFormat, debug, "version", version)
+		}
 		logger.Error(err, "Error running yace")
 		os.Exit(1)
 	}
@@ -97,7 +105,7 @@ func NewYACEApp() *cli.App {
 		},
 		&cli.StringFlag{
 			Name:        "log.format",
-			Value:       "json",
+			Value:       defaultLogFormat,
 			Usage:       "Output format of log messages. One of: [logfmt, json]. Default: [json].",
 			Destination: &logFormat,
 			Action: func(ctx *cli.Context, s string) error {


### PR DESCRIPTION
If we exit very early, inside `app.Run` itself, we can get a panic.

This happens when we're given an unknown commandline flag, for example. In that case  `urfave/cli` exits  before parsing the remaining flags and before we could have a chance to set the logger up from them.

When exiting, check if the logger is `nil`, and create one with default parameters if it is.