### PR TITLE
Decouple config models from internal models

### DIFF
--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface"
 
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
@@ -26,7 +25,7 @@ func NewClient(logger logging.Logger, cloudwatchAPI cloudwatchiface.CloudWatchAP
 	}
 }
 
-func (c client) ListMetrics(ctx context.Context, namespace string, metric *config.Metric, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
+func (c client) ListMetrics(ctx context.Context, namespace string, metric *model.MetricConfig, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
 	filter := &cloudwatch.ListMetricsInput{
 		MetricName: aws.String(metric.Name),
 		Namespace:  aws.String(namespace),
@@ -129,7 +128,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	return output
 }
 
-func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *config.Metric) []*model.Datapoint {
+func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
 	filter := createGetMetricStatisticsInput(dimensions, &namespace, metric, logger)
 
 	if c.logger.IsDebugEnabled() {

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
@@ -71,7 +70,7 @@ func toCloudWatchDimensions(dimensions []*model.Dimension) []*cloudwatch.Dimensi
 	return cwDim
 }
 
-func createGetMetricStatisticsInput(dimensions []*model.Dimension, namespace *string, metric *config.Metric, logger logging.Logger) *cloudwatch.GetMetricStatisticsInput {
+func createGetMetricStatisticsInput(dimensions []*model.Dimension, namespace *string, metric *model.MetricConfig, logger logging.Logger) *cloudwatch.GetMetricStatisticsInput {
 	period := metric.Period
 	length := metric.Length
 	delay := metric.Delay

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
@@ -26,7 +25,7 @@ func NewClient(logger logging.Logger, cloudwatchAPI *cloudwatch.Client) cloudwat
 	}
 }
 
-func (c client) ListMetrics(ctx context.Context, namespace string, metric *config.Metric, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
+func (c client) ListMetrics(ctx context.Context, namespace string, metric *model.MetricConfig, recentlyActiveOnly bool, fn func(page []*model.Metric)) ([]*model.Metric, error) {
 	filter := &cloudwatch.ListMetricsInput{
 		MetricName: aws.String(metric.Name),
 		Namespace:  aws.String(namespace),
@@ -133,7 +132,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	return output
 }
 
-func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *config.Metric) []*model.Datapoint {
+func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
 	filter := createGetMetricStatisticsInput(logger, dimensions, &namespace, metric)
 	if c.logger.IsDebugEnabled() {
 		c.logger.Debug("GetMetricStatistics", "input", filter)

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
@@ -72,7 +71,7 @@ func toCloudWatchDimensions(dimensions []*model.Dimension) []types.Dimension {
 	return cwDim
 }
 
-func createGetMetricStatisticsInput(logger logging.Logger, dimensions []*model.Dimension, namespace *string, metric *config.Metric) *cloudwatch.GetMetricStatisticsInput {
+func createGetMetricStatisticsInput(logger logging.Logger, dimensions []*model.Dimension, namespace *string, metric *model.MetricConfig) *cloudwatch.GetMetricStatisticsInput {
 	period := metric.Period
 	length := metric.Length
 	delay := metric.Delay

--- a/pkg/clients/factory.go
+++ b/pkg/clients/factory.go
@@ -4,13 +4,13 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/account"
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/tagging"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
 
 // Factory is an interface to abstract away all logic required to produce the different
 // YACE specific clients which wrap AWS clients
 type Factory interface {
-	GetCloudwatchClient(region string, role config.Role, concurrency cloudwatch_client.ConcurrencyConfig) cloudwatch_client.Client
-	GetTaggingClient(region string, role config.Role, concurrencyLimit int) tagging.Client
-	GetAccountClient(region string, role config.Role) account.Client
+	GetCloudwatchClient(region string, role model.Role, concurrency cloudwatch_client.ConcurrencyConfig) cloudwatch_client.Client
+	GetTaggingClient(region string, role model.Role, concurrencyLimit int) tagging.Client
+	GetAccountClient(region string, role model.Role) account.Client
 }

--- a/pkg/clients/tagging/client.go
+++ b/pkg/clients/tagging/client.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"errors"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
 
 type Client interface {
-	GetResources(ctx context.Context, job *config.Job, region string) ([]*model.TaggedResource, error)
+	GetResources(ctx context.Context, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error)
 }
 
 var ErrExpectedToFindResources = errors.New("expected to discover resources but none were found")
@@ -26,7 +25,7 @@ func NewLimitedConcurrencyClient(client Client, maxConcurrency int) Client {
 	}
 }
 
-func (c limitedConcurrencyClient) GetResources(ctx context.Context, job *config.Job, region string) ([]*model.TaggedResource, error) {
+func (c limitedConcurrencyClient) GetResources(ctx context.Context, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 	c.sem <- struct{}{}
 	res, err := c.client.GetResources(ctx, job, region)
 	<-c.sem

--- a/pkg/clients/tagging/v1/client.go
+++ b/pkg/clients/tagging/v1/client.go
@@ -62,7 +62,7 @@ func NewClient(
 	}
 }
 
-func (c client) GetResources(ctx context.Context, job *config.Job, region string) ([]*model.TaggedResource, error) {
+func (c client) GetResources(ctx context.Context, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 	svc := config.SupportedServices.GetService(job.Type)
 	var resources []*model.TaggedResource
 	shouldHaveDiscoveredResources := false

--- a/pkg/clients/tagging/v1/filters.go
+++ b/pkg/clients/tagging/v1/filters.go
@@ -17,14 +17,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/storagegateway"
 	"github.com/grafana/regexp"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
 type ServiceFilter struct {
 	// ResourceFunc can be used to fetch additional resources
-	ResourceFunc func(context.Context, client, *config.Job, string) ([]*model.TaggedResource, error)
+	ResourceFunc func(context.Context, client, model.DiscoveryJob, string) ([]*model.TaggedResource, error)
 
 	// FilterFunc can be used to the input resources or to drop based on some condition
 	FilterFunc func(context.Context, client, []*model.TaggedResource) ([]*model.TaggedResource, error)
@@ -84,7 +83,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/AutoScaling": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.autoscalingAPI.DescribeAutoScalingGroupsPagesWithContext(ctx, &autoscaling.DescribeAutoScalingGroupsInput{},
@@ -171,7 +170,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/EC2Spot": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.ec2API.DescribeSpotFleetRequestsPagesWithContext(ctx, &ec2.DescribeSpotFleetRequestsInput{},
@@ -204,7 +203,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/Prometheus": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.prometheusSvcAPI.ListWorkspacesPagesWithContext(ctx, &prometheusservice.ListWorkspacesInput{},
@@ -237,7 +236,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/StorageGateway": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.storageGatewayAPI.ListGatewaysPagesWithContext(ctx, &storagegateway.ListGatewaysInput{},
@@ -277,7 +276,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/TransitGateway": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			err := client.ec2API.DescribeTransitGatewayAttachmentsPagesWithContext(ctx, &ec2.DescribeTransitGatewayAttachmentsInput{},
@@ -313,7 +312,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		// Resource discovery only targets the protections, protections are global, so they will only be discoverable in us-east-1.
 		// Outside us-east-1 no resources are going to be found. We use the shield.ListProtections API to get the protections +
 		// protected resources to add to the tagged resources. This data is eventually usable for joining with metrics.
-		ResourceFunc: func(ctx context.Context, c client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, c client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			var output []*model.TaggedResource
 			pageNum := 0
 			// Default page size is only 20 which can easily lead to throttling

--- a/pkg/clients/tagging/v2/client.go
+++ b/pkg/clients/tagging/v2/client.go
@@ -61,7 +61,7 @@ func NewClient(
 	}
 }
 
-func (c client) GetResources(ctx context.Context, job *config.Job, region string) ([]*model.TaggedResource, error) {
+func (c client) GetResources(ctx context.Context, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 	svc := config.SupportedServices.GetService(job.Type)
 	var resources []*model.TaggedResource
 	shouldHaveDiscoveredResources := false

--- a/pkg/clients/tagging/v2/filters.go
+++ b/pkg/clients/tagging/v2/filters.go
@@ -17,14 +17,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/grafana/regexp"
 
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
 type ServiceFilter struct {
 	// ResourceFunc can be used to fetch additional resources
-	ResourceFunc func(context.Context, client, *config.Job, string) ([]*model.TaggedResource, error)
+	ResourceFunc func(context.Context, client, model.DiscoveryJob, string) ([]*model.TaggedResource, error)
 
 	// FilterFunc can be used to modify the input resources or to drop based on some condition
 	FilterFunc func(context.Context, client, []*model.TaggedResource) ([]*model.TaggedResource, error)
@@ -85,7 +84,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/AutoScaling": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			paginator := autoscaling.NewDescribeAutoScalingGroupsPaginator(client.autoscalingAPI, &autoscaling.DescribeAutoScalingGroupsInput{}, func(options *autoscaling.DescribeAutoScalingGroupsPaginatorOptions) {
@@ -178,7 +177,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/EC2Spot": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			paginator := ec2.NewDescribeSpotFleetRequestsPaginator(client.ec2API, &ec2.DescribeSpotFleetRequestsInput{}, func(options *ec2.DescribeSpotFleetRequestsPaginatorOptions) {
@@ -213,7 +212,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/Prometheus": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			paginator := amp.NewListWorkspacesPaginator(client.prometheusSvcAPI, &amp.ListWorkspacesInput{}, func(options *amp.ListWorkspacesPaginatorOptions) {
@@ -248,7 +247,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/StorageGateway": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			paginator := storagegateway.NewListGatewaysPaginator(client.storageGatewayAPI, &storagegateway.ListGatewaysInput{}, func(options *storagegateway.ListGatewaysPaginatorOptions) {
@@ -289,7 +288,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		},
 	},
 	"AWS/TransitGateway": {
-		ResourceFunc: func(ctx context.Context, client client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0
 			var resources []*model.TaggedResource
 			paginator := ec2.NewDescribeTransitGatewayAttachmentsPaginator(client.ec2API, &ec2.DescribeTransitGatewayAttachmentsInput{}, func(options *ec2.DescribeTransitGatewayAttachmentsPaginatorOptions) {
@@ -327,7 +326,7 @@ var ServiceFilters = map[string]ServiceFilter{
 		// Resource discovery only targets the protections, protections are global, so they will only be discoverable in us-east-1.
 		// Outside us-east-1 no resources are going to be found. We use the shield.ListProtections API to get the protections +
 		// protected resources to add to the tagged resources. This data is eventually usable for joining with metrics.
-		ResourceFunc: func(ctx context.Context, c client, job *config.Job, region string) ([]*model.TaggedResource, error) {
+		ResourceFunc: func(ctx context.Context, c client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			var output []*model.TaggedResource
 			// Default page size is only 20 which can easily lead to throttling
 			request := &shield.ListProtectionsInput{MaxResults: aws.Int32(1000)}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfLoad(t *testing.T) {
 	for _, tc := range testCases {
 		config := ScrapeConf{}
 		configFile := fmt.Sprintf("testdata/%s", tc.configFile)
-		if err := config.Load(configFile, logging.NewNopLogger()); err != nil {
+		if _, err := config.Load(configFile, logging.NewNopLogger()); err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
@@ -64,7 +64,7 @@ func TestBadConfigs(t *testing.T) {
 	for _, tc := range testCases {
 		config := ScrapeConf{}
 		configFile := fmt.Sprintf("testdata/%s", tc.configFile)
-		if err := config.Load(configFile, logging.NewNopLogger()); err != nil {
+		if _, err := config.Load(configFile, logging.NewNopLogger()); err != nil {
 			if !strings.Contains(err.Error(), tc.errorMsg) {
 				t.Errorf("expecter error for config file %q to contain %q but got: %s", tc.configFile, tc.errorMsg, err)
 				t.FailNow()

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
@@ -163,7 +164,7 @@ func defaultOptions() options {
 func UpdateMetrics(
 	ctx context.Context,
 	logger logging.Logger,
-	cfg config.ScrapeConf,
+	jobsCfg model.JobsConfig,
 	registry *prometheus.Registry,
 	factory clients.Factory,
 	optFuncs ...OptionsFunc,
@@ -181,7 +182,7 @@ func UpdateMetrics(
 	tagsData, cloudwatchData := job.ScrapeAwsData(
 		ctx,
 		logger,
-		cfg,
+		jobsCfg,
 		factory,
 		options.metricsPerQuery,
 		options.cloudwatchConcurrency,

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
@@ -16,7 +15,7 @@ import (
 func runCustomNamespaceJob(
 	ctx context.Context,
 	logger logging.Logger,
-	job *config.CustomNamespace,
+	job model.CustomNamespaceJob,
 	clientCloudwatch cloudwatch.Client,
 	metricsPerQuery int,
 ) []*model.CloudwatchData {
@@ -84,7 +83,7 @@ func findGetMetricDataByIDForCustomNamespace(getMetricDatas []*model.CloudwatchD
 
 func getMetricDataForQueriesForCustomNamespace(
 	ctx context.Context,
-	customNamespaceJob *config.CustomNamespace,
+	customNamespaceJob model.CustomNamespaceJob,
 	clientCloudwatch cloudwatch.Client,
 	logger logging.Logger,
 ) []*model.CloudwatchData {
@@ -99,7 +98,7 @@ func getMetricDataForQueriesForCustomNamespace(
 		// This includes, for this metric the possible combinations
 		// of dimensions and value of dimensions with data.
 
-		go func(metric *config.Metric) {
+		go func(metric *model.MetricConfig) {
 			defer wg.Done()
 			metricsList, err := clientCloudwatch.ListMetrics(ctx, customNamespaceJob.Namespace, metric, customNamespaceJob.RecentlyActiveOnly, nil)
 			if err != nil {

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -22,12 +22,12 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		accountID                 string
 		namespace                 string
 		customTags                []model.Tag
-		tagsOnMetrics             model.ExportedTagsOnMetrics
+		tagsOnMetrics             []string
 		dimensionRegexps          []*regexp.Regexp
 		dimensionNameRequirements []string
 		resources                 []*model.TaggedResource
 		metricsList               []*model.Metric
-		m                         *config.Metric
+		m                         *model.MetricConfig
 	}
 	tests := []struct {
 		name               string
@@ -41,11 +41,9 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				accountID:  "123123123123",
 				namespace:  "efs",
 				customTags: nil,
-				tagsOnMetrics: map[string][]string{
-					"efs": {
-						"Value1",
-						"Value2",
-					},
+				tagsOnMetrics: []string{
+					"Value1",
+					"Value2",
 				},
 				dimensionRegexps: config.SupportedServices.GetService("efs").DimensionRegexps,
 				resources: []*model.TaggedResource{
@@ -77,7 +75,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Namespace: "AWS/EFS",
 					},
 				},
-				m: &config.Metric{
+				m: &model.MetricConfig{
 					Name: "StorageBytes",
 					Statistics: []string{
 						"Average",
@@ -130,11 +128,9 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				accountID:  "123123123123",
 				namespace:  "ec2",
 				customTags: nil,
-				tagsOnMetrics: map[string][]string{
-					"ec2": {
-						"Value1",
-						"Value2",
-					},
+				tagsOnMetrics: []string{
+					"Value1",
+					"Value2",
 				},
 				dimensionRegexps: config.SupportedServices.GetService("ec2").DimensionRegexps,
 				resources: []*model.TaggedResource{
@@ -162,7 +158,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Namespace: "AWS/EC2",
 					},
 				},
-				m: &config.Metric{
+				m: &model.MetricConfig{
 					Name: "CPUUtilization",
 					Statistics: []string{
 						"Average",
@@ -211,11 +207,9 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				accountID:  "123123123123",
 				namespace:  "kafka",
 				customTags: nil,
-				tagsOnMetrics: map[string][]string{
-					"kafka": {
-						"Value1",
-						"Value2",
-					},
+				tagsOnMetrics: []string{
+					"Value1",
+					"Value2",
 				},
 				dimensionRegexps: config.SupportedServices.GetService("kafka").DimensionRegexps,
 				resources: []*model.TaggedResource{
@@ -243,7 +237,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Namespace: "AWS/Kafka",
 					},
 				},
-				m: &config.Metric{
+				m: &model.MetricConfig{
 					Name: "GlobalTopicCount",
 					Statistics: []string{
 						"Average",
@@ -366,7 +360,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Namespace: "AWS/ApplicationELB",
 					},
 				},
-				m: &config.Metric{
+				m: &model.MetricConfig{
 					Name: "RequestCount",
 					Statistics: []string{
 						"Sum",

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
@@ -13,7 +12,7 @@ import (
 func runStaticJob(
 	ctx context.Context,
 	logger logging.Logger,
-	resource *config.Static,
+	resource model.StaticJob,
 	clientCloudwatch cloudwatch.Client,
 ) []*model.CloudwatchData {
 	cw := []*model.CloudwatchData{}
@@ -50,7 +49,7 @@ func runStaticJob(
 	return cw
 }
 
-func createStaticDimensions(dimensions []config.Dimension) []*model.Dimension {
+func createStaticDimensions(dimensions []model.Dimension) []*model.Dimension {
 	out := make([]*model.Dimension, 0, len(dimensions))
 	for _, d := range dimensions {
 		d := d

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -175,7 +175,7 @@ func Test_MetricTags(t *testing.T) {
 	testCases := []struct {
 		testName     string
 		resourceTags []Tag
-		exportedTags ExportedTagsOnMetrics
+		exportedTags []string
 		result       []Tag
 	}{
 		{
@@ -186,7 +186,7 @@ func Test_MetricTags(t *testing.T) {
 					Value: "v1",
 				},
 			},
-			exportedTags: ExportedTagsOnMetrics{},
+			exportedTags: []string{},
 			result:       []Tag{},
 		},
 		{
@@ -197,9 +197,7 @@ func Test_MetricTags(t *testing.T) {
 					Value: "v1",
 				},
 			},
-			exportedTags: ExportedTagsOnMetrics{
-				"AWS/Service": []string{"k1"},
-			},
+			exportedTags: []string{"k1"},
 			result: []Tag{
 				{
 					Key:   "k1",
@@ -215,9 +213,7 @@ func Test_MetricTags(t *testing.T) {
 					Value: "v1",
 				},
 			},
-			exportedTags: ExportedTagsOnMetrics{
-				"AWS/Service": []string{"k1", "k2"},
-			},
+			exportedTags: []string{"k1", "k2"},
 			result: []Tag{
 				{
 					Key:   "k1",
@@ -232,41 +228,13 @@ func Test_MetricTags(t *testing.T) {
 		{
 			testName:     "resource without tags",
 			resourceTags: []Tag{},
-			exportedTags: ExportedTagsOnMetrics{
-				"AWS/Service": []string{"k1"},
-			},
+			exportedTags: []string{"k1"},
 			result: []Tag{
 				{
 					Key:   "k1",
 					Value: "",
 				},
 			},
-		},
-		{
-			testName: "empty exported tags for service",
-			resourceTags: []Tag{
-				{
-					Key:   "k1",
-					Value: "v1",
-				},
-			},
-			exportedTags: ExportedTagsOnMetrics{
-				"AWS/Service": []string{},
-			},
-			result: []Tag{},
-		},
-		{
-			testName: "unmatching service",
-			resourceTags: []Tag{
-				{
-					Key:   "k1",
-					Value: "v1",
-				},
-			},
-			exportedTags: ExportedTagsOnMetrics{
-				"AWS/Service_unknown": []string{"k1"},
-			},
-			result: []Tag{},
 		},
 	}
 


### PR DESCRIPTION
With this change, models used for config parsing are fully decoupled from models used internally at scrape time. Once the config is parsed and validated, it is converted to a representation used internally for the actual scrape logic.

The down side of this approach:
- structs appear duplicated between the `config` and `models`
- after parsing we go through a complete mapping of fields to the internal models representation (this has unnoticeable impact at startup and zero impact at runtime)

On the pros side of things:
- allows to continue improving the design of internal models without impacting the configuration
- allows multiple config format to co-exist

Coincidentally this also fixes https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1160