### PR TITLE
Restructure fields on CloudwatchData

### DIFF
--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -25,7 +25,7 @@ type Client interface {
 	GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []MetricDataResult
 
 	// GetMetricStatistics returns the output of the GetMetricStatistics CloudWatch API.
-	GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint
+	GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint
 }
 
 // ConcurrencyLimiter limits the concurrency when calling AWS CloudWatch APIs. The functions implemented
@@ -60,7 +60,7 @@ func NewLimitedConcurrencyClient(client Client, limiter ConcurrencyLimiter) Clie
 	}
 }
 
-func (c limitedConcurrencyClient) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
+func (c limitedConcurrencyClient) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
 	c.limiter.Acquire(getMetricStatisticsCall)
 	res := c.client.GetMetricStatistics(ctx, logger, dimensions, namespace, metric)
 	c.limiter.Release(getMetricStatisticsCall)

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -43,8 +43,9 @@ type ConcurrencyLimiter interface {
 }
 
 type MetricDataResult struct {
-	ID        string
-	Datapoint float64
+	ID string
+	// A nil datapoint is a marker for no datapoint being found
+	Datapoint *float64
 	Timestamp time.Time
 }
 

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -44,7 +44,7 @@ type ConcurrencyLimiter interface {
 
 type MetricDataResult struct {
 	ID        string
-	Datapoint *float64
+	Datapoint float64
 	Timestamp time.Time
 }
 

--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -117,7 +117,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = metricDataResult.Values[0]
+			mappedResult.Datapoint = *metricDataResult.Values[0]
 			mappedResult.Timestamp = *metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -117,7 +117,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = *metricDataResult.Values[0]
+			mappedResult.Datapoint = metricDataResult.Values[0]
 			mappedResult.Timestamp = *metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -72,10 +72,10 @@ func toModelMetric(page *cloudwatch.ListMetricsOutput) []*model.Metric {
 	return modelMetrics
 }
 
-func toModelDimensions(dimensions []*cloudwatch.Dimension) []*model.Dimension {
-	modelDimensions := make([]*model.Dimension, 0, len(dimensions))
+func toModelDimensions(dimensions []*cloudwatch.Dimension) []model.Dimension {
+	modelDimensions := make([]model.Dimension, 0, len(dimensions))
 	for _, dimension := range dimensions {
-		modelDimension := &model.Dimension{
+		modelDimension := model.Dimension{
 			Name:  *dimension.Name,
 			Value: *dimension.Value,
 		}
@@ -125,7 +125,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	return output
 }
 
-func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
+func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
 	filter := createGetMetricStatisticsInput(dimensions, &namespace, metric, logger)
 
 	if c.logger.IsDebugEnabled() {

--- a/pkg/clients/cloudwatch/v1/client_test.go
+++ b/pkg/clients/cloudwatch/v1/client_test.go
@@ -16,7 +16,7 @@ func TestDimensionsToCliString(t *testing.T) {
 	// Setup Test
 
 	// Arrange
-	dimensions := []*model.Dimension{}
+	dimensions := []model.Dimension{}
 	expected := ""
 
 	// Act

--- a/pkg/clients/cloudwatch/v1/client_test.go
+++ b/pkg/clients/cloudwatch/v1/client_test.go
@@ -55,8 +55,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: aws.Float64(2.0), Timestamp: ts},
+				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: 2.0, Timestamp: ts},
 			},
 		},
 		{
@@ -76,8 +76,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: nil, Timestamp: time.Time{}},
+				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: 0, Timestamp: time.Time{}},
 			},
 		},
 	}

