### PR TITLE
Remove unsupported MWAA resource filter

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -71,9 +71,6 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/MWAA",
 		Alias:     "mwaa",
-		ResourceFilters: []*string{
-			aws.String("mwaa"),
-		},
 	},
 	{
 		Namespace: "AWS/ApplicationELB",


### PR DESCRIPTION
Resolves #1150,

Remove resource filter for MWAA service since it is not supported by the tagging API.