### PR TITLE
Refactor dimensions regexp usage for discovery jobs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,6 +356,8 @@ func (c *ScrapeConf) toModelConfig() model.JobsConfig {
 	jobsCfg.StsRegion = c.StsRegion
 
 	for _, discoveryJob := range c.Discovery.Jobs {
+		svc := SupportedServices.GetService(discoveryJob.Type)
+
 		job := model.DiscoveryJob{}
 		job.Regions = discoveryJob.Regions
 		job.Type = discoveryJob.Type
@@ -373,10 +375,10 @@ func (c *ScrapeConf) toModelConfig() model.JobsConfig {
 		job.CustomTags = toModelTags(discoveryJob.CustomTags)
 		job.Metrics = toModelMetricConfig(discoveryJob.Metrics)
 		job.IncludeContextOnInfoMetrics = discoveryJob.IncludeContextOnInfoMetrics
+		job.DimensionsRegexps = svc.ToModelDimensionsRegexp()
 
 		job.ExportedTagsOnMetrics = []string{}
 		if len(c.Discovery.ExportedTagsOnMetrics) > 0 {
-			svc := SupportedServices.GetService(job.Type)
 			if exportedTags, ok := c.Discovery.ExportedTagsOnMetrics[svc.Namespace]; ok {
 				job.ExportedTagsOnMetrics = exportedTags
 			} else if exportedTags, ok := c.Discovery.ExportedTagsOnMetrics[svc.Alias]; ok {

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -181,7 +181,7 @@ func getMetricDataForQueries(
 
 	var assoc resourceAssociator
 	if len(svc.DimensionRegexps) > 0 && len(resources) > 0 {
-		assoc = maxdimassociator.NewAssociator(logger, svc.DimensionRegexps, resources)
+		assoc = maxdimassociator.NewAssociator(logger, discoveryJob.DimensionsRegexps, resources)
 	} else {
 		// If we don't have dimension regex's and resources there's nothing to associate but metrics shouldn't be skipped
 		assoc = nopAssociator{}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/grafana/regexp"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -23,7 +22,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		namespace                 string
 		customTags                []model.Tag
 		tagsOnMetrics             []string
-		dimensionRegexps          []*regexp.Regexp
+		dimensionRegexps          []model.DimensionsRegexp
 		dimensionNameRequirements []string
 		resources                 []*model.TaggedResource
 		metricsList               []*model.Metric
@@ -45,7 +44,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					"Value1",
 					"Value2",
 				},
-				dimensionRegexps: config.SupportedServices.GetService("efs").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EFS").ToModelDimensionsRegexp(),
 				resources: []*model.TaggedResource{
 					{
 						ARN: "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
@@ -132,7 +131,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					"Value1",
 					"Value2",
 				},
-				dimensionRegexps: config.SupportedServices.GetService("ec2").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
 				resources: []*model.TaggedResource{
 					{
 						ARN: "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
@@ -211,7 +210,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					"Value1",
 					"Value2",
 				},
-				dimensionRegexps: config.SupportedServices.GetService("kafka").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Kafka").ToModelDimensionsRegexp(),
 				resources: []*model.TaggedResource{
 					{
 						ARN: "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
@@ -287,7 +286,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				namespace:                 "alb",
 				customTags:                nil,
 				tagsOnMetrics:             nil,
-				dimensionRegexps:          config.SupportedServices.GetService("alb").DimensionRegexps,
+				dimensionRegexps:          config.SupportedServices.GetService("AWS/ApplicationELB").ToModelDimensionsRegexp(),
 				dimensionNameRequirements: []string{"LoadBalancer", "TargetGroup"},
 				resources: []*model.TaggedResource{
 					{

--- a/pkg/job/maxdimassociator/associator_api_gateway_test.go
+++ b/pkg/job/maxdimassociator/associator_api_gateway_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -35,7 +34,7 @@ var apiGatewayResources = []*model.TaggedResource{apiGatewayV1, apiGatewayV1Stag
 
 func TestAssociatorAPIGateway(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -51,7 +50,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 		{
 			name: "should match API Gateway V2 with ApiId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").ToModelDimensionsRegexp(),
 				resources:        apiGatewayResources,
 				metric: &model.Metric{
 					MetricName: "5xx",
@@ -67,7 +66,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 		{
 			name: "should match API Gateway V2 with ApiId and Stage dimensions",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").ToModelDimensionsRegexp(),
 				resources:        apiGatewayResources,
 				metric: &model.Metric{
 					MetricName: "5xx",
@@ -84,7 +83,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 		{
 			name: "should match API Gateway V1 with ApiName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").ToModelDimensionsRegexp(),
 				resources:        apiGatewayResources,
 				metric: &model.Metric{
 					MetricName: "5xx",
@@ -100,7 +99,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 		{
 			name: "should match API Gateway V1 with ApiName and Stage dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").ToModelDimensionsRegexp(),
 				resources:        apiGatewayResources,
 				metric: &model.Metric{
 					MetricName: "5xx",
@@ -117,7 +116,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 		{
 			name: "should match API Gateway V1 with ApiName (Stage is not matched)",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ApiGateway").ToModelDimensionsRegexp(),
 				resources:        apiGatewayResources,
 				metric: &model.Metric{
 					MetricName: "5xx",

--- a/pkg/job/maxdimassociator/associator_client_vpn_test.go
+++ b/pkg/job/maxdimassociator/associator_client_vpn_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -18,7 +17,7 @@ var clientVpn = &model.TaggedResource{
 
 func TestAssociatorClientVPN(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -34,7 +33,7 @@ func TestAssociatorClientVPN(t *testing.T) {
 		{
 			name: "should match ClientVPN with Endpoint dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ClientVPN").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ClientVPN").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{clientVpn},
 				metric: &model.Metric{
 					MetricName: "CrlDaysToExpiry",

--- a/pkg/job/maxdimassociator/associator_ddosprotection_test.go
+++ b/pkg/job/maxdimassociator/associator_ddosprotection_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var protectedResources = []*model.TaggedResource{
 
 func TestAssociatorDDoSProtection(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorDDoSProtection(t *testing.T) {
 		{
 			name: "should match with ResourceArn dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/DDoSProtection").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/DDoSProtection").ToModelDimensionsRegexp(),
 				resources:        protectedResources,
 				metric: &model.Metric{
 					Namespace:  "AWS/DDoSProtection",

--- a/pkg/job/maxdimassociator/associator_dx_test.go
+++ b/pkg/job/maxdimassociator/associator_dx_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -18,7 +17,7 @@ var dxVif = &model.TaggedResource{
 
 func TestAssociatorDX(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -34,7 +33,7 @@ func TestAssociatorDX(t *testing.T) {
 		{
 			name: "should match Virtual Interface with VirtualInterfaceId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/DX").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/DX").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{dxVif},
 				metric: &model.Metric{
 					MetricName: "VirtualInterfaceBpsIngress",

--- a/pkg/job/maxdimassociator/associator_ec2_test.go
+++ b/pkg/job/maxdimassociator/associator_ec2_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var ec2Resources = []*model.TaggedResource{
 
 func TestAssociatorEC2(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorEC2(t *testing.T) {
 		{
 			name: "should match with InstanceId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
 				resources:        ec2Resources,
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
@@ -60,7 +59,7 @@ func TestAssociatorEC2(t *testing.T) {
 		{
 			name: "should match another instance with InstanceId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
 				resources:        ec2Resources,
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
@@ -76,7 +75,7 @@ func TestAssociatorEC2(t *testing.T) {
 		{
 			name: "should skip with unmatched InstanceId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
 				resources:        ec2Resources,
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
@@ -92,7 +91,7 @@ func TestAssociatorEC2(t *testing.T) {
 		{
 			name: "should not skip when unmatching because of non-ARN dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
 				resources:        ec2Resources,
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",

--- a/pkg/job/maxdimassociator/associator_ecs_test.go
+++ b/pkg/job/maxdimassociator/associator_ecs_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -34,7 +33,7 @@ var ecsResources = []*model.TaggedResource{
 
 func TestAssociatorECS(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -50,7 +49,7 @@ func TestAssociatorECS(t *testing.T) {
 		{
 			name: "cluster metric should be assigned cluster resource",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").ToModelDimensionsRegexp(),
 				resources:        ecsResources,
 				metric: &model.Metric{
 					MetricName: "MemoryReservation",
@@ -66,7 +65,7 @@ func TestAssociatorECS(t *testing.T) {
 		{
 			name: "service metric should be assigned service1 resource",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").ToModelDimensionsRegexp(),
 				resources:        ecsResources,
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
@@ -83,7 +82,7 @@ func TestAssociatorECS(t *testing.T) {
 		{
 			name: "service metric should be assigned service2 resource",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/ECS").ToModelDimensionsRegexp(),
 				resources:        ecsResources,
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",

--- a/pkg/job/maxdimassociator/associator_event_roles_test.go
+++ b/pkg/job/maxdimassociator/associator_event_roles_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var eventRuleResources = []*model.TaggedResource{
 
 func TestAssociatorEventRule(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorEventRule(t *testing.T) {
 		{
 			name: "2 dimensions should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Events").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Events").ToModelDimensionsRegexp(),
 				resources:        eventRuleResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",

--- a/pkg/job/maxdimassociator/associator_globalaccelerator_test.go
+++ b/pkg/job/maxdimassociator/associator_globalaccelerator_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -34,7 +33,7 @@ var globalAcceleratorResources = []*model.TaggedResource{
 
 func TestAssociatorGlobalAccelerator(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -50,7 +49,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 		{
 			name: "should match with Accelerator dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").ToModelDimensionsRegexp(),
 				resources:        globalAcceleratorResources,
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",
@@ -66,7 +65,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 		{
 			name: "should match Listener with Accelerator and Listener dimensions",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").ToModelDimensionsRegexp(),
 				resources:        globalAcceleratorResources,
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",
@@ -83,7 +82,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 		{
 			name: "should match EndpointGroup with Accelerator, Listener and EndpointGroup dimensions",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/GlobalAccelerator").ToModelDimensionsRegexp(),
 				resources:        globalAcceleratorResources,
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",

--- a/pkg/job/maxdimassociator/associator_ipam_test.go
+++ b/pkg/job/maxdimassociator/associator_ipam_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var ipamResources = []*model.TaggedResource{
 
 func TestAssociatorIpam(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorIpam(t *testing.T) {
 		{
 			name: "should match with IpamPoolId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/IPAM").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/IPAM").ToModelDimensionsRegexp(),
 				resources:        ipamResources,
 				metric: &model.Metric{
 					MetricName: "VpcIPUsage",
@@ -54,7 +53,7 @@ func TestAssociatorIpam(t *testing.T) {
 		{
 			name: "should skip with unmatched IpamPoolId dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/IPAM").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/IPAM").ToModelDimensionsRegexp(),
 				resources:        ipamResources,
 				metric: &model.Metric{
 					MetricName: "VpcIPUsage",

--- a/pkg/job/maxdimassociator/associator_lambda_test.go
+++ b/pkg/job/maxdimassociator/associator_lambda_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -20,7 +19,7 @@ var lambdaResources = []*model.TaggedResource{lambdaFunction}
 
 func TestAssociatorLambda(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -36,7 +35,7 @@ func TestAssociatorLambda(t *testing.T) {
 		{
 			name: "should match with FunctionName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").ToModelDimensionsRegexp(),
 				resources:        lambdaResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -52,7 +51,7 @@ func TestAssociatorLambda(t *testing.T) {
 		{
 			name: "should skip with unmatched FunctionName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").ToModelDimensionsRegexp(),
 				resources:        lambdaResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -68,7 +67,7 @@ func TestAssociatorLambda(t *testing.T) {
 		{
 			name: "should match with FunctionName and Resource dimensions",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").ToModelDimensionsRegexp(),
 				resources:        lambdaResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -85,7 +84,7 @@ func TestAssociatorLambda(t *testing.T) {
 		{
 			name: "should not skip when empty dimensions",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Lambda").ToModelDimensionsRegexp(),
 				resources:        lambdaResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",

--- a/pkg/job/maxdimassociator/associator_mediaconvert_test.go
+++ b/pkg/job/maxdimassociator/associator_mediaconvert_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var mediaConvertResources = []*model.TaggedResource{
 
 func TestAssociatorMediaConvert(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 		{
 			name: "should match with mediaconvert queue one dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").ToModelDimensionsRegexp(),
 				resources:        mediaConvertResources,
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",
@@ -60,7 +59,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 		{
 			name: "should match with mediaconvert queue two dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").ToModelDimensionsRegexp(),
 				resources:        mediaConvertResources,
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",
@@ -76,7 +75,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 		{
 			name: "should not match with any mediaconvert queue",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MediaConvert").ToModelDimensionsRegexp(),
 				resources:        mediaConvertResources,
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",

--- a/pkg/job/maxdimassociator/associator_memorydb_test.go
+++ b/pkg/job/maxdimassociator/associator_memorydb_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var memoryDBClusters = []*model.TaggedResource{
 
 func TestAssociatorMemoryDB(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 		{
 			name: "should match with ClusterName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").ToModelDimensionsRegexp(),
 				resources:        memoryDBClusters,
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
@@ -60,7 +59,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 		{
 			name: "should match another instance with ClusterName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").ToModelDimensionsRegexp(),
 				resources:        memoryDBClusters,
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
@@ -76,7 +75,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 		{
 			name: "should skip with unmatched ClusterName dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").ToModelDimensionsRegexp(),
 				resources:        memoryDBClusters,
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
@@ -92,7 +91,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 		{
 			name: "should not skip when unmatching because of non-ARN dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/MemoryDB").ToModelDimensionsRegexp(),
 				resources:        memoryDBClusters,
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",

--- a/pkg/job/maxdimassociator/associator_mq_test.go
+++ b/pkg/job/maxdimassociator/associator_mq_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -23,7 +22,7 @@ var activeMQBroker = &model.TaggedResource{
 
 func TestAssociatorMQ(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -39,7 +38,7 @@ func TestAssociatorMQ(t *testing.T) {
 		{
 			name: "should match with Broker dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{rabbitMQBroker},
 				metric: &model.Metric{
 					MetricName: "ProducerCount",
@@ -53,12 +52,12 @@ func TestAssociatorMQ(t *testing.T) {
 			expectedResource: rabbitMQBroker,
 		},
 		{
-			// ActiveMQ allows active/stadby modes where the `Broker` dimension has values
+			// ActiveMQ allows active/standby modes where the `Broker` dimension has values
 			// like `brokername-1` and `brokername-2` which don't match the ARN (the dimension
 			// regex will extract `Broker` as `brokername` from ARN)
 			name: "should match with Broker dimension when broker name has a number suffix",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{activeMQBroker},
 				metric: &model.Metric{
 					MetricName: "ProducerCount",

--- a/pkg/job/maxdimassociator/associator_qldb_test.go
+++ b/pkg/job/maxdimassociator/associator_qldb_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -18,7 +17,7 @@ var validQldbInstance = &model.TaggedResource{
 
 func TestAssociatorQLDB(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -34,7 +33,7 @@ func TestAssociatorQLDB(t *testing.T) {
 		{
 			name: "should match with ledger name dimension",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/QLDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/QLDB").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{validQldbInstance},
 				metric: &model.Metric{
 					Namespace:  "AWS/QLDB",
@@ -50,7 +49,7 @@ func TestAssociatorQLDB(t *testing.T) {
 		{
 			name: "should not match with ledger name dimension when QLDB arn is not valid",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/QLDB").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/QLDB").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{validQldbInstance},
 				metric: &model.Metric{
 					Namespace:  "AWS/QLDB",

--- a/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var sagemakerHealthResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerEndpoint(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 		{
 			name: "2 dimensions should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").ToModelDimensionsRegexp(),
 				resources:        sagemakerHealthResources,
 				metric: &model.Metric{
 					MetricName: "MemoryUtilization",
@@ -61,7 +60,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 		{
 			name: "2 dimensions should not match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/Endpoints").ToModelDimensionsRegexp(),
 				resources:        sagemakerHealthResources,
 				metric: &model.Metric{
 					MetricName: "MemoryUtilization",

--- a/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var sagemakerInfRecJobResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerInfRecJob(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorSagemakerInfRecJob(t *testing.T) {
 		{
 			name: "1 dimension should not match but not skip",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/InferenceRecommendationsJobs").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/InferenceRecommendationsJobs").ToModelDimensionsRegexp(),
 				resources:        sagemakerInfRecJobResources,
 				metric: &model.Metric{
 					MetricName: "ClientInvocations",

--- a/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -28,7 +27,7 @@ var sagemakerPipelineResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerPipeline(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -44,7 +43,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 		{
 			name: "2 dimensions should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").ToModelDimensionsRegexp(),
 				resources:        sagemakerPipelineResources,
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",
@@ -61,7 +60,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 		{
 			name: "1 dimension should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").ToModelDimensionsRegexp(),
 				resources:        sagemakerPipelineResources,
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",
@@ -77,7 +76,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 		{
 			name: "2 dimensions should not match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Sagemaker/ModelBuildingPipeline").ToModelDimensionsRegexp(),
 				resources:        sagemakerPipelineResources,
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",

--- a/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var sagemakerProcessingJobResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerProcessingJob(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorSagemakerProcessingJob(t *testing.T) {
 		{
 			name: "1 dimension should not match but not skip",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/ProcessingJobs").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/ProcessingJobs").ToModelDimensionsRegexp(),
 				resources:        sagemakerProcessingJobResources,
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",

--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -34,7 +33,7 @@ var sagemakerInvocationResources = []*model.TaggedResource{
 
 func TestAssociatorSagemaker(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -50,7 +49,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 		{
 			name: "3 dimensions should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").ToModelDimensionsRegexp(),
 				resources:        sagemakerInvocationResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -68,7 +67,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 		{
 			name: "2 dimensions should match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").ToModelDimensionsRegexp(),
 				resources:        sagemakerInvocationResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -85,7 +84,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 		{
 			name: "2 dimensions should not match",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").ToModelDimensionsRegexp(),
 				resources:        sagemakerInvocationResources,
 				metric: &model.Metric{
 					MetricName: "Invocations",
@@ -102,7 +101,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 		{
 			name: "2 dimensions should match in Upper case",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").ToModelDimensionsRegexp(),
 				resources:        sagemakerInvocationResources,
 				metric: &model.Metric{
 					MetricName: "ModelLatency",

--- a/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var sagemakerTrainingJobResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 		{
 			name: "1 dimension should not skip",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TrainingJobs").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TrainingJobs").ToModelDimensionsRegexp(),
 				resources:        sagemakerTrainingJobResources,
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",

--- a/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
@@ -3,7 +3,6 @@ package maxdimassociator
 import (
 	"testing"
 
-	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -22,7 +21,7 @@ var sagemakerTransformJobResources = []*model.TaggedResource{
 
 func TestAssociatorSagemakerTransformJob(t *testing.T) {
 	type args struct {
-		dimensionRegexps []*regexp.Regexp
+		dimensionRegexps []model.DimensionsRegexp
 		resources        []*model.TaggedResource
 		metric           *model.Metric
 	}
@@ -38,7 +37,7 @@ func TestAssociatorSagemakerTransformJob(t *testing.T) {
 		{
 			name: "1 dimension should not match but not skip",
 			args: args{
-				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TransformJobs").DimensionRegexps,
+				dimensionRegexps: config.SupportedServices.GetService("/aws/sagemaker/TransformJobs").ToModelDimensionsRegexp(),
 				resources:        sagemakerTransformJobResources,
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -31,6 +31,7 @@ type DiscoveryJob struct {
 	RecentlyActiveOnly          bool
 	ExportedTagsOnMetrics       []string
 	IncludeContextOnInfoMetrics bool
+	DimensionsRegexps           []DimensionsRegexp
 	JobLevelMetricFields
 }
 
@@ -79,6 +80,11 @@ type MetricConfig struct {
 	Delay                  int64
 	NilToZero              *bool
 	AddCloudwatchTimestamp *bool
+}
+
+type DimensionsRegexp struct {
+	Regexp          *regexp.Regexp
+	DimensionsNames []string
 }
 
 type LabelSet map[string]struct{}


### PR DESCRIPTION
In discovery jobs, the associator extracts dimensions names from services regexp definitions at each scrape. With this changes, names are pre-computed as part of building the job model. This also fixes a race condition where the slice of dimensions names was modified in place (whereas regexp.SubexpNames() suggests it shouldn't).