--- a/pkg/clients/cloudwatch/v1/client_test.go
+++ b/pkg/clients/cloudwatch/v1/client_test.go
@@ -55,8 +55,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: 2.0, Timestamp: ts},
+				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: aws.Float64(2.0), Timestamp: ts},
 			},
 		},
 		{
@@ -76,8 +76,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: 0, Timestamp: time.Time{}},
+				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: nil, Timestamp: time.Time{}},
 			},
 		},
 	}

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -31,7 +31,7 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, &cloudwatch.MetricDataQuery{
-			Id:         data.GetMetricDataResult.ID,
+			Id:         &data.GetMetricDataResult.ID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -62,9 +62,11 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 func toCloudWatchDimensions(dimensions []model.Dimension) []*cloudwatch.Dimension {
 	cwDim := make([]*cloudwatch.Dimension, 0, len(dimensions))
 	for _, dim := range dimensions {
+		// Don't take pointers directly to loop variables
+		cDim := dim
 		cwDim = append(cwDim, &cloudwatch.Dimension{
-			Name:  &dim.Name,
-			Value: &dim.Value,
+			Name:  &cDim.Name,
+			Value: &cDim.Value,
 		})
 	}
 	return cwDim

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -28,7 +28,7 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 				Namespace:  namespace,
 			},
 			Period: &data.GetMetricDataProcessingParams.Period,
-			Stat:   &data.GetMetricDataResult.Statistic,
+			Stat:   &data.GetMetricDataProcessingParams.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, &cloudwatch.MetricDataQuery{
 			Id:         &data.GetMetricDataProcessingParams.QueryID,

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -18,20 +18,20 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 	metricsDataQuery := make([]*cloudwatch.MetricDataQuery, 0, len(getMetricData))
 	roundingPeriod := model.DefaultPeriodSeconds
 	for _, data := range getMetricData {
-		if data.MetricConfig.Period < roundingPeriod {
-			roundingPeriod = data.MetricConfig.Period
+		if data.GetMetricDataProcessingParams.Period < roundingPeriod {
+			roundingPeriod = data.GetMetricDataProcessingParams.Period
 		}
 		metricStat := &cloudwatch.MetricStat{
 			Metric: &cloudwatch.Metric{
 				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: &data.MetricConfig.Name,
+				MetricName: &data.MetricName,
 				Namespace:  namespace,
 			},
-			Period: &data.MetricConfig.Period,
+			Period: &data.GetMetricDataProcessingParams.Period,
 			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, &cloudwatch.MetricDataQuery{
-			Id:         &data.GetMetricDataResult.ID,
+			Id:         &data.GetMetricDataProcessingParams.QueryID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -18,20 +18,20 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 	metricsDataQuery := make([]*cloudwatch.MetricDataQuery, 0, len(getMetricData))
 	roundingPeriod := model.DefaultPeriodSeconds
 	for _, data := range getMetricData {
-		if data.Period < roundingPeriod {
-			roundingPeriod = data.Period
+		if data.MetricConfig.Period < roundingPeriod {
+			roundingPeriod = data.MetricConfig.Period
 		}
 		metricStat := &cloudwatch.MetricStat{
 			Metric: &cloudwatch.Metric{
 				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: data.Metric,
+				MetricName: &data.MetricConfig.Name,
 				Namespace:  namespace,
 			},
-			Period: &data.Period,
-			Stat:   &data.Statistics[0],
+			Period: &data.MetricConfig.Period,
+			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, &cloudwatch.MetricDataQuery{
-			Id:         data.MetricID,
+			Id:         data.GetMetricDataResult.ID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/cloudwatch/v1/input.go
+++ b/pkg/clients/cloudwatch/v1/input.go
@@ -59,7 +59,7 @@ func createGetMetricDataInput(getMetricData []*model.CloudwatchData, namespace *
 	}
 }
 
-func toCloudWatchDimensions(dimensions []*model.Dimension) []*cloudwatch.Dimension {
+func toCloudWatchDimensions(dimensions []model.Dimension) []*cloudwatch.Dimension {
 	cwDim := make([]*cloudwatch.Dimension, 0, len(dimensions))
 	for _, dim := range dimensions {
 		cwDim = append(cwDim, &cloudwatch.Dimension{
@@ -70,7 +70,7 @@ func toCloudWatchDimensions(dimensions []*model.Dimension) []*cloudwatch.Dimensi
 	return cwDim
 }
 
-func createGetMetricStatisticsInput(dimensions []*model.Dimension, namespace *string, metric *model.MetricConfig, logger logging.Logger) *cloudwatch.GetMetricStatisticsInput {
+func createGetMetricStatisticsInput(dimensions []model.Dimension, namespace *string, metric *model.MetricConfig, logger logging.Logger) *cloudwatch.GetMetricStatisticsInput {
 	period := metric.Period
 	length := metric.Length
 	delay := metric.Delay
@@ -113,7 +113,7 @@ func createGetMetricStatisticsInput(dimensions []*model.Dimension, namespace *st
 	return output
 }
 
-func dimensionsToCliString(dimensions []*model.Dimension) string {
+func dimensionsToCliString(dimensions []model.Dimension) string {
 	out := strings.Builder{}
 	for _, dim := range dimensions {
 		out.WriteString("Name=")

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -75,10 +75,10 @@ func toModelMetric(page *cloudwatch.ListMetricsOutput) []*model.Metric {
 	return modelMetrics
 }
 
-func toModelDimensions(dimensions []types.Dimension) []*model.Dimension {
-	modelDimensions := make([]*model.Dimension, 0, len(dimensions))
+func toModelDimensions(dimensions []types.Dimension) []model.Dimension {
+	modelDimensions := make([]model.Dimension, 0, len(dimensions))
 	for _, dimension := range dimensions {
-		modelDimension := &model.Dimension{
+		modelDimension := model.Dimension{
 			Name:  *dimension.Name,
 			Value: *dimension.Value,
 		}
@@ -131,7 +131,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	return output
 }
 
-func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []*model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
+func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint {
 	filter := createGetMetricStatisticsInput(logger, dimensions, &namespace, metric)
 	if c.logger.IsDebugEnabled() {
 		c.logger.Debug("GetMetricStatistics", "input", filter)

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -123,7 +123,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = &metricDataResult.Values[0]
+			mappedResult.Datapoint = metricDataResult.Values[0]
 			mappedResult.Timestamp = metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -123,7 +123,7 @@ func toMetricDataResult(resp cloudwatch.GetMetricDataOutput) []cloudwatch_client
 	for _, metricDataResult := range resp.MetricDataResults {
 		mappedResult := cloudwatch_client.MetricDataResult{ID: *metricDataResult.Id}
 		if len(metricDataResult.Values) > 0 {
-			mappedResult.Datapoint = metricDataResult.Values[0]
+			mappedResult.Datapoint = &metricDataResult.Values[0]
 			mappedResult.Timestamp = metricDataResult.Timestamps[0]
 		}
 		output = append(output, mappedResult)

--- a/pkg/clients/cloudwatch/v2/client_test.go
+++ b/pkg/clients/cloudwatch/v2/client_test.go
@@ -40,8 +40,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: aws.Float64(2.0), Timestamp: ts},
+				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: 2.0, Timestamp: ts},
 			},
 		},
 		{
@@ -61,8 +61,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: nil, Timestamp: time.Time{}},
+				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: 0, Timestamp: time.Time{}},
 			},
 		},
 	}

--- a/pkg/clients/cloudwatch/v2/client_test.go
+++ b/pkg/clients/cloudwatch/v2/client_test.go
@@ -40,8 +40,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: 2.0, Timestamp: ts},
+				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: aws.Float64(2.0), Timestamp: ts},
 			},
 		},
 		{
@@ -61,8 +61,8 @@ func Test_toMetricDataResult(t *testing.T) {
 				},
 			},
 			expectedMetricDataResults: []cloudwatch_client.MetricDataResult{
-				{ID: "metric-1", Datapoint: 1.0, Timestamp: ts.Add(10 * time.Minute)},
-				{ID: "metric-2", Datapoint: 0, Timestamp: time.Time{}},
+				{ID: "metric-1", Datapoint: aws.Float64(1.0), Timestamp: ts.Add(10 * time.Minute)},
+				{ID: "metric-2", Datapoint: nil, Timestamp: time.Time{}},
 			},
 		},
 	}

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -19,20 +19,20 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 	metricsDataQuery := make([]types.MetricDataQuery, 0, len(getMetricData))
 	roundingPeriod := model.DefaultPeriodSeconds
 	for _, data := range getMetricData {
-		if data.Period < roundingPeriod {
-			roundingPeriod = data.Period
+		if data.MetricConfig.Period < roundingPeriod {
+			roundingPeriod = data.MetricConfig.Period
 		}
 		metricStat := &types.MetricStat{
 			Metric: &types.Metric{
 				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: data.Metric,
+				MetricName: &data.MetricConfig.Name,
 				Namespace:  namespace,
 			},
-			Period: aws.Int32(int32(data.Period)),
-			Stat:   &data.Statistics[0],
+			Period: aws.Int32(int32(data.MetricConfig.Period)),
+			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
-			Id:         data.MetricID,
+			Id:         data.GetMetricDataResult.ID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -29,7 +29,7 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 				Namespace:  namespace,
 			},
 			Period: aws.Int32(int32(data.GetMetricDataProcessingParams.Period)),
-			Stat:   &data.GetMetricDataResult.Statistic,
+			Stat:   &data.GetMetricDataProcessingParams.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
 			Id:         &data.GetMetricDataProcessingParams.QueryID,

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -60,7 +60,7 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 	}
 }
 
-func toCloudWatchDimensions(dimensions []*model.Dimension) []types.Dimension {
+func toCloudWatchDimensions(dimensions []model.Dimension) []types.Dimension {
 	cwDim := make([]types.Dimension, 0, len(dimensions))
 	for _, dim := range dimensions {
 		cwDim = append(cwDim, types.Dimension{
@@ -71,7 +71,7 @@ func toCloudWatchDimensions(dimensions []*model.Dimension) []types.Dimension {
 	return cwDim
 }
 
-func createGetMetricStatisticsInput(logger logging.Logger, dimensions []*model.Dimension, namespace *string, metric *model.MetricConfig) *cloudwatch.GetMetricStatisticsInput {
+func createGetMetricStatisticsInput(logger logging.Logger, dimensions []model.Dimension, namespace *string, metric *model.MetricConfig) *cloudwatch.GetMetricStatisticsInput {
 	period := metric.Period
 	length := metric.Length
 	delay := metric.Delay
@@ -116,7 +116,7 @@ func createGetMetricStatisticsInput(logger logging.Logger, dimensions []*model.D
 	return output
 }
 
-func dimensionsToCliString(dimensions []*model.Dimension) string {
+func dimensionsToCliString(dimensions []model.Dimension) string {
 	out := strings.Builder{}
 	for _, dim := range dimensions {
 		out.WriteString("Name=")

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -63,9 +63,11 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 func toCloudWatchDimensions(dimensions []model.Dimension) []types.Dimension {
 	cwDim := make([]types.Dimension, 0, len(dimensions))
 	for _, dim := range dimensions {
+		// Don't take pointers directly to loop variables
+		cDim := dim
 		cwDim = append(cwDim, types.Dimension{
-			Name:  &dim.Name,
-			Value: &dim.Value,
+			Name:  &cDim.Name,
+			Value: &cDim.Value,
 		})
 	}
 	return cwDim

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -32,7 +32,7 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
-			Id:         data.GetMetricDataResult.ID,
+			Id:         &data.GetMetricDataResult.ID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -19,20 +19,20 @@ func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.Clou
 	metricsDataQuery := make([]types.MetricDataQuery, 0, len(getMetricData))
 	roundingPeriod := model.DefaultPeriodSeconds
 	for _, data := range getMetricData {
-		if data.MetricConfig.Period < roundingPeriod {
-			roundingPeriod = data.MetricConfig.Period
+		if data.GetMetricDataProcessingParams.Period < roundingPeriod {
+			roundingPeriod = data.GetMetricDataProcessingParams.Period
 		}
 		metricStat := &types.MetricStat{
 			Metric: &types.Metric{
 				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: &data.MetricConfig.Name,
+				MetricName: &data.MetricName,
 				Namespace:  namespace,
 			},
-			Period: aws.Int32(int32(data.MetricConfig.Period)),
+			Period: aws.Int32(int32(data.GetMetricDataProcessingParams.Period)),
 			Stat:   &data.GetMetricDataResult.Statistic,
 		}
 		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
-			Id:         &data.GetMetricDataResult.ID,
+			Id:         &data.GetMetricDataProcessingParams.QueryID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),
 		})

--- a/pkg/clients/v2/factory_test.go
+++ b/pkg/clients/v2/factory_test.go
@@ -450,6 +450,6 @@ func (t testClient) GetMetricData(_ context.Context, _ logging.Logger, _ []*mode
 	return nil
 }
 
-func (t testClient) GetMetricStatistics(_ context.Context, _ logging.Logger, _ []*model.Dimension, _ string, _ *model.MetricConfig) []*model.Datapoint {
+func (t testClient) GetMetricStatistics(_ context.Context, _ logging.Logger, _ []model.Dimension, _ string, _ *model.MetricConfig) []*model.Datapoint {
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -486,8 +486,8 @@ func toModelMetricConfig(metrics []*Metric) []*model.MetricConfig {
 			Period:                 m.Period,
 			Length:                 m.Length,
 			Delay:                  m.Delay,
-			NilToZero:              m.NilToZero,
-			AddCloudwatchTimestamp: m.AddCloudwatchTimestamp,
+			NilToZero:              aws.BoolValue(m.NilToZero),
+			AddCloudwatchTimestamp: aws.BoolValue(m.AddCloudwatchTimestamp),
 		})
 	}
 	return ret

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -109,7 +109,7 @@ func getMetricDataForQueriesForCustomNamespace(
 					for _, stat := range metric.Statistics {
 						id := fmt.Sprintf("id_%d", rand.Int())
 						data = append(data, &model.CloudwatchData{
-							ID:           customNamespaceJob.Name,
+							ResourceName: customNamespaceJob.Name,
 							Namespace:    customNamespaceJob.Namespace,
 							Dimensions:   cwMetric.Dimensions,
 							MetricConfig: metric,

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -54,8 +54,8 @@ func runCustomNamespaceJob(
 				for _, result := range data {
 					getMetricData, err := findGetMetricDataByIDForCustomNamespace(input, result.ID)
 					if err == nil {
-						getMetricData.GetMetricDataPoint = result.Datapoint
-						getMetricData.GetMetricDataTimestamps = result.Timestamp
+						getMetricData.GetMetricDataResult.Datapoint = result.Datapoint
+						getMetricData.GetMetricDataResult.Timestamp = result.Timestamp
 						output = append(output, getMetricData)
 					}
 				}
@@ -72,7 +72,7 @@ func runCustomNamespaceJob(
 
 func findGetMetricDataByIDForCustomNamespace(getMetricDatas []*model.CloudwatchData, value string) (*model.CloudwatchData, error) {
 	for _, getMetricData := range getMetricDatas {
-		if *getMetricData.MetricID == value {
+		if *getMetricData.GetMetricDataResult.ID == value {
 			return getMetricData, nil
 		}
 	}
@@ -106,18 +106,17 @@ func getMetricDataForQueriesForCustomNamespace(
 						continue
 					}
 
-					for _, stats := range metric.Statistics {
+					for _, stat := range metric.Statistics {
 						id := fmt.Sprintf("id_%d", rand.Int())
 						data = append(data, &model.CloudwatchData{
-							ID:                     &customNamespaceJob.Name,
-							MetricID:               &id,
-							Metric:                 &metric.Name,
-							Namespace:              &customNamespaceJob.Namespace,
-							Statistics:             []string{stats},
-							NilToZero:              metric.NilToZero,
-							AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
-							Dimensions:             cwMetric.Dimensions,
-							Period:                 metric.Period,
+							ID:           customNamespaceJob.Name,
+							Namespace:    customNamespaceJob.Namespace,
+							Dimensions:   cwMetric.Dimensions,
+							MetricConfig: metric,
+							GetMetricDataResult: &model.GetMetricDataResult{
+								ID:        &id,
+								Statistic: stat,
+							},
 						})
 					}
 				}

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -72,7 +72,7 @@ func runCustomNamespaceJob(
 
 func findGetMetricDataByIDForCustomNamespace(getMetricDatas []*model.CloudwatchData, value string) (*model.CloudwatchData, error) {
 	for _, getMetricData := range getMetricDatas {
-		if *getMetricData.GetMetricDataResult.ID == value {
+		if getMetricData.GetMetricDataResult.ID == value {
 			return getMetricData, nil
 		}
 	}
@@ -114,7 +114,7 @@ func getMetricDataForQueriesForCustomNamespace(
 							Dimensions:   cwMetric.Dimensions,
 							MetricConfig: metric,
 							GetMetricDataResult: &model.GetMetricDataResult{
-								ID:        &id,
+								ID:        id,
 								Statistic: stat,
 							},
 						})

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -54,8 +54,13 @@ func runCustomNamespaceJob(
 				for _, result := range data {
 					getMetricData, err := findGetMetricDataByIDForCustomNamespace(input, result.ID)
 					if err == nil {
-						getMetricData.GetMetricDataResult.Datapoint = result.Datapoint
-						getMetricData.GetMetricDataResult.Timestamp = result.Timestamp
+						getMetricData.GetMetricDataResult = &model.GetMetricDataResult{
+							Statistic: getMetricData.GetMetricDataProcessingParams.Statistic,
+							Datapoint: result.Datapoint,
+							Timestamp: result.Timestamp,
+						}
+						// All done processing we can drop the processing params
+						getMetricData.GetMetricDataProcessingParams = nil
 						output = append(output, getMetricData)
 					}
 				}
@@ -72,7 +77,7 @@ func runCustomNamespaceJob(
 
 func findGetMetricDataByIDForCustomNamespace(getMetricDatas []*model.CloudwatchData, value string) (*model.CloudwatchData, error) {
 	for _, getMetricData := range getMetricDatas {
-		if getMetricData.GetMetricDataResult.ID == value {
+		if getMetricData.GetMetricDataResult == nil && getMetricData.GetMetricDataProcessingParams.QueryID == value {
 			return getMetricData, nil
 		}
 	}
@@ -109,14 +114,24 @@ func getMetricDataForQueriesForCustomNamespace(
 					for _, stat := range metric.Statistics {
 						id := fmt.Sprintf("id_%d", rand.Int())
 						data = append(data, &model.CloudwatchData{
+							MetricName:   metric.Name,
 							ResourceName: customNamespaceJob.Name,
 							Namespace:    customNamespaceJob.Namespace,
 							Dimensions:   cwMetric.Dimensions,
-							MetricConfig: metric,
-							GetMetricDataResult: &model.GetMetricDataResult{
-								ID:        id,
+							GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+								QueryID:   id,
+								Period:    metric.Period,
+								Length:    metric.Length,
+								Delay:     metric.Delay,
 								Statistic: stat,
 							},
+							MetricMigrationParams: model.MetricMigrationParams{
+								NilToZero:              metric.NilToZero,
+								AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
+							},
+							Tags:                      nil,
+							GetMetricDataResult:       nil,
+							GetMetricStatisticsResult: nil,
 						})
 					}
 				}

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -109,7 +109,7 @@ func runDiscoveryJob(
 	// Remove unprocessed/unknown elements in place, if any. Since getMetricDatas
 	// is a slice of pointers, the compaction can be easily done in-place.
 	getMetricDatas = compact(getMetricDatas, func(m *model.CloudwatchData) bool {
-		return m.GetMetricDataResult.MappedToAQueryResult == true
+		return m.GetMetricDataResult.MappedToAQueryResult
 	})
 	return resources, getMetricDatas
 }

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -259,10 +259,10 @@ func getFilteredMetricDatas(
 			id := fmt.Sprintf("id_%d", rand.Int())
 
 			getMetricsData = append(getMetricsData, &model.CloudwatchData{
-				ID:         resource.ARN,
-				Namespace:  namespace,
-				Tags:       metricTags,
-				Dimensions: cwMetric.Dimensions,
+				ResourceName: resource.ARN,
+				Namespace:    namespace,
+				Tags:         metricTags,
+				Dimensions:   cwMetric.Dimensions,
 				GetMetricDataResult: &model.GetMetricDataResult{
 					ID:        id,
 					Statistic: stat,

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -109,7 +109,7 @@ func runDiscoveryJob(
 	// Remove unprocessed/unknown elements in place, if any. Since getMetricDatas
 	// is a slice of pointers, the compaction can be easily done in-place.
 	getMetricDatas = compact(getMetricDatas, func(m *model.CloudwatchData) bool {
-		return m.GetMetricDataResult == nil
+		return m.GetMetricDataResult != nil
 	})
 	return resources, getMetricDatas
 }

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -2,11 +2,11 @@ package job
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
@@ -89,7 +89,6 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					AddCloudwatchTimestamp: aws.Bool(false),
 					Dimensions: []*model.Dimension{
 						{
 							Name:  "FileSystemId",
@@ -100,14 +99,9 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "Standard",
 						},
 					},
-					ID:        aws.String("arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123"),
-					Metric:    aws.String("StorageBytes"),
-					Namespace: aws.String("efs"),
-					NilToZero: aws.Bool(false),
-					Period:    60,
-					Statistics: []string{
-						"Average",
-					},
+					ID:                  "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
+					Namespace:           "efs",
+					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -117,6 +111,17 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Key:   "Value2",
 							Value: "",
 						},
+					},
+					MetricConfig: &model.MetricConfig{
+						Name: "StorageBytes",
+						Statistics: []string{
+							"Average",
+						},
+						Period:                 60,
+						Length:                 600,
+						Delay:                  120,
+						NilToZero:              aws.Bool(false),
+						AddCloudwatchTimestamp: aws.Bool(false),
 					},
 				},
 			},
@@ -172,21 +177,15 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					AddCloudwatchTimestamp: aws.Bool(false),
 					Dimensions: []*model.Dimension{
 						{
 							Name:  "InstanceId",
 							Value: "i-12312312312312312",
 						},
 					},
-					ID:        aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
-					Metric:    aws.String("CPUUtilization"),
-					Namespace: aws.String("ec2"),
-					NilToZero: aws.Bool(false),
-					Period:    60,
-					Statistics: []string{
-						"Average",
-					},
+					ID:                  "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
+					Namespace:           "ec2",
+					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -196,6 +195,17 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Key:   "Value2",
 							Value: "",
 						},
+					},
+					MetricConfig: &model.MetricConfig{
+						Name: "CPUUtilization",
+						Statistics: []string{
+							"Average",
+						},
+						Period:                 60,
+						Length:                 600,
+						Delay:                  120,
+						NilToZero:              aws.Bool(false),
+						AddCloudwatchTimestamp: aws.Bool(false),
 					},
 				},
 			},
@@ -251,21 +261,15 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					AddCloudwatchTimestamp: aws.Bool(false),
 					Dimensions: []*model.Dimension{
 						{
 							Name:  "Cluster Name",
 							Value: "demo-cluster-1",
 						},
 					},
-					ID:        aws.String("arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12"),
-					Metric:    aws.String("GlobalTopicCount"),
-					Namespace: aws.String("kafka"),
-					NilToZero: aws.Bool(false),
-					Period:    60,
-					Statistics: []string{
-						"Average",
-					},
+					ID:                  "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
+					Namespace:           "kafka",
+					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -275,6 +279,17 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Key:   "Value2",
 							Value: "",
 						},
+					},
+					MetricConfig: &model.MetricConfig{
+						Name: "GlobalTopicCount",
+						Statistics: []string{
+							"Average",
+						},
+						Period:                 60,
+						Length:                 600,
+						Delay:                  120,
+						NilToZero:              aws.Bool(false),
+						AddCloudwatchTimestamp: aws.Bool(false),
 					},
 				},
 			},
@@ -374,7 +389,6 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					AddCloudwatchTimestamp: aws.Bool(false),
 					Dimensions: []*model.Dimension{
 						{
 							Name:  "LoadBalancer",
@@ -385,15 +399,21 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "targetgroup/some-ALB/9999666677773333",
 						},
 					},
-					ID:        aws.String("arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345"),
-					Metric:    aws.String("RequestCount"),
-					Namespace: aws.String("alb"),
-					NilToZero: aws.Bool(false),
-					Period:    60,
-					Statistics: []string{
-						"Sum",
+					ID:                  "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
+					Namespace:           "alb",
+					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Sum"},
+					Tags:                []model.Tag{},
+					MetricConfig: &model.MetricConfig{
+						Name: "RequestCount",
+						Statistics: []string{
+							"Sum",
+						},
+						Period:                 60,
+						Length:                 600,
+						Delay:                  120,
+						NilToZero:              aws.Bool(false),
+						AddCloudwatchTimestamp: aws.Bool(false),
 					},
-					Tags: []model.Tag{},
 				},
 			},
 		},
@@ -406,33 +426,13 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				t.Errorf("len(getFilteredMetricDatas()) = %v, want %v", len(metricDatas), len(tt.wantGetMetricsData))
 			}
 			for i, got := range metricDatas {
-				if *got.ID != *tt.wantGetMetricsData[i].ID {
-					t.Errorf("getFilteredMetricDatas().ID = %v, want %v", *got.ID, *tt.wantGetMetricsData[i].ID)
-				}
-				if !reflect.DeepEqual(got.Dimensions, tt.wantGetMetricsData[i].Dimensions) {
-					t.Errorf("getFilteredMetricDatas().Dimensions = %+v, want %+v", got.Dimensions, tt.wantGetMetricsData[i].Dimensions)
-				}
-				if *got.Metric != *tt.wantGetMetricsData[i].Metric {
-					t.Errorf("getFilteredMetricDatas().Metric = %v, want %v", *got.Metric, *tt.wantGetMetricsData[i].Metric)
-				}
-				if *got.Namespace != *tt.wantGetMetricsData[i].Namespace {
-					t.Errorf("getFilteredMetricDatas().Namespace = %v, want %v", *got.Namespace, *tt.wantGetMetricsData[i].Namespace)
-				}
-				if *got.AddCloudwatchTimestamp != *tt.wantGetMetricsData[i].AddCloudwatchTimestamp {
-					t.Errorf("getFilteredMetricDatas().AddCloudwatchTimestamp = %v, want %v", *got.AddCloudwatchTimestamp, *tt.wantGetMetricsData[i].AddCloudwatchTimestamp)
-				}
-				if *got.NilToZero != *tt.wantGetMetricsData[i].NilToZero {
-					t.Errorf("getFilteredMetricDatas().NilToZero = %v, want %v", *got.NilToZero, *tt.wantGetMetricsData[i].NilToZero)
-				}
-				if got.Period != tt.wantGetMetricsData[i].Period {
-					t.Errorf("getFilteredMetricDatas().Period = %v, want %v", got.Period, tt.wantGetMetricsData[i].Period)
-				}
-				if !reflect.DeepEqual(got.Statistics, tt.wantGetMetricsData[i].Statistics) {
-					t.Errorf("getFilteredMetricDatas().Statistics = %+v, want %+v", got.Statistics, tt.wantGetMetricsData[i].Statistics)
-				}
-				if !reflect.DeepEqual(got.Tags, tt.wantGetMetricsData[i].Tags) {
-					t.Errorf("getFilteredMetricDatas().Tags = %+v, want %+v", got.Tags, tt.wantGetMetricsData[i].Tags)
-				}
+				want := tt.wantGetMetricsData[i]
+				assert.Equal(t, want.ID, got.ID)
+				assert.Equal(t, want.Namespace, got.Namespace)
+				assert.ElementsMatch(t, want.Dimensions, got.Dimensions)
+				assert.Equal(t, want.GetMetricDataResult.Statistic, got.GetMetricDataResult.Statistic)
+				assert.ElementsMatch(t, want.Tags, got.Tags)
+				assert.Equal(t, *want.MetricConfig, *got.MetricConfig)
 			}
 		})
 	}
@@ -453,47 +453,63 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-3", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-3", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-4", Datapoint: aws.Float64(20), Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
+						{ID: "metric-4", Datapoint: 20, Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-3"), Metric: aws.String("MetricThree"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-4"), Metric: aws.String("MetricFour"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-3")}, MetricConfig: &model.MetricConfig{Name: "MetricThree"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-4")}, MetricConfig: &model.MetricConfig{Name: "MetricFour"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					Metric:                  aws.String("MetricTwo"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(12),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 12,
+						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					Metric:                  aws.String("MetricThree"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(15),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricThree"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 15,
+						Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					Metric:                  aws.String("MetricFour"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(20),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricFour"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 20,
+						Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
+					},
 				},
 			},
 		},
@@ -502,20 +518,24 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 			},
 		},
@@ -524,20 +544,24 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-2", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 			},
 		},
@@ -546,30 +570,38 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					nil,
 					{
-						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					Metric:                  aws.String("MetricTwo"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(12),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 12,
+						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+					},
 				},
 			},
 		},
@@ -578,56 +610,71 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					MetricID:                aws.String("metric-2"),
-					Metric:                  aws.String("MetricTwo"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      nil,
-					GetMetricDataTimestamps: time.Time{},
+					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        aws.String("metric-2"),
+						Statistic: "",
+						Datapoint: 0,
+						Timestamp: time.Time{},
+					},
 				},
 			},
 		},
 		{
-			"nil metric datapoint",
+			"missing metric datapoint",
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 						{ID: "metric-2"},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{MetricID: aws.String("metric-1"), Metric: aws.String("MetricOne"), Namespace: aws.String("svc")},
-					{MetricID: aws.String("metric-2"), Metric: aws.String("MetricTwo"), Namespace: aws.String("svc")},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					Metric:                  aws.String("MetricOne"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      aws.Float64(5),
-					GetMetricDataTimestamps: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 5,
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+					},
 				},
 				{
-					Metric:                  aws.String("MetricTwo"),
-					Namespace:               aws.String("svc"),
-					GetMetricDataPoint:      nil,
-					GetMetricDataTimestamps: time.Time{},
+					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
+					Namespace:    "svc",
+					GetMetricDataResult: &model.GetMetricDataResult{
+						ID:        nil,
+						Statistic: "",
+						Datapoint: 0,
+						Timestamp: time.Time{},
+					},
 				},
 			},
 		},
@@ -643,7 +690,6 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 
 func getSampleMetricDatas(id string) *model.CloudwatchData {
 	return &model.CloudwatchData{
-		AddCloudwatchTimestamp: aws.Bool(false),
 		Dimensions: []*model.Dimension{
 			{
 				Name:  "FileSystemId",
@@ -654,15 +700,8 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 				Value: "Standard",
 			},
 		},
-		ID:        aws.String(id),
-		MetricID:  aws.String(id),
-		Metric:    aws.String("StorageBytes"),
-		Namespace: aws.String("efs"),
-		NilToZero: aws.Bool(false),
-		Period:    60,
-		Statistics: []string{
-			"Average",
-		},
+		ID:        id,
+		Namespace: "efs",
 		Tags: []model.Tag{
 			{
 				Key:   "Value1",
@@ -672,6 +711,17 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 				Key:   "Value2",
 				Value: "",
 			},
+		},
+		MetricConfig: &model.MetricConfig{
+			Name:      "StorageBytes",
+			NilToZero: aws.Bool(false),
+			Period:    60,
+			Statistics: []string{
+				"Average",
+			},
+		},
+		GetMetricDataResult: &model.GetMetricDataResult{
+			ID: aws.String(id),
 		},
 	}
 }
@@ -728,7 +778,7 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResour
 			id := testResourceIDs[(batch*metricsPerQuery+i)%testResourcesCount]
 			newBatchOutputs = append(newBatchOutputs, cloudwatch.MetricDataResult{
 				ID:        id,
-				Datapoint: aws.Float64(1.4 * float64(batch)),
+				Datapoint: 1.4 * float64(batch),
 				Timestamp: now,
 			})
 		}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -99,7 +99,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "Standard",
 						},
 					},
-					ID:                  "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
+					ResourceName:        "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
 					Namespace:           "efs",
 					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
@@ -183,7 +183,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "i-12312312312312312",
 						},
 					},
-					ID:                  "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
+					ResourceName:        "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
 					Namespace:           "ec2",
 					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
@@ -267,7 +267,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "demo-cluster-1",
 						},
 					},
-					ID:                  "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
+					ResourceName:        "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
 					Namespace:           "kafka",
 					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
@@ -399,7 +399,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "targetgroup/some-ALB/9999666677773333",
 						},
 					},
