### PR TITLE
Simplify CloudWatch API call counters

### DIFF
--- a/pkg/clients/cloudwatch/v1/client.go
+++ b/pkg/clients/cloudwatch/v1/client.go
@@ -39,7 +39,6 @@ func (c client) ListMetrics(ctx context.Context, namespace string, metric *model
 	}
 
 	err := c.cloudwatchAPI.ListMetricsPagesWithContext(ctx, filter, func(page *cloudwatch.ListMetricsOutput, lastPage bool) bool {
-		promutil.CloudwatchListMetricsAPICounter.Inc()
 		promutil.CloudwatchAPICounter.WithLabelValues("ListMetrics").Inc()
 
 		metricsPage := toModelMetric(page)

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -43,7 +43,7 @@ func (c client) ListMetrics(ctx context.Context, namespace string, metric *model
 	})
 
 	for paginator.HasMorePages() {
-		promutil.CloudwatchListMetricsAPICounter.Inc()
+		promutil.CloudwatchAPICounter.WithLabelValues("ListMetrics").Inc()
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			promutil.CloudwatchAPIErrorCounter.WithLabelValues("ListMetrics").Inc()

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -17,8 +17,9 @@ import (
 
 // Metrics is a slice of prometheus metrics specific to the scraping process such API call counters
 var Metrics = []prometheus.Collector{
-	promutil.CloudwatchAPICounter,
 	promutil.CloudwatchAPIErrorCounter,
+	promutil.CloudwatchAPICounter,
+	promutil.CloudwatchListMetricsAPICounter,
 	promutil.CloudwatchGetMetricDataAPICounter,
 	promutil.CloudwatchGetMetricDataAPIMetricsCounter,
 	promutil.CloudwatchGetMetricStatisticsAPICounter,

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -19,7 +19,6 @@ import (
 var Metrics = []prometheus.Collector{
 	promutil.CloudwatchAPIErrorCounter,
 	promutil.CloudwatchAPICounter,
-	promutil.CloudwatchListMetricsAPICounter,
 	promutil.CloudwatchGetMetricDataAPICounter,
 	promutil.CloudwatchGetMetricDataAPIMetricsCounter,
 	promutil.CloudwatchGetMetricStatisticsAPICounter,

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -10,25 +10,29 @@ import (
 )
 
 var (
-	CloudwatchAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "yace_cloudwatch_requests_total",
-		Help: "Help is not implemented yet.",
-	})
-	CloudwatchAPIErrorCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	CloudwatchAPIErrorCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_request_errors",
 		Help: "Help is not implemented yet.",
+	}, []string{"api_name"})
+	CloudwatchAPICounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_requests_total",
+		Help: "Number of calls made to the CloudWatch APIs",
+	}, []string{"api_name"})
+	CloudwatchListMetricsAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "yace_cloudwatch_listmetrics_requests_total",
+		Help: "DEPRECATED: replaced by yace_cloudwatch_requests_total with api_name label",
 	})
 	CloudwatchGetMetricDataAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_getmetricdata_requests_total",
-		Help: "Help is not implemented yet.",
+		Help: "DEPRECATED: replaced by yace_cloudwatch_requests_total with api_name label",
 	})
 	CloudwatchGetMetricDataAPIMetricsCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "yace_cloudwatch_getmetricdata_metrics_total",
-		Help: "Help is not implemented yet.",
+		Name: "yace_cloudwatch_getmetricdata_metrics_requested_total",
+		Help: "Number of metrics requested from the CloudWatch GetMetricData API which is how AWS bills",
 	})
 	CloudwatchGetMetricStatisticsAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_getmetricstatistics_requests_total",
-		Help: "Help is not implemented yet.",
+		Help: "DEPRECATED: replaced by yace_cloudwatch_requests_total with api_name label",
 	})
 	ResourceGroupTaggingAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_resourcegrouptaggingapi_requests_total",

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -18,10 +18,6 @@ var (
 		Name: "yace_cloudwatch_requests_total",
 		Help: "Number of calls made to the CloudWatch APIs",
 	}, []string{"api_name"})
-	CloudwatchListMetricsAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "yace_cloudwatch_listmetrics_requests_total",
-		Help: "DEPRECATED: replaced by yace_cloudwatch_requests_total with api_name label",
-	})
 	CloudwatchGetMetricDataAPICounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "yace_cloudwatch_getmetricdata_requests_total",
 		Help: "DEPRECATED: replaced by yace_cloudwatch_requests_total with api_name label",


### PR DESCRIPTION
This PR adjusts the way call and error counting is done for the exported Cloudwatch API calls metrics,

1. `yace_cloudwatch_requests_total` and `yace_cloudwatch_request_errors` include a label `api_name`
2. All API specific metrics have help text marking them as deprecated in favor of the generic ones with the label
3. Adds request call increments to `ListMetrics`
4. `yace_cloudwatch_request_errors` is incremented for all CloudWatch APIs
5. `yace_cloudwatch_getmetricdata_metrics_requested_total` is now based on the number of request metrics vs the returned data to match AWS Docs on how calls are billed

Resolves: https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1233