### PR TITLE
Add support for AWS Bedrock metrics

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -832,4 +832,8 @@ var SupportedServices = serviceConfigs{
 			regexp.MustCompile(":pipeline/(?P<PipelineName>[^/]+)"),
 		},
 	},
+	{
+		Namespace: "AWS/Bedrock",
+		Alias:     "bedrock",
+	},
 }


### PR DESCRIPTION
This PR adds support for [Bedrock metrics](https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-cw.html). AWS Bedrock provides a service for executing pre-trained (or fine-tuned) LLMS or ML models, so basically all metrics are related to api calls latencies, counts, input/output token sizes. 

Bedrock [supports tagging custom models](https://docs.aws.amazon.com/bedrock/latest/userguide/tagging.html), which I didn't get the chance to try out. This PR just adds support for all metrics for all models, without importing tags data.

<img width="1256" alt="image" src="https://github.com/nerdswords/yet-another-cloudwatch-exporter/assets/2617411/7eaf6c88-9b7c-482d-9e2e-645a68e3eea6">