-					ID:                  "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
+					ResourceName:        "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
 					Namespace:           "alb",
 					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Sum"},
 					Tags:                []model.Tag{},
@@ -427,7 +427,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			}
 			for i, got := range metricDatas {
 				want := tt.wantGetMetricsData[i]
-				assert.Equal(t, want.ID, got.ID)
+				assert.Equal(t, want.ResourceName, got.ResourceName)
 				assert.Equal(t, want.Namespace, got.Namespace)
 				assert.ElementsMatch(t, want.Dimensions, got.Dimensions)
 				assert.Equal(t, want.GetMetricDataResult.Statistic, got.GetMetricDataResult.Statistic)
@@ -464,10 +464,10 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-3")}, MetricConfig: &model.MetricConfig{Name: "MetricThree"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-4")}, MetricConfig: &model.MetricConfig{Name: "MetricFour"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-3"}, MetricConfig: &model.MetricConfig{Name: "MetricThree"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-4"}, MetricConfig: &model.MetricConfig{Name: "MetricFour"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -475,40 +475,44 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 12,
-						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+						ID:                   "metric-2",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            12,
+						Timestamp:            time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricThree"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 15,
-						Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
+						ID:                   "metric-3",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            15,
+						Timestamp:            time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricFour"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 20,
-						Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
+						ID:                   "metric-4",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            20,
+						Timestamp:            time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -523,7 +527,7 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -531,10 +535,11 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -549,7 +554,7 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -557,10 +562,11 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -578,8 +584,8 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -587,20 +593,22 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 12,
-						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+						ID:                   "metric-2",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            12,
+						Timestamp:            time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -614,8 +622,8 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -623,20 +631,22 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        aws.String("metric-2"),
-						Statistic: "",
-						Datapoint: 0,
-						Timestamp: time.Time{},
+						ID:                   "metric-2",
+						MappedToAQueryResult: false,
+						Statistic:            "",
+						Datapoint:            0,
+						Timestamp:            time.Time{},
 					},
 				},
 			},
@@ -651,8 +661,8 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-1")}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: aws.String("metric-2")}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
@@ -660,20 +670,22 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 5,
-						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						ID:                   "metric-1",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            5,
+						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
 					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
 					Namespace:    "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:        nil,
-						Statistic: "",
-						Datapoint: 0,
-						Timestamp: time.Time{},
+						ID:                   "metric-2",
+						MappedToAQueryResult: true,
+						Statistic:            "",
+						Datapoint:            0,
+						Timestamp:            time.Time{},
 					},
 				},
 			},
@@ -700,8 +712,8 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 				Value: "Standard",
 			},
 		},
-		ID:        id,
-		Namespace: "efs",
+		ResourceName: id,
+		Namespace:    "efs",
 		Tags: []model.Tag{
 			{
 				Key:   "Value1",

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -88,6 +89,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
+					MetricName: "StorageBytes",
 					Dimensions: []model.Dimension{
 						{
 							Name:  "FileSystemId",
@@ -98,9 +100,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "Standard",
 						},
 					},
-					ResourceName:        "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
-					Namespace:           "efs",
-					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
+					ResourceName: "arn:aws:elasticfilesystem:us-east-1:123123123123:file-system/fs-abc123",
+					Namespace:    "efs",
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -111,14 +112,14 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "",
 						},
 					},
