### PR TITLE
Support partner events buses

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -914,8 +914,5 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("events"),
 		},
-		DimensionRegexps: []*regexp.Regexp{
-			regexp.MustCompile(":rule/(?P<EventBusName>[^/]+)/(?P<RuleName>[^/]+)$"),
-		},
 	},
 }


### PR DESCRIPTION
AWS/Events partner buses are currently not fetched by YACE, because their names contain / character.
This is written here on the EventBus Name property: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-eventbus.html
```
Name
The name of the new event bus.

Custom event bus names can't contain the / character, but you can use the / character in partner event bus names. In addition, for partner event buses, the name must exactly match the name of the partner event source that this event bus is matched to.
```

This PR is expected to make metrics for buses with names containing / character to also be captured by YACE 
