### PR TITLE
Restore default behaviour of returning nil/absent metrics as NaN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	go build -v -ldflags "$(GO_LDFLAGS)" -o yace ./cmd/yace
 
 test:
-	go test -v -bench=^$ -race -count=1 ./...
+	go test -v -bench=^$$ -race -count=1 ./...
 
 lint:
 	golangci-lint run -v -c .golangci.yml

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -44,7 +44,7 @@ type ConcurrencyLimiter interface {
 
 type MetricDataResult struct {
 	ID        string
-	Datapoint float64
+	Datapoint *float64
 	Timestamp time.Time
 }
 

--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -116,7 +116,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = *metricDataResult.Values[0]
+			mappedResult.Datapoint = metricDataResult.Values[0]
 			mappedResult.Timestamp = *metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -122,7 +122,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = metricDataResult.Values[0]
+			mappedResult.Datapoint = &metricDataResult.Values[0]
 			mappedResult.Timestamp = metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v2/client_test.go
+++ b/pkg/clients/cloudwatch/v2/client_test.go
@@ -1,32 +1,17 @@
-package v1
+package v2
 
 import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
 	"github.com/stretchr/testify/require"
 
 	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
-	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 )
-
-func TestDimensionsToCliString(t *testing.T) {
-	// Setup Test
-
-	// Arrange
-	dimensions := []*model.Dimension{}
-	expected := ""
-
-	// Act
-	actual := dimensionsToCliString(dimensions)
-
-	// Assert
-	if actual != expected {
-		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
-	}
-}
 
 func Test_toMetricDataResult(t *testing.T) {
 	ts := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -41,16 +26,16 @@ func Test_toMetricDataResult(t *testing.T) {
 		{
 			name: "all metrics present",
 			getMetricDataOutput: cloudwatch.GetMetricDataOutput{
-				MetricDataResults: []*cloudwatch.MetricDataResult{
+				MetricDataResults: []types.MetricDataResult{
 					{
 						Id:         aws.String("metric-1"),
-						Values:     []*float64{aws.Float64(1.0), aws.Float64(2.0), aws.Float64(3.0)},
-						Timestamps: []*time.Time{aws.Time(ts.Add(10 * time.Minute)), aws.Time(ts.Add(5 * time.Minute)), aws.Time(ts)},
+						Values:     []float64{1.0, 2.0, 3.0},
+						Timestamps: []time.Time{ts.Add(10 * time.Minute), ts.Add(5 * time.Minute), ts},
 					},
 					{
 						Id:         aws.String("metric-2"),
-						Values:     []*float64{aws.Float64(2.0)},
-						Timestamps: []*time.Time{aws.Time(ts)},
+						Values:     []float64{2.0},
+						Timestamps: []time.Time{ts},
 					},
 				},
 			},
@@ -62,16 +47,16 @@ func Test_toMetricDataResult(t *testing.T) {
 		{
 			name: "metric with no values",
 			getMetricDataOutput: cloudwatch.GetMetricDataOutput{
-				MetricDataResults: []*cloudwatch.MetricDataResult{
+				MetricDataResults: []types.MetricDataResult{
 					{
 						Id:         aws.String("metric-1"),
-						Values:     []*float64{aws.Float64(1.0), aws.Float64(2.0), aws.Float64(3.0)},
-						Timestamps: []*time.Time{aws.Time(ts.Add(10 * time.Minute)), aws.Time(ts.Add(5 * time.Minute)), aws.Time(ts)},
+						Values:     []float64{1.0, 2.0, 3.0},
+						Timestamps: []time.Time{ts.Add(10 * time.Minute), ts.Add(5 * time.Minute), ts},
 					},
 					{
 						Id:         aws.String("metric-2"),
-						Values:     []*float64{},
-						Timestamps: []*time.Time{},
+						Values:     []float64{},
+						Timestamps: []time.Time{},
 					},
 				},
 			},

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -54,9 +54,7 @@ func runCustomNamespaceJob(
 				for _, result := range data {
 					getMetricData, err := findGetMetricDataByIDForCustomNamespace(input, result.ID)
 					if err == nil {
-						// Copy to avoid a loop closure bug
-						dataPoint := result.Datapoint
-						getMetricData.GetMetricDataPoint = &dataPoint
+						getMetricData.GetMetricDataPoint = result.Datapoint
 						getMetricData.GetMetricDataTimestamps = result.Timestamp
 						output = append(output, getMetricData)
 					}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -149,9 +149,7 @@ func mapResultsToMetricDatas(output [][]cloudwatch.MetricDataResult, datas []*mo
 			if metricData.MetricID == nil {
 				continue
 			}
-			// Copy to avoid a loop closure bug
-			dataPoint := metricDataResult.Datapoint
-			metricData.GetMetricDataPoint = &dataPoint
+			metricData.GetMetricDataPoint = metricDataResult.Datapoint
 			metricData.GetMetricDataTimestamps = metricDataResult.Timestamp
 			metricData.MetricID = nil // mark as processed
 		}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/config"
@@ -433,6 +434,209 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					t.Errorf("getFilteredMetricDatas().Tags = %+v, want %+v", got.Tags, tt.wantGetMetricsData[i].Tags)
 				}
 			}
+		})
+	}
+}
+
+func Test_mapResultsToMetricDatas(t *testing.T) {
+	type args struct {
+		metricDataResults [][]cloudwatch.MetricDataResult
+		cloudwatchDatas   []*model.CloudwatchData
+	}
+	tests := []struct {
+		name                string
+		args                args
+		wantCloudwatchDatas []*model.CloudwatchData
+	}{
+		{
+			"all datapoints present",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-3", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+					},
+					{
+						{ID: "metric-4", Datapoint: 20, Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
+					},
+					{
+						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-3"), Metric: aws.String("MetricThree"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-4"), Metric: aws.String("MetricFour"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+				{
+					Metric:                  aws.String("MetricTwo"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(12),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+				},
+				{
+					Metric:                  aws.String("MetricThree"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(15),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
+				},
+				{
+					Metric:                  aws.String("MetricFour"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(20),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
+				},
+			},
+		},
+		{
+			"duplicate results",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+			},
+		},
+		{
+			"unexpected result ID",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+			},
+		},
+		{
+			"nil metric data result",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+					},
+					nil,
+					{
+						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+				{
+					Metric:                  aws.String("MetricTwo"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(12),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+				},
+			},
+		},
+		{
+			"missing metric data result",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+				{
+					MetricID:                aws.String("metric-2"),
+					Metric:                  aws.String("MetricTwo"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      nil,
+					GetMetricDataTimestamps: time.Time{},
+				},
+			},
+		},
+		{
+			"nil metric datapoint",
+			args{
+				metricDataResults: [][]cloudwatch.MetricDataResult{
+					{
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-2"},
+					},
+				},
+				cloudwatchDatas: []*model.CloudwatchData{
+					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+				},
+			},
+			[]*model.CloudwatchData{
+				{
+					Metric:                  aws.String("MetricOne"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      aws.Float64(5),
+					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+				},
+				{
+					Metric:                  aws.String("MetricTwo"),
+					Namespace:               aws.String("svc"),
+					GetMetricDataPoint:      nil,
+					GetMetricDataTimestamps: time.Time{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapResultsToMetricDatas(tt.args.metricDataResults, tt.args.cloudwatchDatas, logging.NewNopLogger())
+			// mapResultsToMetricDatas() modifies its []*model.CloudwatchData parameter in-place, assert that it was updated
+			require.Equal(t, tt.wantCloudwatchDatas, tt.args.cloudwatchDatas)
 		})
 	}
 }

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -453,14 +453,14 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-3", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-3", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-4", Datapoint: 20, Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
+						{ID: "metric-4", Datapoint: aws.Float64(20), Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
@@ -502,8 +502,8 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
@@ -524,8 +524,8 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-2", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
@@ -546,11 +546,11 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					nil,
 					{
-						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
@@ -578,7 +578,7 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
@@ -607,7 +607,7 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 						{ID: "metric-2"},
 					},
 				},
@@ -728,7 +728,7 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResour
 			id := testResourceIDs[(batch*metricsPerQuery+i)%testResourcesCount]
 			newBatchOutputs = append(newBatchOutputs, cloudwatch.MetricDataResult{
 				ID:        id,
-				Datapoint: 1.4 * float64(batch),
+				Datapoint: aws.Float64(1.4 * float64(batch)),
 				Timestamp: now,
 			})
 		}


### PR DESCRIPTION
The default value for `MetricDataResult.Datapoint` was 0, so all metrics without datapoints were being returned as if they had a datapoint with the value 0, regardless of the `nilToZero` flag.

Making this field a pointer allows the v1 and v2 clients to return `nil` when there is no data, which eventually gets passed through to the existing code for handling `nil` datapoints and the `nilToZero` flag.

Fixes #1242

Might be related to #1138