-					MetricConfig: &model.MetricConfig{
-						Name: "StorageBytes",
-						Statistics: []string{
-							"Average",
-						},
-						Period:                 60,
-						Length:                 600,
-						Delay:                  120,
+					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+						QueryID:   "asdf",
+						Period:    60,
+						Length:    600,
+						Delay:     120,
+						Statistic: "Average",
+					},
+					MetricMigrationParams: model.MetricMigrationParams{
 						NilToZero:              false,
 						AddCloudwatchTimestamp: false,
 					},
@@ -176,15 +177,15 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
+					MetricName:   "CPUUtilization",
+					ResourceName: "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
+					Namespace:    "ec2",
 					Dimensions: []model.Dimension{
 						{
 							Name:  "InstanceId",
 							Value: "i-12312312312312312",
 						},
 					},
-					ResourceName:        "arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312",
-					Namespace:           "ec2",
-					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -195,14 +196,13 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "",
 						},
 					},
-					MetricConfig: &model.MetricConfig{
-						Name: "CPUUtilization",
-						Statistics: []string{
-							"Average",
-						},
-						Period:                 60,
-						Length:                 600,
-						Delay:                  120,
+					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+						Statistic: "Average",
+						Period:    60,
+						Length:    600,
+						Delay:     120,
+					},
+					MetricMigrationParams: model.MetricMigrationParams{
 						NilToZero:              false,
 						AddCloudwatchTimestamp: false,
 					},
@@ -260,15 +260,15 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
+					MetricName: "GlobalTopicCount",
 					Dimensions: []model.Dimension{
 						{
 							Name:  "Cluster Name",
 							Value: "demo-cluster-1",
 						},
 					},
-					ResourceName:        "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
-					Namespace:           "kafka",
-					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Average"},
+					ResourceName: "arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12",
+					Namespace:    "kafka",
 					Tags: []model.Tag{
 						{
 							Key:   "Value1",
@@ -279,14 +279,14 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "",
 						},
 					},
-					MetricConfig: &model.MetricConfig{
-						Name: "GlobalTopicCount",
-						Statistics: []string{
-							"Average",
-						},
-						Period:                 60,
-						Length:                 600,
-						Delay:                  120,
+					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+						QueryID:   "asdf",
+						Statistic: "Average",
+						Period:    60,
+						Length:    600,
+						Delay:     120,
+					},
+					MetricMigrationParams: model.MetricMigrationParams{
 						NilToZero:              false,
 						AddCloudwatchTimestamp: false,
 					},
@@ -388,6 +388,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
+					MetricName: "RequestCount",
 					Dimensions: []model.Dimension{
 						{
 							Name:  "LoadBalancer",
@@ -398,18 +399,16 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 							Value: "targetgroup/some-ALB/9999666677773333",
 						},
 					},
-					ResourceName:        "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
-					Namespace:           "alb",
-					GetMetricDataResult: &model.GetMetricDataResult{Statistic: "Sum"},
-					Tags:                []model.Tag{},
-					MetricConfig: &model.MetricConfig{
-						Name: "RequestCount",
-						Statistics: []string{
-							"Sum",
-						},
-						Period:                 60,
-						Length:                 600,
-						Delay:                  120,
+					ResourceName: "arn:aws:elasticloadbalancing:us-east-1:123123123123:loadbalancer/app/some-ALB/0123456789012345",
+					Namespace:    "alb",
+					Tags:         []model.Tag{},
+					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+						Statistic: "Sum",
+						Period:    60,
+						Length:    600,
+						Delay:     120,
+					},
+					MetricMigrationParams: model.MetricMigrationParams{
 						NilToZero:              false,
 						AddCloudwatchTimestamp: false,
 					},
@@ -426,12 +425,19 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			}
 			for i, got := range metricDatas {
 				want := tt.wantGetMetricsData[i]
+				assert.Equal(t, want.MetricName, got.MetricName)
 				assert.Equal(t, want.ResourceName, got.ResourceName)
 				assert.Equal(t, want.Namespace, got.Namespace)
 				assert.ElementsMatch(t, want.Dimensions, got.Dimensions)
-				assert.Equal(t, want.GetMetricDataResult.Statistic, got.GetMetricDataResult.Statistic)
 				assert.ElementsMatch(t, want.Tags, got.Tags)
-				assert.Equal(t, want.MetricConfig, got.MetricConfig)
+				assert.Equal(t, want.MetricMigrationParams, got.MetricMigrationParams)
+				assert.NotEmpty(t, got.GetMetricDataProcessingParams.QueryID)
+				assert.Equal(t, want.GetMetricDataProcessingParams.Statistic, got.GetMetricDataProcessingParams.Statistic)
+				assert.Equal(t, want.GetMetricDataProcessingParams.Length, got.GetMetricDataProcessingParams.Length)
+				assert.Equal(t, want.GetMetricDataProcessingParams.Period, got.GetMetricDataProcessingParams.Period)
+				assert.Equal(t, want.GetMetricDataProcessingParams.Delay, got.GetMetricDataProcessingParams.Delay)
+				assert.Nil(t, got.GetMetricDataResult)
+				assert.Nil(t, got.GetMetricStatisticsResult)
 			}
 		})
 	}
@@ -452,66 +458,58 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-3", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-3", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-4", Datapoint: 20, Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
+						{ID: "metric-4", Datapoint: aws.Float64(20), Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC)},
 					},
 					{
-						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-3"}, MetricConfig: &model.MetricConfig{Name: "MetricThree"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-4"}, MetricConfig: &model.MetricConfig{Name: "MetricFour"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-2", Statistic: "Max"}, MetricName: "MetricTwo", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-3", Statistic: "Sum"}, MetricName: "MetricThree", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-4", Statistic: "Count"}, MetricName: "MetricFour", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
-					Namespace:    "svc",
+					MetricName: "MetricTwo",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-2",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            12,
-						Timestamp:            time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+						Statistic: "Max",
+						Datapoint: aws.Float64(12),
+						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricThree"},
-					Namespace:    "svc",
+					MetricName: "MetricThree",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-3",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            15,
-						Timestamp:            time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
+						Statistic: "Sum",
+						Datapoint: aws.Float64(15),
+						Timestamp: time.Date(2023, time.June, 7, 3, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricFour"},
-					Namespace:    "svc",
+					MetricName: "MetricFour",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-4",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            20,
-						Timestamp:            time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
+						Statistic: "Count",
+						Datapoint: aws.Float64(20),
+						Timestamp: time.Date(2023, time.June, 7, 4, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -521,24 +519,22 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-1", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -548,24 +544,22 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
-						{ID: "metric-2", Datapoint: 15, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(15), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -575,39 +569,35 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 					nil,
 					{
-						{ID: "metric-2", Datapoint: 12, Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
+						{ID: "metric-2", Datapoint: aws.Float64(12), Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-2", Statistic: "Max"}, MetricName: "MetricTwo", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
-					Namespace:    "svc",
+					MetricName: "MetricTwo",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-2",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            12,
-						Timestamp:            time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
+						Statistic: "Max",
+						Datapoint: aws.Float64(12),
+						Timestamp: time.Date(2023, time.June, 7, 2, 9, 8, 0, time.UTC),
 					},
 				},
 			},
@@ -617,74 +607,62 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-2", Statistic: "Max"}, MetricName: "MetricTwo", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
-					Namespace:    "svc",
-					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-2",
-						MappedToAQueryResult: false,
-						Statistic:            "",
-						Datapoint:            0,
-						Timestamp:            time.Time{},
-					},
+					MetricName:          "MetricTwo",
+					Namespace:           "svc",
+					GetMetricDataResult: nil,
 				},
 			},
 		},
 		{
-			"missing metric datapoint",
+			"nil metric datapoint",
 			args{
 				metricDataResults: [][]cloudwatch.MetricDataResult{
 					{
-						{ID: "metric-1", Datapoint: 5, Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
+						{ID: "metric-1", Datapoint: aws.Float64(5), Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC)},
 						{ID: "metric-2"},
 					},
 				},
 				cloudwatchDatas: []*model.CloudwatchData{
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-1"}, MetricConfig: &model.MetricConfig{Name: "MetricOne"}, Namespace: "svc"},
-					{GetMetricDataResult: &model.GetMetricDataResult{ID: "metric-2"}, MetricConfig: &model.MetricConfig{Name: "MetricTwo"}, Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-1", Statistic: "Min"}, MetricName: "MetricOne", Namespace: "svc"},
+					{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{QueryID: "metric-2", Statistic: "Max"}, MetricName: "MetricTwo", Namespace: "svc"},
 				},
 			},
 			[]*model.CloudwatchData{
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricOne"},
-					Namespace:    "svc",
+					MetricName: "MetricOne",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-1",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            5,
-						Timestamp:            time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
+						Statistic: "Min",
+						Datapoint: aws.Float64(5),
+						Timestamp: time.Date(2023, time.June, 7, 1, 9, 8, 0, time.UTC),
 					},
 				},
 				{
-					MetricConfig: &model.MetricConfig{Name: "MetricTwo"},
-					Namespace:    "svc",
+					MetricName: "MetricTwo",
+					Namespace:  "svc",
 					GetMetricDataResult: &model.GetMetricDataResult{
-						ID:                   "metric-2",
-						MappedToAQueryResult: true,
-						Statistic:            "",
-						Datapoint:            0,
-						Timestamp:            time.Time{},
+						Statistic: "Max",
+						Datapoint: nil,
+						Timestamp: time.Time{},
 					},
 				},
 			},
@@ -694,13 +672,26 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mapResultsToMetricDatas(tt.args.metricDataResults, tt.args.cloudwatchDatas, logging.NewNopLogger())
 			// mapResultsToMetricDatas() modifies its []*model.CloudwatchData parameter in-place, assert that it was updated
-			require.Equal(t, tt.wantCloudwatchDatas, tt.args.cloudwatchDatas)
+
+			// Ensure processing params were nil'ed when expected to be
+			for _, data := range tt.args.cloudwatchDatas {
+				if data.GetMetricDataResult != nil {
+					require.Nil(t, data.GetMetricDataProcessingParams, "GetMetricDataResult is not nil GetMetricDataProcessingParams should have been nil")
+				} else {
+					require.NotNil(t, data.GetMetricDataProcessingParams, "GetMetricDataResult is nil GetMetricDataProcessingParams should not have been nil")
+				}
+
+				// Drop processing params to simplify further asserts
+				data.GetMetricDataProcessingParams = nil
+			}
+			require.ElementsMatch(t, tt.wantCloudwatchDatas, tt.args.cloudwatchDatas)
 		})
 	}
 }
 
 func getSampleMetricDatas(id string) *model.CloudwatchData {
 	return &model.CloudwatchData{
+		MetricName: "StorageBytes",
 		Dimensions: []model.Dimension{
 			{
 				Name:  "FileSystemId",
@@ -723,16 +714,16 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 				Value: "",
 			},
 		},
-		MetricConfig: &model.MetricConfig{
-			Name:      "StorageBytes",
-			NilToZero: false,
-			Period:    60,
-			Statistics: []string{
-				"Average",
-			},
+		MetricMigrationParams: model.MetricMigrationParams{
+			NilToZero:              false,
+			AddCloudwatchTimestamp: false,
 		},
-		GetMetricDataResult: &model.GetMetricDataResult{
-			ID: id,
+		GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
+			QueryID:   id,
+			Period:    60,
+			Length:    60,
+			Delay:     0,
+			Statistic: "Average",
 		},
 	}
 }
@@ -789,7 +780,7 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount, metricsPerResour
 			id := testResourceIDs[(batch*metricsPerQuery+i)%testResourcesCount]
 			newBatchOutputs = append(newBatchOutputs, cloudwatch.MetricDataResult{
 				ID:        id,
-				Datapoint: 1.4 * float64(batch),
+				Datapoint: aws.Float64(1.4 * float64(batch)),
 				Timestamp: now,
 			})
 		}

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -83,8 +82,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Period:                 60,
 					Length:                 600,
 					Delay:                  120,
-					NilToZero:              aws.Bool(false),
-					AddCloudwatchTimestamp: aws.Bool(false),
+					NilToZero:              false,
+					AddCloudwatchTimestamp: false,
 				},
 			},
 			[]model.CloudwatchData{
@@ -120,8 +119,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Period:                 60,
 						Length:                 600,
 						Delay:                  120,
-						NilToZero:              aws.Bool(false),
-						AddCloudwatchTimestamp: aws.Bool(false),
+						NilToZero:              false,
+						AddCloudwatchTimestamp: false,
 					},
 				},
 			},
@@ -171,8 +170,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Period:                 60,
 					Length:                 600,
 					Delay:                  120,
-					NilToZero:              aws.Bool(false),
-					AddCloudwatchTimestamp: aws.Bool(false),
+					NilToZero:              false,
+					AddCloudwatchTimestamp: false,
 				},
 			},
 			[]model.CloudwatchData{
@@ -204,8 +203,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Period:                 60,
 						Length:                 600,
 						Delay:                  120,
-						NilToZero:              aws.Bool(false),
-						AddCloudwatchTimestamp: aws.Bool(false),
+						NilToZero:              false,
+						AddCloudwatchTimestamp: false,
 					},
 				},
 			},
