### PR TITLE
getmetricdata refactor QueryID generation and result mapping

### DIFF
--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -2,8 +2,6 @@ package job
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"sync"
 
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
@@ -63,14 +61,12 @@ func getMetricDataForQueriesForCustomNamespace(
 					}
 
 					for _, stat := range metric.Statistics {
-						id := fmt.Sprintf("id_%d", rand.Int())
 						data = append(data, &model.CloudwatchData{
 							MetricName:   metric.Name,
 							ResourceName: customNamespaceJob.Name,
 							Namespace:    customNamespaceJob.Namespace,
 							Dimensions:   cwMetric.Dimensions,
 							GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-								QueryID:   id,
 								Period:    metric.Period,
 								Length:    metric.Length,
 								Delay:     metric.Delay,

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"strings"
 	"sync"
 
@@ -166,15 +165,12 @@ func getFilteredMetricDatas(
 
 		metricTags := resource.MetricTags(tagsOnMetrics)
 		for _, stat := range m.Statistics {
-			id := fmt.Sprintf("id_%d", rand.Int())
-
 			getMetricsData = append(getMetricsData, &model.CloudwatchData{
 				MetricName:   m.Name,
 				ResourceName: resource.ARN,
 				Namespace:    namespace,
 				Dimensions:   cwMetric.Dimensions,
 				GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-					QueryID:   id,
 					Period:    m.Period,
 					Length:    m.Length,
 					Delay:     m.Delay,

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -108,7 +108,6 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						},
 					},
 					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-						QueryID:   "asdf",
 						Period:    60,
 						Length:    600,
 						Delay:     120,
@@ -275,7 +274,6 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 						},
 					},
 					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-						QueryID:   "asdf",
 						Statistic: "Average",
 						Period:    60,
 						Length:    600,
@@ -426,7 +424,6 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				assert.ElementsMatch(t, want.Dimensions, got.Dimensions)
 				assert.ElementsMatch(t, want.Tags, got.Tags)
 				assert.Equal(t, want.MetricMigrationParams, got.MetricMigrationParams)
-				assert.NotEmpty(t, got.GetMetricDataProcessingParams.QueryID)
 				assert.Equal(t, want.GetMetricDataProcessingParams.Statistic, got.GetMetricDataProcessingParams.Statistic)
 				assert.Equal(t, want.GetMetricDataProcessingParams.Length, got.GetMetricDataProcessingParams.Length)
 				assert.Equal(t, want.GetMetricDataProcessingParams.Period, got.GetMetricDataProcessingParams.Period)

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -182,7 +182,7 @@ type GetMetricStatisticsResult struct {
 }
 
 type GetMetricDataProcessingParams struct {
-	// QueryID is the query ID for GetMetricData used in results mapping
+	// QueryID is a value internal to processing used for mapping results from GetMetricData their original request
 	QueryID string
 
 	// The statistic to be used to call GetMetricData


### PR DESCRIPTION
I noticed we could simplify the way we handle `QueryIDs` to keep it local to the `getmetricdata.Processor`. 

Before this PR QueryIDs were a random number created when the `model.CloudwatchData` entry is first created as a part of `ListMetrics`. Then the results of GetMetricData were mapped back to the `model.CloudwatchData` after all requests were completed by generating a lookup map by `QueryID`.

This PR moves QueryID generation to right before calling `GetMetricData` and gets the value based on the index in the batch being run. Then instead of needing to accumulate results and map them all back later the results are mapped back when the request is finished using the index of the batch. Benchmark compare results are below with before being take taken after the test refactor changeset https://github.com/nerdswords/yet-another-cloudwatch-exporter/commit/c71d9b86e52d132e71c6d997ad9a80beae4f00e7

```
❯ benchstat before.txt after.txt
goos: darwint before.txt after.txt
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/getmetricdata
                           │  before.txt   │              after.txt              │
                           │    sec/op     │    sec/op     vs base               │
ProcessorRun/small_case-8     2.790µ ± ∞ ¹   4.272µ ± ∞ ¹  +53.12% (p=0.008 n=5)
ProcessorRun/medium_case-8   100.83µ ± ∞ ¹   86.84µ ± ∞ ¹  -13.87% (p=0.008 n=5)
ProcessorRun/big_case-8       196.2µ ± ∞ ¹   183.9µ ± ∞ ¹   -6.31% (p=0.008 n=5)
geomean                       38.08µ         40.86µ         +7.31%

                           │   before.txt   │              after.txt               │
                           │      B/op      │     B/op       vs base               │
ProcessorRun/small_case-8     1.449Ki ± ∞ ¹   1.010Ki ± ∞ ¹  -30.32% (p=0.008 n=5)
ProcessorRun/medium_case-8   114.77Ki ± ∞ ¹   58.37Ki ± ∞ ¹  -49.14% (p=0.008 n=5)
ProcessorRun/big_case-8       233.6Ki ± ∞ ¹   122.8Ki ± ∞ ¹  -47.43% (p=0.008 n=5)
geomean                       33.87Ki         19.34Ki        -42.89%

                           │  before.txt  │              after.txt              │
                           │  allocs/op   │  allocs/op    vs base               │
ProcessorRun/small_case-8     24.00 ± ∞ ¹    30.00 ± ∞ ¹  +25.00% (p=0.008 n=5)
ProcessorRun/medium_case-8   1.292k ± ∞ ¹   2.454k ± ∞ ¹  +89.94% (p=0.008 n=5)
ProcessorRun/big_case-8      2.805k ± ∞ ¹   5.223k ± ∞ ¹  +86.20% (p=0.008 n=5)
geomean                       443.1          727.2        +64.12%
```

CPU is up for small use cases and total allocs are up likely due to the formatting being pulled in but total bytes allocated is down dramatically across all use cases 🥳.

<details>
<summary>Raw bench results</summary>

Before
```
goos: darwin
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/getmetricdata
BenchmarkProcessorRun/small_case-8                405494              2860 ns/op            1484 B/op         24 allocs/op
BenchmarkProcessorRun/small_case-8                421262              2811 ns/op            1484 B/op         24 allocs/op
BenchmarkProcessorRun/small_case-8                433365              2790 ns/op            1484 B/op         24 allocs/op
BenchmarkProcessorRun/small_case-8                437379              2784 ns/op            1484 B/op         24 allocs/op
BenchmarkProcessorRun/small_case-8                434563              2745 ns/op            1484 B/op         24 allocs/op
BenchmarkProcessorRun/medium_case-8                10000            100368 ns/op          117436 B/op       1294 allocs/op
BenchmarkProcessorRun/medium_case-8                10000            100825 ns/op          117525 B/op       1291 allocs/op
BenchmarkProcessorRun/medium_case-8                10000            100522 ns/op          117342 B/op       1291 allocs/op
BenchmarkProcessorRun/medium_case-8                10000            101038 ns/op          117544 B/op       1292 allocs/op
BenchmarkProcessorRun/medium_case-8                10000            101644 ns/op          117620 B/op       1294 allocs/op
BenchmarkProcessorRun/big_case-8                    6126            196510 ns/op          239134 B/op       2804 allocs/op
BenchmarkProcessorRun/big_case-8                    6144            195730 ns/op          240752 B/op       2771 allocs/op
BenchmarkProcessorRun/big_case-8                    5934            196006 ns/op          239871 B/op       2813 allocs/op
BenchmarkProcessorRun/big_case-8                    6139            196230 ns/op          239080 B/op       2805 allocs/op
BenchmarkProcessorRun/big_case-8                    6150            196712 ns/op          239251 B/op       2805 allocs/op
```

After
```
goos: darwin-bench=. ./pkg/job/getmetricdata -benchmem -count 5
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/job/getmetricdata
BenchmarkProcessorRun/small_case-8                274554              4243 ns/op            1034 B/op         30 allocs/op
BenchmarkProcessorRun/small_case-8                281883              4351 ns/op            1034 B/op         30 allocs/op
BenchmarkProcessorRun/small_case-8                282146              4272 ns/op            1034 B/op         30 allocs/op
BenchmarkProcessorRun/small_case-8                283269              4293 ns/op            1034 B/op         30 allocs/op
BenchmarkProcessorRun/small_case-8                264598              4226 ns/op            1034 B/op         30 allocs/op
BenchmarkProcessorRun/medium_case-8                14740             82373 ns/op           59577 B/op       2438 allocs/op
BenchmarkProcessorRun/medium_case-8                14216             86834 ns/op           59784 B/op       2455 allocs/op
BenchmarkProcessorRun/medium_case-8                13854             87629 ns/op           59912 B/op       2463 allocs/op
BenchmarkProcessorRun/medium_case-8                13839             87504 ns/op           59773 B/op       2454 allocs/op
BenchmarkProcessorRun/medium_case-8                13766             86839 ns/op           59723 B/op       2452 allocs/op
BenchmarkProcessorRun/big_case-8                    6440            182484 ns/op          126482 B/op       5249 allocs/op
BenchmarkProcessorRun/big_case-8                    6842            182450 ns/op          125545 B/op       5197 allocs/op
BenchmarkProcessorRun/big_case-8                    6426            183850 ns/op          125540 B/op       5211 allocs/op
BenchmarkProcessorRun/big_case-8                    6073            187266 ns/op          126771 B/op       5268 allocs/op
BenchmarkProcessorRun/big_case-8                    6496            184059 ns/op          125770 B/op       5223 allocs/op
```
</details>