### PR TITLE
ApiGateway: bugfix to restore FilterFunc for correct mapping of resou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ As a quick start, the following IAM policy can be used to grant the all permissi
         "cloudwatch:GetMetricData",
         "cloudwatch:GetMetricStatistics",
         "cloudwatch:ListMetrics",
+        "apigateway:GET",
         "aps:ListWorkspaces",
         "autoscaling:DescribeAutoScalingGroups",
         "dms:DescribeReplicationInstances",
@@ -168,6 +169,11 @@ These are the bare minimum permissions required to run Static and Discovery Jobs
 "cloudwatch:GetMetricData",
 "cloudwatch:GetMetricStatistics",
 "cloudwatch:ListMetrics"
+```
+
+This permission is required to discover resources for the AWS/ApiGateway namespace
+```json
+"apigateway:GET"
 ```
 
 This permission is required to discover resources for the AWS/AutoScaling namespace

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.4
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.4
 	github.com/aws/aws-sdk-go-v2/service/amp v1.25.1
+	github.com/aws/aws-sdk-go-v2/service/apigateway v1.23.3
+	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,10 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
 github.com/aws/aws-sdk-go-v2/service/amp v1.25.1 h1:kdytWcOvNUmqSVWSRNeAirv4e1j397UQC3d6ofS2CxQ=
 github.com/aws/aws-sdk-go-v2/service/amp v1.25.1/go.mod h1:cG/8NqEsOGrLYBgIeixa7aaHzY8RvbUhMQYJBbSdD+c=
+github.com/aws/aws-sdk-go-v2/service/apigateway v1.23.3 h1:STt7Loc3FYm8xoU0zF8cvXLgk0aXFEhBpw/QWoxey+8=
+github.com/aws/aws-sdk-go-v2/service/apigateway v1.23.3/go.mod h1:Cz7oE8VP37eZ/JYhWoeRaqX2GoecJ2EkO7OEcjV4KQ4=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1 h1:nOJwQpU2wDe2qtw+vwkywJ44UhK66P6+1UIRotE7Jmo=
+github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.20.1/go.mod h1:A95FM8hxO6umoiROudoYtTmZYl7KN9nbez8deLDOCnA=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.2 h1:nbDDSiI4JpmOzSvtxa1jduRMmib+t/IU2mWgF3mSSBU=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.40.2/go.mod h1:g+K5WaPD3zegO3keZ8kV4dzPzU80aypAXSCXy7WL5xo=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.36.1 h1:mQySuI87thHtcbZvEDjwUROGWikU6fqgpHklCBXpJU4=

--- a/pkg/clients/tagging/v1/client.go
+++ b/pkg/clients/tagging/v1/client.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -25,6 +27,8 @@ type client struct {
 	logger            logging.Logger
 	taggingAPI        resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI
 	autoscalingAPI    autoscalingiface.AutoScalingAPI
+	apiGatewayAPI     apigatewayiface.APIGatewayAPI
+	apiGatewayV2API   apigatewayv2iface.ApiGatewayV2API
 	ec2API            ec2iface.EC2API
 	dmsAPI            databasemigrationserviceiface.DatabaseMigrationServiceAPI
 	prometheusSvcAPI  prometheusserviceiface.PrometheusServiceAPI
@@ -36,6 +40,8 @@ func NewClient(
 	logger logging.Logger,
 	taggingAPI resourcegroupstaggingapiiface.ResourceGroupsTaggingAPIAPI,
 	autoscalingAPI autoscalingiface.AutoScalingAPI,
+	apiGatewayAPI apigatewayiface.APIGatewayAPI,
+	apiGatewayV2API apigatewayv2iface.ApiGatewayV2API,
 	ec2API ec2iface.EC2API,
 	dmsClient databasemigrationserviceiface.DatabaseMigrationServiceAPI,
 	prometheusClient prometheusserviceiface.PrometheusServiceAPI,
@@ -46,6 +52,8 @@ func NewClient(
 		logger:            logger,
 		taggingAPI:        taggingAPI,
 		autoscalingAPI:    autoscalingAPI,
+		apiGatewayAPI:     apiGatewayAPI,
+		apiGatewayV2API:   apiGatewayV2API,
 		ec2API:            ec2API,
 		dmsAPI:            dmsClient,
 		prometheusSvcAPI:  prometheusClient,

--- a/pkg/clients/tagging/v1/filters_test.go
+++ b/pkg/clients/tagging/v1/filters_test.go
@@ -7,6 +7,10 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go/service/databasemigrationservice/databasemigrationserviceiface"
 
@@ -25,6 +29,174 @@ func TestValidServiceNames(t *testing.T) {
 			t.Errorf("no filter functions defined for service name '%s'", svc)
 			t.FailNow()
 		}
+	}
+}
+
+func TestApiGatewayFilterFunc(t *testing.T) {
+	tests := []struct {
+		name            string
+		iface           client
+		inputResources  []*model.TaggedResource
+		outputResources []*model.TaggedResource
+	}{
+		{
+			"api gateway resources skip stages",
+			client{
+				apiGatewayAPI: apiGatewayClient{
+					getRestApisOutput: &apigateway.GetRestApisOutput{
+						Items: []*apigateway.RestApi{
+							{
+								ApiKeySource:              nil,
+								BinaryMediaTypes:          nil,
+								CreatedDate:               nil,
+								Description:               nil,
+								DisableExecuteApiEndpoint: nil,
+								EndpointConfiguration:     nil,
+								Id:                        aws.String("gwid1234"),
+								MinimumCompressionSize:    nil,
+								Name:                      aws.String("apiname"),
+								Policy:                    nil,
+								Tags:                      nil,
+								Version:                   nil,
+								Warnings:                  nil,
+							},
+						},
+						Position: nil,
+					},
+				},
+				apiGatewayV2API: apiGatewayV2Client{
+					getRestApisOutput: &apigatewayv2.GetApisOutput{
+						Items: []*apigatewayv2.Api{},
+					},
+				},
+			},
+			[]*model.TaggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/gwid1234/stages/main",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/gwid1234",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+			[]*model.TaggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/restapis/apiname",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+		},
+		{
+			"api gateway v2",
+			client{
+				apiGatewayAPI: apiGatewayClient{
+					getRestApisOutput: &apigateway.GetRestApisOutput{
+						Items: []*apigateway.RestApi{},
+					},
+				},
+				apiGatewayV2API: apiGatewayV2Client{
+					getRestApisOutput: &apigatewayv2.GetApisOutput{
+						Items: []*apigatewayv2.Api{
+							{
+								CreatedDate:               nil,
+								Description:               nil,
+								DisableExecuteApiEndpoint: nil,
+								ApiId:                     aws.String("gwid9876"),
+								Name:                      aws.String("apiv2name"),
+								Tags:                      nil,
+								Version:                   nil,
+								Warnings:                  nil,
+							},
+						},
+						NextToken: nil,
+					},
+				},
+			},
+			[]*model.TaggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/apis/gwid9876/stages/$default",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value",
+						},
+					},
+				},
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/apis/gwid9876",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+			[]*model.TaggedResource{
+				{
+					ARN:       "arn:aws:apigateway:us-east-1::/apis/gwid9876",
+					Namespace: "apigateway",
+					Region:    "us-east-1",
+					Tags: []model.Tag{
+						{
+							Key:   "Test",
+							Value: "Value 2",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			apigateway := ServiceFilters["AWS/ApiGateway"]
+
+			outputResources, err := apigateway.FilterFunc(context.Background(), test.iface, test.inputResources)
+			if err != nil {
+				t.Logf("Error from FilterFunc: %v", err)
+				t.FailNow()
+			}
+			if len(outputResources) != len(test.outputResources) {
+				t.Logf("len(outputResources) = %d, want %d", len(outputResources), len(test.outputResources))
+				t.Fail()
+			}
+			for i, resource := range outputResources {
+				if len(test.outputResources) <= i {
+					break
+				}
+				wantResource := *test.outputResources[i]
+				if !reflect.DeepEqual(*resource, wantResource) {
+					t.Errorf("outputResources[%d] = %+v, want %+v", i, *resource, wantResource)
+				}
+			}
+		})
 	}
 }
 
@@ -241,6 +413,25 @@ func TestDMSFilterFunc(t *testing.T) {
 			}
 		})
 	}
+}
+
+type apiGatewayClient struct {
+	apigatewayiface.APIGatewayAPI
+	getRestApisOutput *apigateway.GetRestApisOutput
+}
+
+func (apigateway apiGatewayClient) GetRestApisPagesWithContext(_ aws.Context, _ *apigateway.GetRestApisInput, fn func(*apigateway.GetRestApisOutput, bool) bool, _ ...request.Option) error {
+	fn(apigateway.getRestApisOutput, true)
+	return nil
+}
+
+type apiGatewayV2Client struct {
+	apigatewayv2iface.ApiGatewayV2API
+	getRestApisOutput *apigatewayv2.GetApisOutput
+}
+
+func (apigateway apiGatewayV2Client) GetApisWithContext(_ aws.Context, _ *apigatewayv2.GetApisInput, _ ...request.Option) (*apigatewayv2.GetApisOutput, error) {
+	return apigateway.getRestApisOutput, nil
 }
 
 type dmsClient struct {

--- a/pkg/clients/tagging/v2/client.go
+++ b/pkg/clients/tagging/v2/client.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -25,6 +27,8 @@ type client struct {
 	logger            logging.Logger
 	taggingAPI        *resourcegroupstaggingapi.Client
 	autoscalingAPI    *autoscaling.Client
+	apiGatewayAPI     *apigateway.Client
+	apiGatewayV2API   *apigatewayv2.Client
 	ec2API            *ec2.Client
 	dmsAPI            *databasemigrationservice.Client
 	prometheusSvcAPI  *amp.Client
@@ -36,6 +40,8 @@ func NewClient(
 	logger logging.Logger,
 	taggingAPI *resourcegroupstaggingapi.Client,
 	autoscalingAPI *autoscaling.Client,
+	apiGatewayAPI *apigateway.Client,
+	apiGatewayV2API *apigatewayv2.Client,
 	ec2API *ec2.Client,
 	dmsClient *databasemigrationservice.Client,
 	prometheusClient *amp.Client,
@@ -46,6 +52,8 @@ func NewClient(
 		logger:            logger,
 		taggingAPI:        taggingAPI,
 		autoscalingAPI:    autoscalingAPI,
+		apiGatewayAPI:     apiGatewayAPI,
+		apiGatewayV2API:   apiGatewayV2API,
 		ec2API:            ec2API,
 		dmsAPI:            dmsClient,
 		prometheusSvcAPI:  prometheusClient,

--- a/pkg/clients/tagging/v2/filters.go
+++ b/pkg/clients/tagging/v2/filters.go
@@ -3,9 +3,12 @@ package v2
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -27,6 +30,62 @@ type ServiceFilter struct {
 
 // ServiceFilters maps a service namespace to (optional) ServiceFilter
 var ServiceFilters = map[string]ServiceFilter{
+	"AWS/ApiGateway": {
+		// ApiGateway ARNs use the Id (for v1 REST APIs) and ApiId (for v2 APIs) instead of
+		// the ApiName (display name). See https://docs.aws.amazon.com/apigateway/latest/developerguide/arn-format-reference.html
+		// However, in metrics, the ApiId dimension uses the ApiName as value.
+		//
+		// Here we use the ApiGateway API to map resource correctly. For backward compatibility,
+		// in v1 REST APIs we change the ARN to replace the ApiId with ApiName, while for v2 APIs
+		// we leave the ARN as-is.
+		FilterFunc: func(ctx context.Context, client client, inputResources []*model.TaggedResource) ([]*model.TaggedResource, error) {
+			var limit int32 = 500 // max number of results per page. default=25, max=500
+			const maxPages = 10
+			input := apigateway.GetRestApisInput{Limit: &limit}
+			output := apigateway.GetRestApisOutput{}
+			var pageNum int
+
+			paginator := apigateway.NewGetRestApisPaginator(client.apiGatewayAPI, &input, func(options *apigateway.GetRestApisPaginatorOptions) {
+				options.StopOnDuplicateToken = true
+			})
+			for paginator.HasMorePages() && pageNum <= maxPages {
+				page, err := paginator.NextPage(ctx)
+				promutil.APIGatewayAPICounter.Inc()
+				if err != nil {
+					return nil, fmt.Errorf("error calling apiGatewayAPI.GetRestApis, %w", err)
+				}
+				pageNum++
+				output.Items = append(output.Items, page.Items...)
+			}
+
+			outputV2, err := client.apiGatewayV2API.GetApis(ctx, &apigatewayv2.GetApisInput{})
+			if err != nil {
+				return nil, fmt.Errorf("error calling apigatewayv2.GetApis, %w", err)
+			}
+
+			var outputResources []*model.TaggedResource
+			for _, resource := range inputResources {
+				for i, gw := range output.Items {
+					if strings.HasSuffix(resource.ARN, "/restapis/"+*gw.Id) {
+						r := resource
+						r.ARN = strings.ReplaceAll(resource.ARN, *gw.Id, *gw.Name)
+						outputResources = append(outputResources, r)
+						output.Items = append(output.Items[:i], output.Items[i+1:]...)
+						break
+					}
+				}
+				for i, gw := range outputV2.Items {
+					if strings.HasSuffix(resource.ARN, "/apis/"+*gw.ApiId) {
+						outputResources = append(outputResources, resource)
+						outputV2.Items = append(outputV2.Items[:i], outputV2.Items[i+1:]...)
+						break
+					}
+				}
+			}
+
+			return outputResources, nil
+		},
+	},
 	"AWS/AutoScaling": {
 		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
 			pageNum := 0

--- a/pkg/clients/v1/factory.go
+++ b/pkg/clients/v1/factory.go
@@ -10,6 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/aws/aws-sdk-go/service/apigateway/apigatewayiface"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
@@ -228,6 +232,8 @@ func createTaggingClient(logger logging.Logger, session *session.Session, region
 		logger,
 		createTagSession(session, region, role, logger.IsDebugEnabled()),
 		createASGSession(session, region, role, logger.IsDebugEnabled()),
+		createAPIGatewaySession(session, region, role, fips, logger.IsDebugEnabled()),
+		createAPIGatewayV2Session(session, region, role, fips, logger.IsDebugEnabled()),
 		createEC2Session(session, region, role, fips, logger.IsDebugEnabled()),
 		createDMSSession(session, region, role, fips, logger.IsDebugEnabled()),
 		createPrometheusSession(session, region, role, logger.IsDebugEnabled()),
@@ -370,6 +376,34 @@ func createTagSession(sess *session.Session, region *string, role model.Role, is
 	}
 
 	return resourcegroupstaggingapi.New(sess, setSTSCreds(sess, config, role))
+}
+
+func createAPIGatewaySession(sess *session.Session, region *string, role model.Role, fips bool, isDebugEnabled bool) apigatewayiface.APIGatewayAPI {
+	maxAPIGatewayAPIRetries := 5
+	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
+	if fips {
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
+
+	if isDebugEnabled {
+		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
+	}
+
+	return apigateway.New(sess, setSTSCreds(sess, config, role))
+}
+
+func createAPIGatewayV2Session(sess *session.Session, region *string, role model.Role, fips bool, isDebugEnabled bool) apigatewayv2iface.ApiGatewayV2API {
+	maxAPIGatewayAPIRetries := 5
+	config := &aws.Config{Region: region, MaxRetries: &maxAPIGatewayAPIRetries}
+	if fips {
+		config.UseFIPSEndpoint = endpoints.FIPSEndpointStateEnabled
+	}
+
+	if isDebugEnabled {
+		config.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody)
+	}
+
+	return apigatewayv2.New(sess, setSTSCreds(sess, config, role))
 }
 
 func createASGSession(sess *session.Session, region *string, role model.Role, isDebugEnabled bool) autoscalingiface.AutoScalingAPI {

--- a/pkg/clients/v1/factory_test.go
+++ b/pkg/clients/v1/factory_test.go
@@ -998,6 +998,30 @@ func TestCreateTagSession(t *testing.T) {
 		})
 }
 
+func TestCreateAPIGatewaySession(t *testing.T) {
+	testAWSClient(
+		t,
+		"APIGateway",
+		func(t *testing.T, s *session.Session, region *string, role model.Role, fips bool) {
+			iface := createAPIGatewaySession(s, region, role, fips, false)
+			if iface == nil {
+				t.Fail()
+			}
+		})
+}
+
+func TestCreateAPIGatewayV2Session(t *testing.T) {
+	testAWSClient(
+		t,
+		"APIGatewayV2",
+		func(t *testing.T, s *session.Session, region *string, role model.Role, fips bool) {
+			iface := createAPIGatewayV2Session(s, region, role, fips, false)
+			if iface == nil {
+				t.Fail()
+			}
+		})
+}
+
 func TestCreateASGSession(t *testing.T) {
 	testAWSClient(
 		t,

--- a/pkg/clients/v2/factory.go
+++ b/pkg/clients/v2/factory.go
@@ -12,6 +12,8 @@ import (
 	aws_config "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
@@ -174,6 +176,8 @@ func (c *CachingFactory) GetTaggingClient(region string, role model.Role, concur
 		c.logger,
 		c.createTaggingClient(c.clients[role][region].awsConfig),
 		c.createAutoScalingClient(c.clients[role][region].awsConfig),
+		c.createAPIGatewayClient(c.clients[role][region].awsConfig),
+		c.createAPIGatewayV2Client(c.clients[role][region].awsConfig),
 		c.createEC2Client(c.clients[role][region].awsConfig),
 		c.createDMSClient(c.clients[role][region].awsConfig),
 		c.createPrometheusClient(c.clients[role][region].awsConfig),
@@ -218,6 +222,8 @@ func (c *CachingFactory) Refresh() {
 				c.logger,
 				c.createTaggingClient(cache.awsConfig),
 				c.createAutoScalingClient(cache.awsConfig),
+				c.createAPIGatewayClient(cache.awsConfig),
+				c.createAPIGatewayV2Client(cache.awsConfig),
 				c.createEC2Client(cache.awsConfig),
 				c.createDMSClient(cache.awsConfig),
 				c.createPrometheusClient(cache.awsConfig),
@@ -305,6 +311,34 @@ func (c *CachingFactory) createAutoScalingClient(assumedConfig *aws.Config) *aut
 		// AWS FIPS Reference: https://aws.amazon.com/compliance/fips/
 		// 	EC2 autoscaling has FIPS compliant URLs for govcloud, but they do not use any FIPS prefixing, and should work
 		//	with sdk v2s EndpointResolverV2
+	})
+}
+
+func (c *CachingFactory) createAPIGatewayClient(assumedConfig *aws.Config) *apigateway.Client {
+	return apigateway.NewFromConfig(*assumedConfig, func(options *apigateway.Options) {
+		if c.logger.IsDebugEnabled() {
+			options.ClientLogMode = aws.LogRequestWithBody | aws.LogResponseWithBody
+		}
+		if c.endpointURLOverride != "" {
+			options.BaseEndpoint = aws.String(c.endpointURLOverride)
+		}
+		if c.fipsEnabled {
+			options.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
+		}
+	})
+}
+
+func (c *CachingFactory) createAPIGatewayV2Client(assumedConfig *aws.Config) *apigatewayv2.Client {
+	return apigatewayv2.NewFromConfig(*assumedConfig, func(options *apigatewayv2.Options) {
+		if c.logger.IsDebugEnabled() {
+			options.ClientLogMode = aws.LogRequestWithBody | aws.LogResponseWithBody
+		}
+		if c.endpointURLOverride != "" {
+			options.BaseEndpoint = aws.String(c.endpointURLOverride)
+		}
+		if c.fipsEnabled {
+			options.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
+		}
 	})
 }
 

--- a/pkg/clients/v2/factory_test.go
+++ b/pkg/clients/v2/factory_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/amp"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -356,6 +358,32 @@ func TestCachingFactory_createTaggingClient_DoesNotEnableFIPS(t *testing.T) {
 	require.NotNil(t, options)
 
 	assert.Equal(t, options.EndpointOptions.UseFIPSEndpoint, aws.FIPSEndpointStateUnset)
+}
+
+func TestCachingFactory_createAPIGatewayClient_EnablesFIPS(t *testing.T) {
+	factory, err := NewFactory(logging.NewNopLogger(), jobsCfgWithDefaultRoleAndRegion1, true)
+	require.NoError(t, err)
+
+	client := factory.createAPIGatewayClient(factory.clients[defaultRole]["region1"].awsConfig)
+	require.NotNil(t, client)
+
+	options := getOptions[apigateway.Client, apigateway.Options](client)
+	require.NotNil(t, options)
+
+	assert.Equal(t, options.EndpointOptions.UseFIPSEndpoint, aws.FIPSEndpointStateEnabled)
+}
+
+func TestCachingFactory_createAPIGatewayV2Client_EnablesFIPS(t *testing.T) {
+	factory, err := NewFactory(logging.NewNopLogger(), jobsCfgWithDefaultRoleAndRegion1, true)
+	require.NoError(t, err)
+
+	client := factory.createAPIGatewayV2Client(factory.clients[defaultRole]["region1"].awsConfig)
+	require.NotNil(t, client)
+
+	options := getOptions[apigatewayv2.Client, apigatewayv2.Options](client)
+	require.NotNil(t, options)
+
+	assert.Equal(t, options.EndpointOptions.UseFIPSEndpoint, aws.FIPSEndpointStateEnabled)
 }
 
 func TestCachingFactory_createAutoScalingClient_DoesNotEnableFIPS(t *testing.T) {

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -25,6 +25,7 @@ var Metrics = []prometheus.Collector{
 	promutil.ResourceGroupTaggingAPICounter,
 	promutil.AutoScalingAPICounter,
 	promutil.TargetGroupsAPICounter,
+	promutil.APIGatewayAPICounter,
 	promutil.Ec2APICounter,
 	promutil.DmsAPICounter,
 	promutil.StoragegatewayAPICounter,

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -42,6 +42,12 @@ var (
 		Name: "yace_cloudwatch_targetgroupapi_requests_total",
 		Help: "Help is not implemented yet.",
 	})
+	APIGatewayAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_apigatewayapi_requests_total",
+	})
+	APIGatewayAPIV2Counter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_apigatewayapiv2_requests_total",
+	})
 	Ec2APICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_ec2api_requests_total",
 		Help: "Help is not implemented yet.",


### PR DESCRIPTION
…rces

Reverts almost entirely https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/1067

I wrongly deleted usage of the ApiGateway API, but the associator code can't work correctly unless resources are filtered by ApiId first.

Added a comment in filters code to explain why we need to keep this logic around.

Fixes https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1331