@@ -255,8 +254,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Period:                 60,
 					Length:                 600,
 					Delay:                  120,
-					NilToZero:              aws.Bool(false),
-					AddCloudwatchTimestamp: aws.Bool(false),
+					NilToZero:              false,
+					AddCloudwatchTimestamp: false,
 				},
 			},
 			[]model.CloudwatchData{
@@ -288,8 +287,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Period:                 60,
 						Length:                 600,
 						Delay:                  120,
-						NilToZero:              aws.Bool(false),
-						AddCloudwatchTimestamp: aws.Bool(false),
+						NilToZero:              false,
+						AddCloudwatchTimestamp: false,
 					},
 				},
 			},
@@ -383,8 +382,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					Period:                 60,
 					Length:                 600,
 					Delay:                  120,
-					NilToZero:              aws.Bool(false),
-					AddCloudwatchTimestamp: aws.Bool(false),
+					NilToZero:              false,
+					AddCloudwatchTimestamp: false,
 				},
 			},
 			[]model.CloudwatchData{
@@ -411,8 +410,8 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						Period:                 60,
 						Length:                 600,
 						Delay:                  120,
-						NilToZero:              aws.Bool(false),
-						AddCloudwatchTimestamp: aws.Bool(false),
+						NilToZero:              false,
+						AddCloudwatchTimestamp: false,
 					},
 				},
 			},
@@ -432,7 +431,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				assert.ElementsMatch(t, want.Dimensions, got.Dimensions)
 				assert.Equal(t, want.GetMetricDataResult.Statistic, got.GetMetricDataResult.Statistic)
 				assert.ElementsMatch(t, want.Tags, got.Tags)
-				assert.Equal(t, *want.MetricConfig, *got.MetricConfig)
+				assert.Equal(t, want.MetricConfig, got.MetricConfig)
 			}
 		})
 	}
@@ -726,7 +725,7 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 		},
 		MetricConfig: &model.MetricConfig{
 			Name:      "StorageBytes",
-			NilToZero: aws.Bool(false),
+			NilToZero: false,
 			Period:    60,
 			Statistics: []string{
 				"Average",

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -61,7 +61,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				metricsList: []*model.Metric{
 					{
 						MetricName: "StorageBytes",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "FileSystemId",
 								Value: "fs-abc123",
@@ -88,7 +88,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{
 							Name:  "FileSystemId",
 							Value: "fs-abc123",
@@ -153,7 +153,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				metricsList: []*model.Metric{
 					{
 						MetricName: "CPUUtilization",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "InstanceId",
 								Value: "i-12312312312312312",
@@ -176,7 +176,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{
 							Name:  "InstanceId",
 							Value: "i-12312312312312312",
@@ -237,7 +237,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				metricsList: []*model.Metric{
 					{
 						MetricName: "GlobalTopicCount",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "Cluster Name",
 								Value: "demo-cluster-1",
@@ -260,7 +260,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{
 							Name:  "Cluster Name",
 							Value: "demo-cluster-1",
@@ -319,7 +319,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				metricsList: []*model.Metric{
 					{
 						MetricName: "RequestCount",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "LoadBalancer",
 								Value: "app/some-ALB/0123456789012345",
@@ -337,7 +337,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 					{
 						MetricName: "RequestCount",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "LoadBalancer",
 								Value: "app/some-ALB/0123456789012345",
@@ -351,7 +351,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 					{
 						MetricName: "RequestCount",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "LoadBalancer",
 								Value: "app/some-ALB/0123456789012345",
@@ -365,7 +365,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 					{
 						MetricName: "RequestCount",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "LoadBalancer",
 								Value: "app/some-ALB/0123456789012345",
@@ -388,7 +388,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 			},
 			[]model.CloudwatchData{
 				{
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{
 							Name:  "LoadBalancer",
 							Value: "app/some-ALB/0123456789012345",
@@ -701,7 +701,7 @@ func Test_mapResultsToMetricDatas(t *testing.T) {
 
 func getSampleMetricDatas(id string) *model.CloudwatchData {
 	return &model.CloudwatchData{
-		Dimensions: []*model.Dimension{
+		Dimensions: []model.Dimension{
 			{
 				Name:  "FileSystemId",
 				Value: "fs-abc123",

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -721,7 +721,7 @@ func getSampleMetricDatas(id string) *model.CloudwatchData {
 			},
 		},
 		GetMetricDataResult: &model.GetMetricDataResult{
-			ID: aws.String(id),
+			ID: id,
 		},
 	}
 }

--- a/pkg/job/maxdimassociator/associator_api_gateway_test.go
+++ b/pkg/job/maxdimassociator/associator_api_gateway_test.go
@@ -55,7 +55,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "5xx",
 					Namespace:  "AWS/ApiGateway",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ApiId", Value: "98765fghij"},
 					},
 				},
@@ -71,7 +71,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "5xx",
 					Namespace:  "AWS/ApiGateway",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ApiId", Value: "98765fghij"},
 						{Name: "Stage", Value: "$default"},
 					},
@@ -88,7 +88,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "5xx",
 					Namespace:  "AWS/ApiGateway",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ApiName", Value: "test-api"},
 					},
 				},
@@ -104,7 +104,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "5xx",
 					Namespace:  "AWS/ApiGateway",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ApiName", Value: "test-api"},
 						{Name: "Stage", Value: "test"},
 					},
@@ -121,7 +121,7 @@ func TestAssociatorAPIGateway(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "5xx",
 					Namespace:  "AWS/ApiGateway",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ApiName", Value: "test-api"},
 						{Name: "Stage", Value: "dev"},
 					},

--- a/pkg/job/maxdimassociator/associator_client_vpn_test.go
+++ b/pkg/job/maxdimassociator/associator_client_vpn_test.go
@@ -38,7 +38,7 @@ func TestAssociatorClientVPN(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CrlDaysToExpiry",
 					Namespace:  "AWS/ClientVPN",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Endpoint", Value: "cvpn-endpoint-0c9e5bd20be71e296"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_ddosprotection_test.go
+++ b/pkg/job/maxdimassociator/associator_ddosprotection_test.go
@@ -48,7 +48,7 @@ func TestAssociatorDDoSProtection(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/DDoSProtection",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ResourceArn", Value: "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_dx_test.go
+++ b/pkg/job/maxdimassociator/associator_dx_test.go
@@ -38,7 +38,7 @@ func TestAssociatorDX(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "VirtualInterfaceBpsIngress",
 					Namespace:  "AWS/DX",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ConnectionId", Value: "dxlag-abc123"},
 						{Name: "VirtualInterfaceId", Value: "dxvif-abc123"},
 					},

--- a/pkg/job/maxdimassociator/associator_ec2_test.go
+++ b/pkg/job/maxdimassociator/associator_ec2_test.go
@@ -48,7 +48,7 @@ func TestAssociatorEC2(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "InstanceId", Value: "i-abc123"},
 					},
 				},
@@ -64,7 +64,7 @@ func TestAssociatorEC2(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "InstanceId", Value: "i-def456"},
 					},
 				},
@@ -80,7 +80,7 @@ func TestAssociatorEC2(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "InstanceId", Value: "i-blahblah"},
 					},
 				},
@@ -96,7 +96,7 @@ func TestAssociatorEC2(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/EC2",
 					MetricName: "StatusCheckFailed_System",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "AutoScalingGroupName", Value: "some-asg-name"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_ec_test.go
+++ b/pkg/job/maxdimassociator/associator_ec_test.go
@@ -48,7 +48,7 @@ func TestAssociatorEC(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "TotalCmdsCount",
 					Namespace:  "AWS/ElastiCache",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "clusterId", Value: "test-serverless-cluster"},
 					},
 				},
@@ -64,7 +64,7 @@ func TestAssociatorEC(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "EngineCPUUtilization",
 					Namespace:  "AWS/ElastiCache",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "CacheClusterId", Value: "test-cluster-0001-001"},
 					},
 				},
@@ -80,7 +80,7 @@ func TestAssociatorEC(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "EngineCPUUtilization",
 					Namespace:  "AWS/ElastiCache",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "CacheClusterId", Value: "test-cluster-0001-002"},
 					},
 				},
@@ -96,7 +96,7 @@ func TestAssociatorEC(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "TotalCmdsCount",
 					Namespace:  "AWS/ElastiCache",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "clusterId", Value: "test-unmatched-serverless-cluster"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_ecs_test.go
+++ b/pkg/job/maxdimassociator/associator_ecs_test.go
@@ -54,7 +54,7 @@ func TestAssociatorECS(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "MemoryReservation",
 					Namespace:  "AWS/ECS",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "sampleCluster"},
 					},
 				},
@@ -70,7 +70,7 @@ func TestAssociatorECS(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
 					Namespace:  "AWS/ECS",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "sampleCluster"},
 						{Name: "ServiceName", Value: "service1"},
 					},
@@ -87,7 +87,7 @@ func TestAssociatorECS(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
 					Namespace:  "AWS/ECS",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "sampleCluster"},
 						{Name: "ServiceName", Value: "service2"},
 					},

--- a/pkg/job/maxdimassociator/associator_event_roles_test.go
+++ b/pkg/job/maxdimassociator/associator_event_roles_test.go
@@ -42,7 +42,7 @@ func TestAssociatorEventRule(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/Events",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EventBusName", Value: "event-bus-name"},
 						{Name: "RuleName", Value: "rule-name"},
 					},

--- a/pkg/job/maxdimassociator/associator_globalaccelerator_test.go
+++ b/pkg/job/maxdimassociator/associator_globalaccelerator_test.go
@@ -54,7 +54,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",
 					Namespace:  "AWS/GlobalAccelerator",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Accelerator", Value: "super-accelerator"},
 					},
 				},
@@ -70,7 +70,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",
 					Namespace:  "AWS/GlobalAccelerator",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Accelerator", Value: "super-accelerator"},
 						{Name: "Listener", Value: "some_listener"},
 					},
@@ -87,7 +87,7 @@ func TestAssociatorGlobalAccelerator(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ProcessedBytesOut",
 					Namespace:  "AWS/GlobalAccelerator",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Accelerator", Value: "super-accelerator"},
 						{Name: "Listener", Value: "some_listener"},
 						{Name: "EndpointGroup", Value: "eg1"},

--- a/pkg/job/maxdimassociator/associator_gwlb_test.go
+++ b/pkg/job/maxdimassociator/associator_gwlb_test.go
@@ -54,7 +54,7 @@ func TestAssociatorGwlb(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "HealthyHostCount",
 					Namespace:  "AWS/GatewayELB",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "LoadBalancer", Value: "gwy/gwlb-1/4a049e69add14452"},
 					},
 				},
@@ -70,7 +70,7 @@ func TestAssociatorGwlb(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "HealthyHostCount",
 					Namespace:  "AWS/GatewayELB",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "LoadBalancer", Value: "gwy/gwlb-1/4a049e69add14452"},
 						{Name: "TargetGroup", Value: "targetgroup/gwlb-target-group-1/012e9f368748cd345c"},
 					},
@@ -87,7 +87,7 @@ func TestAssociatorGwlb(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "HealthyHostCount",
 					Namespace:  "AWS/GatewayELB",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "LoadBalancer", Value: "gwy/non-existing-gwlb/a96cc19724cf1a87"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_ipam_test.go
+++ b/pkg/job/maxdimassociator/associator_ipam_test.go
@@ -42,7 +42,7 @@ func TestAssociatorIpam(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "VpcIPUsage",
 					Namespace:  "AWS/IPAM",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "IpamPoolId", Value: "ipam-pool-1ff5e4e9ad2c28b7b"},
 					},
 				},
@@ -58,7 +58,7 @@ func TestAssociatorIpam(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "VpcIPUsage",
 					Namespace:  "AWS/IPAM",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "IpamPoolId", Value: "ipam-pool-blahblah"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_kms_test.go
+++ b/pkg/job/maxdimassociator/associator_kms_test.go
@@ -38,7 +38,7 @@ func TestAssociatorKMS(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "SecondsUntilKeyMaterialExpiration",
 					Namespace:  "AWS/KMS",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "KeyId", Value: "12345678-1234-1234-1234-123456789012"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_lambda_test.go
+++ b/pkg/job/maxdimassociator/associator_lambda_test.go
@@ -40,7 +40,7 @@ func TestAssociatorLambda(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/Lambda",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "FunctionName", Value: "lambdaFunction"},
 					},
 				},
@@ -56,7 +56,7 @@ func TestAssociatorLambda(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/Lambda",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "FunctionName", Value: "anotherLambdaFunction"},
 					},
 				},
@@ -72,7 +72,7 @@ func TestAssociatorLambda(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/Lambda",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "FunctionName", Value: "lambdaFunction"},
 						{Name: "Resource", Value: "lambdaFunction"},
 					},
@@ -89,7 +89,7 @@ func TestAssociatorLambda(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/Lambda",
-					Dimensions: []*model.Dimension{},
+					Dimensions: []model.Dimension{},
 				},
 			},
 			expectedSkip:     false,

--- a/pkg/job/maxdimassociator/associator_mediaconvert_test.go
+++ b/pkg/job/maxdimassociator/associator_mediaconvert_test.go
@@ -48,7 +48,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",
 					Namespace:  "AWS/MediaConvert",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Queue", Value: "arn:aws:mediaconvert:eu-west-1:631611414237:queues/a-queue"},
 					},
 				},
@@ -64,7 +64,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",
 					Namespace:  "AWS/MediaConvert",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Queue", Value: "arn:aws:mediaconvert:eu-west-1:631611414237:queues/a-second-queue"},
 					},
 				},
@@ -80,7 +80,7 @@ func TestAssociatorMediaConvert(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "JobsCompletedCount",
 					Namespace:  "AWS/MediaConvert",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Queue", Value: "arn:aws:mediaconvert:eu-west-1:631611414237:queues/a-non-existing-queue"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_memorydb_test.go
+++ b/pkg/job/maxdimassociator/associator_memorydb_test.go
@@ -48,7 +48,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "mycluster"},
 					},
 				},
@@ -64,7 +64,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "othercluster"},
 					},
 				},
@@ -80,7 +80,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
 					MetricName: "CPUUtilization",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "ClusterName", Value: "blahblah"},
 					},
 				},
@@ -96,7 +96,7 @@ func TestAssociatorMemoryDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/MemoryDB",
 					MetricName: "BytesUsedForMemoryDB",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "OtherName", Value: "some-other-value"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_mq_test.go
+++ b/pkg/job/maxdimassociator/associator_mq_test.go
@@ -43,7 +43,7 @@ func TestAssociatorMQ(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ProducerCount",
 					Namespace:  "AWS/AmazonMQ",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Broker", Value: "rabbitmq-broker"},
 					},
 				},
@@ -62,7 +62,7 @@ func TestAssociatorMQ(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ProducerCount",
 					Namespace:  "AWS/AmazonMQ",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Broker", Value: "activemq-broker-1"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_qldb_test.go
+++ b/pkg/job/maxdimassociator/associator_qldb_test.go
@@ -38,7 +38,7 @@ func TestAssociatorQLDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/QLDB",
 					MetricName: "JournalStorage",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "LedgerName", Value: "test2"},
 					},
 				},
@@ -54,7 +54,7 @@ func TestAssociatorQLDB(t *testing.T) {
 				metric: &model.Metric{
 					Namespace:  "AWS/QLDB",
 					MetricName: "JournalStorage",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "LedgerName", Value: "test1"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_endpoint_test.go
@@ -48,7 +48,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "MemoryUtilization",
 					Namespace:  "/aws/sagemaker/Endpoints",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "example-endpoint-two"},
 						{Name: "VariantName", Value: "example-endpoint-two-variant-one"},
 					},
@@ -65,7 +65,7 @@ func TestAssociatorSagemakerEndpoint(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "MemoryUtilization",
 					Namespace:  "/aws/sagemaker/Endpoints",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "example-endpoint-three"},
 						{Name: "VariantName", Value: "example-endpoint-three-variant-one"},
 					},

--- a/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_inf_rec_test.go
@@ -42,7 +42,7 @@ func TestAssociatorSagemakerInfRecJob(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ClientInvocations",
 					Namespace:  "/aws/sagemaker/InferenceRecommendationsJobs",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "JobName", Value: "example-inf-rec-job-one"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_pipeline_test.go
@@ -48,7 +48,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",
 					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "PipelineName", Value: "example-pipeline-one"},
 						{Name: "StepName", Value: "example-pipeline-one-step-two"},
 					},
@@ -65,7 +65,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",
 					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "PipelineName", Value: "example-pipeline-two"},
 					},
 				},
@@ -81,7 +81,7 @@ func TestAssociatorSagemakerPipeline(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ExecutionStarted",
 					Namespace:  "AWS/Sagemaker/ModelBuildingPipeline",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "PipelineName", Value: "example-pipeline-three"},
 						{Name: "StepName", Value: "example-pipeline-three-step-two"},
 					},

--- a/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_processing_test.go
@@ -42,7 +42,7 @@ func TestAssociatorSagemakerProcessingJob(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
 					Namespace:  "/aws/sagemaker/ProcessingJobs",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Host", Value: "example-processing-job-one/algo-1"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -54,7 +54,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/SageMaker",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "example-endpoint-one"},
 						{Name: "VariantName", Value: "example-endpoint-one-variant-one"},
 						{Name: "EndpointConfigName", Value: "example-endpoint-one-endpoint-config"},
@@ -72,7 +72,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/SageMaker",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "example-endpoint-two"},
 						{Name: "VariantName", Value: "example-endpoint-two-variant-one"},
 					},
@@ -89,7 +89,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "Invocations",
 					Namespace:  "AWS/SageMaker",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "example-endpoint-three"},
 						{Name: "VariantName", Value: "example-endpoint-three-variant-one"},
 					},
@@ -106,7 +106,7 @@ func TestAssociatorSagemaker(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "ModelLatency",
 					Namespace:  "AWS/SageMaker",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "EndpointName", Value: "Example-Endpoint-Upper"},
 						{Name: "VariantName", Value: "example-endpoint-two-variant-one"},
 					},

--- a/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_training_test.go
@@ -42,7 +42,7 @@ func TestAssociatorSagemakerTrainingJob(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
 					Namespace:  "/aws/sagemaker/TrainingJobs",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Host", Value: "example-training-job-one/algo-1"},
 					},
 				},

--- a/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_transform_test.go
@@ -42,7 +42,7 @@ func TestAssociatorSagemakerTransformJob(t *testing.T) {
 				metric: &model.Metric{
 					MetricName: "CPUUtilization",
 					Namespace:  "/aws/sagemaker/TransformJobs",
-					Dimensions: []*model.Dimension{
+					Dimensions: []model.Dimension{
 						{Name: "Host", Value: "example-transform-job-one/algo-1"},
 					},
 				},

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -26,17 +26,17 @@ func runStaticJob(
 			defer wg.Done()
 
 			data := model.CloudwatchData{
-				ID:           resource.Name,
+				ResourceName: resource.Name,
 				Namespace:    resource.Namespace,
 				Dimensions:   createStaticDimensions(resource.Dimensions),
 				MetricConfig: metric,
 			}
 
-			data.GetMetricStatisticResult = &model.GetMetricStatisticResult{
+			data.GetMetricStatisticsResult = &model.GetMetricStatisticResult{
 				Datapoints: clientCloudwatch.GetMetricStatistics(ctx, logger, data.Dimensions, resource.Namespace, metric),
 			}
 
-			if data.GetMetricStatisticResult.Datapoints != nil {
+			if data.GetMetricStatisticsResult.Datapoints != nil {
 				mux.Lock()
 				cw = append(cw, &data)
 				mux.Unlock()

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -47,11 +47,11 @@ func runStaticJob(
 	return cw
 }
 
-func createStaticDimensions(dimensions []model.Dimension) []*model.Dimension {
-	out := make([]*model.Dimension, 0, len(dimensions))
+func createStaticDimensions(dimensions []model.Dimension) []model.Dimension {
+	out := make([]model.Dimension, 0, len(dimensions))
 	for _, d := range dimensions {
 		d := d
-		out = append(out, &model.Dimension{
+		out = append(out, model.Dimension{
 			Name:  d.Name,
 			Value: d.Value,
 		})

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -26,14 +26,23 @@ func runStaticJob(
 			defer wg.Done()
 
 			data := model.CloudwatchData{
+				MetricName:   metric.Name,
 				ResourceName: resource.Name,
 				Namespace:    resource.Namespace,
 				Dimensions:   createStaticDimensions(resource.Dimensions),
-				MetricConfig: metric,
+				MetricMigrationParams: model.MetricMigrationParams{
+					NilToZero:              metric.NilToZero,
+					AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
+				},
+				Tags:                          nil,
+				GetMetricDataProcessingParams: nil,
+				GetMetricDataResult:           nil,
+				GetMetricStatisticsResult:     nil,
 			}
 
-			data.GetMetricStatisticsResult = &model.GetMetricStatisticResult{
+			data.GetMetricStatisticsResult = &model.GetMetricStatisticsResult{
 				Datapoints: clientCloudwatch.GetMetricStatistics(ctx, logger, data.Dimensions, resource.Namespace, metric),
+				Statistics: metric.Statistics,
 			}
 
 			if data.GetMetricStatisticsResult.Datapoints != nil {

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -25,20 +25,18 @@ func runStaticJob(
 		go func() {
 			defer wg.Done()
 
-			id := resource.Name
 			data := model.CloudwatchData{
-				ID:                     &id,
-				Metric:                 &metric.Name,
-				Namespace:              &resource.Namespace,
-				Statistics:             metric.Statistics,
-				NilToZero:              metric.NilToZero,
-				AddCloudwatchTimestamp: metric.AddCloudwatchTimestamp,
-				Dimensions:             createStaticDimensions(resource.Dimensions),
+				ID:           resource.Name,
+				Namespace:    resource.Namespace,
+				Dimensions:   createStaticDimensions(resource.Dimensions),
+				MetricConfig: metric,
 			}
 
-			data.Points = clientCloudwatch.GetMetricStatistics(ctx, logger, data.Dimensions, resource.Namespace, metric)
+			data.GetMetricStatisticResult = &model.GetMetricStatisticResult{
+				Datapoints: clientCloudwatch.GetMetricStatistics(ctx, logger, data.Dimensions, resource.Namespace, metric),
+			}
 
-			if data.Points != nil {
+			if data.GetMetricStatisticResult.Datapoints != nil {
 				mux.Lock()
 				cw = append(cw, &data)
 				mux.Unlock()

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -168,10 +168,14 @@ type GetMetricStatisticResult struct {
 }
 
 type GetMetricDataResult struct {
-	ID        *string
-	Statistic string
-	Datapoint float64
-	Timestamp time.Time
+	// GetMetricData Query ID used for results mapping
+	ID string
+	// Indicates if this result was successfully mapped to a query result, only used during metric gathering
+	// and does not need to be respected afterward
+	MappedToAQueryResult bool
+	Statistic            string
+	Datapoint            float64
+	Timestamp            time.Time
 }
 
 // TaggedResource is an AWS resource with tags

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -154,13 +154,19 @@ type ScrapeContext struct {
 // CloudwatchData is an internal representation of a CloudWatch
 // metric with attached data points, metric and resource information.
 type CloudwatchData struct {
-	ID                       string
-	Namespace                string
-	Tags                     []Tag
-	Dimensions               []*Dimension
-	MetricConfig             *MetricConfig
-	GetMetricDataResult      *GetMetricDataResult
-	GetMetricStatisticResult *GetMetricStatisticResult
+	// ResourceName will have different values depending on the job type
+	// DiscoveryJob = Resource ARN associated with the metric or global when it could not be associated but shouldn't be dropped
+	// StaticJob = Resource Name from static job config
+	// CustomNamespace = Custom Namespace job name
+	ResourceName string
+	Namespace    string
+	Tags         []Tag
+	Dimensions   []*Dimension
+	MetricConfig *MetricConfig
+	// GetMetricsDataResult is an optional field and will be non-nil when metric data was populated from the GetMetricsData API (Discovery and CustomNamespace jobs)
+	GetMetricDataResult *GetMetricDataResult
+	// GetMetricStatisticsResult is an optional field and will be non-nil when metric data was populated from the GetMetricStatistics API (static jobs)
+	GetMetricStatisticsResult *GetMetricStatisticResult
 }
 
 type GetMetricStatisticResult struct {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -106,7 +106,7 @@ type Dimension struct {
 
 type Metric struct {
 	// The dimensions for the metric.
-	Dimensions []*Dimension
+	Dimensions []Dimension
 	MetricName string
 	Namespace  string
 }
@@ -161,7 +161,7 @@ type CloudwatchData struct {
 	ResourceName string
 	Namespace    string
 	Tags         []Tag
-	Dimensions   []*Dimension
+	Dimensions   []Dimension
 	MetricConfig *MetricConfig
 	// GetMetricsDataResult is an optional field and will be non-nil when metric data was populated from the GetMetricsData API (Discovery and CustomNamespace jobs)
 	GetMetricDataResult *GetMetricDataResult

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -78,8 +78,8 @@ type MetricConfig struct {
 	Period                 int64
 	Length                 int64
 	Delay                  int64
-	NilToZero              *bool
-	AddCloudwatchTimestamp *bool
+	NilToZero              bool
+	AddCloudwatchTimestamp bool
 }
 
 type DimensionsRegexp struct {

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -154,6 +154,7 @@ type ScrapeContext struct {
 // CloudwatchData is an internal representation of a CloudWatch
 // metric with attached data points, metric and resource information.
 type CloudwatchData struct {
+	MetricName string
 	// ResourceName will have different values depending on the job type
 	// DiscoveryJob = Resource ARN associated with the metric or global when it could not be associated but shouldn't be dropped
 	// StaticJob = Resource Name from static job config
@@ -162,26 +163,46 @@ type CloudwatchData struct {
 	Namespace    string
 	Tags         []Tag
 	Dimensions   []Dimension
-	MetricConfig *MetricConfig
+	// GetMetricDataProcessingParams includes necessary fields to run GetMetricData
+	GetMetricDataProcessingParams *GetMetricDataProcessingParams
+
+	// MetricMigrationParams holds configuration values necessary when migrating the resulting metrics
+	MetricMigrationParams MetricMigrationParams
+
 	// GetMetricsDataResult is an optional field and will be non-nil when metric data was populated from the GetMetricsData API (Discovery and CustomNamespace jobs)
 	GetMetricDataResult *GetMetricDataResult
+
 	// GetMetricStatisticsResult is an optional field and will be non-nil when metric data was populated from the GetMetricStatistics API (static jobs)
-	GetMetricStatisticsResult *GetMetricStatisticResult
+	GetMetricStatisticsResult *GetMetricStatisticsResult
 }
 
-type GetMetricStatisticResult struct {
+type GetMetricStatisticsResult struct {
 	Datapoints []*Datapoint
+	Statistics []string
+}
+
+type GetMetricDataProcessingParams struct {
+	// QueryID is the query ID for GetMetricData used in results mapping
+	QueryID string
+
+	// The statistic to be used to call GetMetricData
+	Statistic string
+
+	// Fields which impact the start and endtime for
+	Period int64
+	Length int64
+	Delay  int64
+}
+
+type MetricMigrationParams struct {
+	NilToZero              bool
+	AddCloudwatchTimestamp bool
 }
 
 type GetMetricDataResult struct {
-	// GetMetricData Query ID used for results mapping
-	ID string
-	// Indicates if this result was successfully mapped to a query result, only used during metric gathering
-	// and does not need to be respected afterward
-	MappedToAQueryResult bool
-	Statistic            string
-	Datapoint            float64
-	Timestamp            time.Time
+	Statistic string
+	Datapoint *float64
+	Timestamp time.Time
 }
 
 // TaggedResource is an AWS resource with tags

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -154,19 +154,24 @@ type ScrapeContext struct {
 // CloudwatchData is an internal representation of a CloudWatch
 // metric with attached data points, metric and resource information.
 type CloudwatchData struct {
-	ID                      *string
-	MetricID                *string
-	Metric                  *string
-	Namespace               *string
-	Statistics              []string
-	Points                  []*Datapoint
-	GetMetricDataPoint      *float64
-	GetMetricDataTimestamps time.Time
-	NilToZero               *bool
-	AddCloudwatchTimestamp  *bool
-	Tags                    []Tag
-	Dimensions              []*Dimension
-	Period                  int64
+	ID                       string
+	Namespace                string
+	Tags                     []Tag
+	Dimensions               []*Dimension
+	MetricConfig             *MetricConfig
+	GetMetricDataResult      *GetMetricDataResult
+	GetMetricStatisticResult *GetMetricStatisticResult
+}
+
+type GetMetricStatisticResult struct {
+	Datapoints []*Datapoint
+}
+
+type GetMetricDataResult struct {
+	ID        *string
+	Statistic string
+	Datapoint float64
+	Timestamp time.Time
 }
 
 // TaggedResource is an AWS resource with tags
@@ -184,7 +189,7 @@ type TaggedResource struct {
 	Tags []Tag
 }
 
-// filterThroughTags returns true if all filterTags match
+// FilterThroughTags returns true if all filterTags match
 // with tags of the TaggedResource, returns false otherwise.
 func (r TaggedResource) FilterThroughTags(filterTags []SearchTag) bool {
 	if len(filterTags) == 0 {

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -64,10 +64,7 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 		contextLabels := contextToLabels(result.Context, labelsSnakeCase, logger)
 		for _, metric := range result.Data {
 			var statisticsRepresentedInMetric []string
-			includeTimestamp := false
-			if metric.MetricConfig.AddCloudwatchTimestamp != nil {
-				includeTimestamp = *metric.MetricConfig.AddCloudwatchTimestamp
-			}
+			includeTimestamp := metric.MetricConfig.AddCloudwatchTimestamp
 			// A result from GetMetricData is for a single statistic noted on the result while a
 			// result from GetMetricStatistics is for all statistics configured for the metric
 			if metric.GetMetricDataResult != nil {
@@ -96,7 +93,7 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 				// It's unclear if this use case is possible with GetMetricDataResults since NaN would need to be returned
 				// as the value directly. GetMetricStatisticsResults can include a statistic with no matching datapoint which
 				// we will turn in to a NaN above. Doing this here ensures we will always respect NilToZero for any possible NaN
-				if *metric.MetricConfig.NilToZero && math.IsNaN(exportedDatapoint) {
+				if metric.MetricConfig.NilToZero && math.IsNaN(exportedDatapoint) {
 					exportedDatapoint = 0
 				}
 

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -75,9 +75,9 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 				}
 				var exportedDatapoint float64
 				if dataPoint == nil && metric.MetricMigrationParams.AddCloudwatchTimestamp {
-					// If we did not get a datapoint then the is default making it unusable in the exported metric
-					// Attempting to put a timestamp on the metric ourselves will likely conflict with future CloudWatch
-					// timestamps which are always in the past. It's safer to skip here than guess
+					// If we did not get a datapoint then the timestamp is a default value making it unusable in the
+					// exported metric. Attempting to put a fake timestamp on the metric will likely conflict with
+					// future CloudWatch timestamps which are always in the past. It's safer to skip here than guess
 					continue
 				}
 				if dataPoint == nil {

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -272,7 +272,7 @@ func TestBuildMetrics(t *testing.T) {
 								Value: "redis-cluster",
 							},
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -291,7 +291,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 2,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -311,7 +311,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 3,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -331,7 +331,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 4,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 				},
 			}},
@@ -437,7 +437,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 0,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -457,7 +457,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 0,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -477,7 +477,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 0,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
 						MetricConfig: &model.MetricConfig{
@@ -497,7 +497,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 0,
 							Timestamp: ts,
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 				},
 			}},
@@ -581,7 +581,7 @@ func TestBuildMetrics(t *testing.T) {
 								Value: "redis-cluster",
 							},
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						MetricConfig: &model.MetricConfig{
 							NilToZero: aws.Bool(false),
 							Name:      "CPUUtilization",
@@ -638,7 +638,7 @@ func TestBuildMetrics(t *testing.T) {
 								Value: "redis-cluster",
 							},
 						},
-						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						MetricConfig: &model.MetricConfig{
 							NilToZero: aws.Bool(false),
 							Name:      "CPUUtilization",

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -258,7 +258,7 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:      "CPUUtilization",
-							NilToZero: aws.Bool(true),
+							NilToZero: true,
 						},
 						Namespace: "AWS/ElastiCache",
 						GetMetricDataResult: &model.GetMetricDataResult{
@@ -277,7 +277,7 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:      "FreeableMemory",
-							NilToZero: aws.Bool(false),
+							NilToZero: false,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -296,8 +296,8 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:                   "NetworkBytesIn",
-							NilToZero:              aws.Bool(true),
-							AddCloudwatchTimestamp: aws.Bool(false),
+							NilToZero:              true,
+							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -316,8 +316,8 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:                   "NetworkBytesOut",
-							NilToZero:              aws.Bool(true),
-							AddCloudwatchTimestamp: aws.Bool(true),
+							NilToZero:              true,
+							AddCloudwatchTimestamp: true,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -423,7 +423,7 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:      "CPUUtilization",
-							NilToZero: aws.Bool(true),
+							NilToZero: true,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -442,7 +442,7 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:      "FreeableMemory",
-							NilToZero: aws.Bool(false),
+							NilToZero: false,
 						},
 						Namespace: "AWS/ElastiCache",
 
@@ -462,8 +462,8 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:                   "NetworkBytesIn",
-							NilToZero:              aws.Bool(true),
-							AddCloudwatchTimestamp: aws.Bool(false),
+							NilToZero:              true,
+							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -482,8 +482,8 @@ func TestBuildMetrics(t *testing.T) {
 					{
 						MetricConfig: &model.MetricConfig{
 							Name:                   "NetworkBytesOut",
-							NilToZero:              aws.Bool(true),
-							AddCloudwatchTimestamp: aws.Bool(true),
+							NilToZero:              true,
+							AddCloudwatchTimestamp: true,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
@@ -583,7 +583,7 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						MetricConfig: &model.MetricConfig{
-							NilToZero: aws.Bool(false),
+							NilToZero: false,
 							Name:      "CPUUtilization",
 						},
 					},
@@ -640,7 +640,7 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						MetricConfig: &model.MetricConfig{
-							NilToZero: aws.Bool(false),
+							NilToZero: false,
 							Name:      "CPUUtilization",
 						},
 					},

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -53,7 +53,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"name":          "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_CustomTag": "tag_Value",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 			},
 			expectedLabels: map[string]model.LabelSet{
@@ -93,7 +93,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"name":           "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_custom_tag": "tag_Value",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 			},
 			expectedLabels: map[string]model.LabelSet{
@@ -130,7 +130,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"name":                 "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
 						"dimension_InstanceId": "i-abc123",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 			},
 			observedMetricLabels: map[string]model.LabelSet{
@@ -147,7 +147,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"name":                 "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
 						"dimension_InstanceId": "i-abc123",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 				{
 					Name: aws.String("aws_elasticache_info"),
@@ -155,7 +155,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"name":           "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_custom_tag": "tag_Value",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 			},
 			expectedLabels: map[string]model.LabelSet{
@@ -209,7 +209,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 						"region":                 "us-east-2",
 						"custom_tag_billable_to": "api",
 					},
-					Value: aws.Float64(0),
+					Value: 0,
 				},
 			},
 			expectedLabels: map[string]model.LabelSet{
@@ -247,7 +247,7 @@ func TestBuildMetrics(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "metric with non-nil data point",
+			name: "metric with GetMetricDataResult",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{
 					Region:     "us-east-1",
@@ -256,66 +256,82 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						Metric:     aws.String("CPUUtilization"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:      "CPUUtilization",
+							NilToZero: aws.Bool(true),
+						},
+						Namespace: "AWS/ElastiCache",
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 1,
+							Timestamp: ts,
+						},
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						GetMetricDataPoint:      aws.Float64(1),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("FreeableMemory"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:      "FreeableMemory",
+							NilToZero: aws.Bool(false),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(false),
-						GetMetricDataPoint:      aws.Float64(2),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 2,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("NetworkBytesIn"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:                   "NetworkBytesIn",
+							NilToZero:              aws.Bool(true),
+							AddCloudwatchTimestamp: aws.Bool(false),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						AddCloudwatchTimestamp:  aws.Bool(false),
-						GetMetricDataPoint:      aws.Float64(3),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 3,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("NetworkBytesOut"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:                   "NetworkBytesOut",
+							NilToZero:              aws.Bool(true),
+							AddCloudwatchTimestamp: aws.Bool(true),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						AddCloudwatchTimestamp:  aws.Bool(true),
-						GetMetricDataPoint:      aws.Float64(4),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 4,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 				},
 			}},
@@ -323,7 +339,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedMetrics: []*PrometheusMetric{
 				{
 					Name:      aws.String("aws_elasticache_cpuutilization_average"),
-					Value:     aws.Float64(1),
+					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -334,7 +350,7 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				{
 					Name:      aws.String("aws_elasticache_freeable_memory_average"),
-					Value:     aws.Float64(2),
+					Value:     2,
 					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -345,7 +361,7 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				{
 					Name:      aws.String("aws_elasticache_network_bytes_in_average"),
-					Value:     aws.Float64(3),
+					Value:     3,
 					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -356,7 +372,7 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				{
 					Name:             aws.String("aws_elasticache_network_bytes_out_average"),
-					Value:            aws.Float64(4),
+					Value:            4,
 					Timestamp:        ts,
 					IncludeTimestamp: true,
 					Labels: map[string]string{
@@ -396,7 +412,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "metrics with nil data points",
+			name: "metrics with no data points",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{
 					Region:     "us-east-1",
@@ -405,66 +421,83 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						Metric:     aws.String("CPUUtilization"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:      "CPUUtilization",
+							NilToZero: aws.Bool(true),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						GetMetricDataPoint:      nil,
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 0,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("FreeableMemory"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:      "FreeableMemory",
+							NilToZero: aws.Bool(false),
+						},
+						Namespace: "AWS/ElastiCache",
+
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(false),
-						GetMetricDataPoint:      nil,
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 0,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("NetworkBytesIn"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:                   "NetworkBytesIn",
+							NilToZero:              aws.Bool(true),
+							AddCloudwatchTimestamp: aws.Bool(false),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						AddCloudwatchTimestamp:  aws.Bool(false),
-						GetMetricDataPoint:      nil,
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 0,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						Metric:     aws.String("NetworkBytesOut"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						MetricConfig: &model.MetricConfig{
+							Name:                   "NetworkBytesOut",
+							NilToZero:              aws.Bool(true),
+							AddCloudwatchTimestamp: aws.Bool(true),
+						},
+						Namespace: "AWS/ElastiCache",
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(true),
-						AddCloudwatchTimestamp:  aws.Bool(true),
-						GetMetricDataPoint:      nil,
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 0,
+							Timestamp: ts,
+						},
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 				},
 			}},
@@ -472,7 +505,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedMetrics: []*PrometheusMetric{
 				{
 					Name:      aws.String("aws_elasticache_cpuutilization_average"),
-					Value:     aws.Float64(0),
+					Value:     0,
 					Timestamp: time.Time{},
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -483,7 +516,7 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				{
 					Name:      aws.String("aws_elasticache_freeable_memory_average"),
-					Value:     aws.Float64(math.NaN()),
+					Value:     math.NaN(),
 					Timestamp: time.Time{},
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -494,7 +527,7 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				{
 					Name:      aws.String("aws_elasticache_network_bytes_in_average"),
-					Value:     aws.Float64(0),
+					Value:     0,
 					Timestamp: time.Time{},
 					Labels: map[string]string{
 						"account_id":               "123456789012",
@@ -536,19 +569,23 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						Metric:     aws.String("CPUUtilization"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						Namespace: "AWS/ElastiCache",
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 1,
+							Timestamp: ts,
+						},
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(false),
-						GetMetricDataPoint:      aws.Float64(1),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						MetricConfig: &model.MetricConfig{
+							NilToZero: aws.Bool(false),
+							Name:      "CPUUtilization",
+						},
 					},
 				},
 			}},
@@ -556,7 +593,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedMetrics: []*PrometheusMetric{
 				{
 					Name:      aws.String("aws_elasticache_cpuutilization_average"),
-					Value:     aws.Float64(1),
+					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":                 "123456789012",
@@ -589,19 +626,23 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						Metric:     aws.String("CPUUtilization"),
-						Namespace:  aws.String("AWS/ElastiCache"),
-						Statistics: []string{"Average"},
+						Namespace: "AWS/ElastiCache",
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: 1,
+							Timestamp: ts,
+						},
 						Dimensions: []*model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
 							},
 						},
-						NilToZero:               aws.Bool(false),
-						GetMetricDataPoint:      aws.Float64(1),
-						GetMetricDataTimestamps: ts,
-						ID:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster"),
+						ID: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+						MetricConfig: &model.MetricConfig{
+							NilToZero: aws.Bool(false),
+							Name:      "CPUUtilization",
+						},
 					},
 				},
 			}},
@@ -609,7 +650,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedMetrics: []*PrometheusMetric{
 				{
 					Name:      aws.String("aws_elasticache_cpuutilization_average"),
-					Value:     aws.Float64(1),
+					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":                 "123456789012",
@@ -652,8 +693,8 @@ func TestBuildMetrics(t *testing.T) {
 // struct values are NaN because NaN != NaN
 func replaceNaNValues(metrics []*PrometheusMetric) []*PrometheusMetric {
 	for _, metric := range metrics {
-		if metric.Value != nil && math.IsNaN(*metric.Value) {
-			metric.Value = aws.Float64(54321.0)
+		if math.IsNaN(metric.Value) {
+			metric.Value = 54321.0
 		}
 	}
 	return metrics
@@ -707,17 +748,17 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{"label1": "value1"},
-					Value:  aws.Float64(1.0),
+					Value:  1.0,
 				},
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{"label2": "value2"},
-					Value:  aws.Float64(2.0),
+					Value:  2.0,
 				},
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{},
-					Value:  aws.Float64(3.0),
+					Value:  3.0,
 				},
 			},
 			observedLabels: map[string]model.LabelSet{"metric1": {"label1": {}, "label2": {}, "label3": {}}},
@@ -725,17 +766,17 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{"label1": "value1", "label2": "", "label3": ""},
-					Value:  aws.Float64(1.0),
+					Value:  1.0,
 				},
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{"label1": "", "label3": "", "label2": "value2"},
-					Value:  aws.Float64(2.0),
+					Value:  2.0,
 				},
 				{
 					Name:   aws.String("metric1"),
 					Labels: map[string]string{"label1": "", "label2": "", "label3": ""},
-					Value:  aws.Float64(3.0),
+					Value:  3.0,
 				},
 			},
 		},

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -266,7 +266,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 1,
 							Timestamp: ts,
 						},
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -280,7 +280,7 @@ func TestBuildMetrics(t *testing.T) {
 							NilToZero: false,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -300,7 +300,7 @@ func TestBuildMetrics(t *testing.T) {
 							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -320,7 +320,7 @@ func TestBuildMetrics(t *testing.T) {
 							AddCloudwatchTimestamp: true,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -426,7 +426,7 @@ func TestBuildMetrics(t *testing.T) {
 							NilToZero: true,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -446,7 +446,7 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						Namespace: "AWS/ElastiCache",
 
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -466,7 +466,7 @@ func TestBuildMetrics(t *testing.T) {
 							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -486,7 +486,7 @@ func TestBuildMetrics(t *testing.T) {
 							AddCloudwatchTimestamp: true,
 						},
 						Namespace: "AWS/ElastiCache",
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -575,7 +575,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 1,
 							Timestamp: ts,
 						},
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",
@@ -632,7 +632,7 @@ func TestBuildMetrics(t *testing.T) {
 							Datapoint: 1,
 							Timestamp: ts,
 						},
-						Dimensions: []*model.Dimension{
+						Dimensions: []model.Dimension{
 							{
 								Name:  "CacheClusterId",
 								Value: "redis-cluster",

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -247,7 +247,7 @@ func TestBuildMetrics(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "metric with GetMetricDataResult",
+			name: "metric with GetMetricDataResult and non-nil datapoint",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{
 					Region:     "us-east-1",
@@ -256,14 +256,15 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:      "CPUUtilization",
-							NilToZero: true,
+						MetricName: "CPUUtilization",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              true,
+							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 1,
+							Datapoint: aws.Float64(1),
 							Timestamp: ts,
 						},
 						Dimensions: []model.Dimension{
@@ -275,9 +276,10 @@ func TestBuildMetrics(t *testing.T) {
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:      "FreeableMemory",
-							NilToZero: false,
+						MetricName: "FreeableMemory",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
 						},
 						Namespace: "AWS/ElastiCache",
 						Dimensions: []model.Dimension{
@@ -288,14 +290,14 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 2,
+							Datapoint: aws.Float64(2),
 							Timestamp: ts,
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:                   "NetworkBytesIn",
+						MetricName: "NetworkBytesIn",
+						MetricMigrationParams: model.MetricMigrationParams{
 							NilToZero:              true,
 							AddCloudwatchTimestamp: false,
 						},
@@ -308,14 +310,14 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 3,
+							Datapoint: aws.Float64(3),
 							Timestamp: ts,
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:                   "NetworkBytesOut",
+						MetricName: "NetworkBytesOut",
+						MetricMigrationParams: model.MetricMigrationParams{
 							NilToZero:              true,
 							AddCloudwatchTimestamp: true,
 						},
@@ -328,7 +330,7 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 4,
+							Datapoint: aws.Float64(4),
 							Timestamp: ts,
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
@@ -412,7 +414,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "metrics with no data points",
+			name: "metric with GetMetricDataResult and nil datapoint",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{
 					Region:     "us-east-1",
@@ -421,47 +423,8 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:      "CPUUtilization",
-							NilToZero: true,
-						},
-						Namespace: "AWS/ElastiCache",
-						Dimensions: []model.Dimension{
-							{
-								Name:  "CacheClusterId",
-								Value: "redis-cluster",
-							},
-						},
-						GetMetricDataResult: &model.GetMetricDataResult{
-							Statistic: "Average",
-							Datapoint: 0,
-							Timestamp: ts,
-						},
-						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
-					},
-					{
-						MetricConfig: &model.MetricConfig{
-							Name:      "FreeableMemory",
-							NilToZero: false,
-						},
-						Namespace: "AWS/ElastiCache",
-
-						Dimensions: []model.Dimension{
-							{
-								Name:  "CacheClusterId",
-								Value: "redis-cluster",
-							},
-						},
-						GetMetricDataResult: &model.GetMetricDataResult{
-							Statistic: "Average",
-							Datapoint: 0,
-							Timestamp: ts,
-						},
-						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
-					},
-					{
-						MetricConfig: &model.MetricConfig{
-							Name:                   "NetworkBytesIn",
+						MetricName: "CPUUtilization",
+						MetricMigrationParams: model.MetricMigrationParams{
 							NilToZero:              true,
 							AddCloudwatchTimestamp: false,
 						},
@@ -474,14 +437,55 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 0,
+							Datapoint: nil,
 							Timestamp: ts,
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 					},
 					{
-						MetricConfig: &model.MetricConfig{
-							Name:                   "NetworkBytesOut",
+						MetricName: "FreeableMemory",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
+						},
+						Namespace: "AWS/ElastiCache",
+
+						Dimensions: []model.Dimension{
+							{
+								Name:  "CacheClusterId",
+								Value: "redis-cluster",
+							},
+						},
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: nil,
+							Timestamp: ts,
+						},
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+					},
+					{
+						MetricName: "NetworkBytesIn",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              true,
+							AddCloudwatchTimestamp: false,
+						},
+						Namespace: "AWS/ElastiCache",
+						Dimensions: []model.Dimension{
+							{
+								Name:  "CacheClusterId",
+								Value: "redis-cluster",
+							},
+						},
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: nil,
+							Timestamp: ts,
+						},
+						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+					},
+					{
+						MetricName: "NetworkBytesOut",
+						MetricMigrationParams: model.MetricMigrationParams{
 							NilToZero:              true,
 							AddCloudwatchTimestamp: true,
 						},
@@ -494,7 +498,7 @@ func TestBuildMetrics(t *testing.T) {
 						},
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 0,
+							Datapoint: nil,
 							Timestamp: ts,
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
@@ -506,35 +510,38 @@ func TestBuildMetrics(t *testing.T) {
 				{
 					Name:      aws.String("aws_elasticache_cpuutilization_average"),
 					Value:     0,
-					Timestamp: time.Time{},
+					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
 						"name":                     "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"region":                   "us-east-1",
 						"dimension_CacheClusterId": "redis-cluster",
 					},
+					IncludeTimestamp: false,
 				},
 				{
 					Name:      aws.String("aws_elasticache_freeable_memory_average"),
 					Value:     math.NaN(),
-					Timestamp: time.Time{},
+					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
 						"name":                     "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"region":                   "us-east-1",
 						"dimension_CacheClusterId": "redis-cluster",
 					},
+					IncludeTimestamp: false,
 				},
 				{
 					Name:      aws.String("aws_elasticache_network_bytes_in_average"),
 					Value:     0,
-					Timestamp: time.Time{},
+					Timestamp: ts,
 					Labels: map[string]string{
 						"account_id":               "123456789012",
 						"name":                     "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"region":                   "us-east-1",
 						"dimension_CacheClusterId": "redis-cluster",
 					},
+					IncludeTimestamp: false,
 				},
 			},
 			expectedLabels: map[string]model.LabelSet{
@@ -569,10 +576,15 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
+						MetricName: "CPUUtilization",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
+						},
 						Namespace: "AWS/ElastiCache",
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 1,
+							Datapoint: aws.Float64(1),
 							Timestamp: ts,
 						},
 						Dimensions: []model.Dimension{
@@ -582,10 +594,6 @@ func TestBuildMetrics(t *testing.T) {
 							},
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
-						MetricConfig: &model.MetricConfig{
-							NilToZero: false,
-							Name:      "CPUUtilization",
-						},
 					},
 				},
 			}},
@@ -626,10 +634,15 @@ func TestBuildMetrics(t *testing.T) {
 				},
 				Data: []*model.CloudwatchData{
 					{
+						MetricName: "CPUUtilization",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
+						},
 						Namespace: "AWS/ElastiCache",
 						GetMetricDataResult: &model.GetMetricDataResult{
 							Statistic: "Average",
-							Datapoint: 1,
+							Datapoint: aws.Float64(1),
 							Timestamp: ts,
 						},
 						Dimensions: []model.Dimension{
@@ -639,10 +652,6 @@ func TestBuildMetrics(t *testing.T) {
 							},
 						},
 						ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
-						MetricConfig: &model.MetricConfig{
-							NilToZero: false,
-							Name:      "CPUUtilization",
-						},
 					},
 				},
 			}},

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -89,7 +89,7 @@ var splitRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 type PrometheusMetric struct {
 	Name             *string
 	Labels           map[string]string
-	Value            *float64
+	Value            float64
 	IncludeTimestamp bool
 	Timestamp        time.Time
 }
@@ -125,7 +125,7 @@ func createMetric(metric *PrometheusMetric) prometheus.Metric {
 		ConstLabels: metric.Labels,
 	})
 
-	gauge.Set(*metric.Value)
+	gauge.Set(metric.Value)
 
 	if !metric.IncludeTimestamp {
 		return gauge


### PR DESCRIPTION
This PR restructures some of the fields on the `CloudwatchData` struct to make the field usage much more obvious. This struct is used through out the scraping process to carry around context and the result of finding metric data and contains a lot of overlapping/overloaded fields. The net result should be a struct that is much easier to understand making some of the complex mapping done in `migrate.BuildMetrics` a little more obvious, and less pointers where they are not necessary.

Related to: https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1290
