### PR TITLE
promutil: trim leading '_' for nonstandard namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Features:
 * ...
 
 Bugs:
-* ...
+* Fixed issue with generated Prometheus metric name when working with AWS namespaces which have
+a leading special character, like `/aws/sagemaker/TrainingJobs`
 
 Docs:
 * ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs:
 * ...
 
 Refactoring:
-* Refactored out the name-building part of `promutil.BuildNamespaceInfoMetrics()` into `promutil.BuildInfoMetricName()`.
+* Refactored out the name-building part of `promutil.BuildNamespaceInfoMetrics()` into `promutil.BuildInfoMetricName()` and `promutil.BuildMetricPrefix()`.
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs:
 * ...
 
 Refactoring:
-* ...
+* Refactored out the name-building part of `promutil.BuildNamespaceInfoMetrics()` into `promutil.BuildInfoMetricName()`.
 
 **Dependencies**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Docs:
 * ...
 
 Refactoring:
-* Refactored out the name-building part of `promutil.BuildNamespaceInfoMetrics()` into `promutil.BuildInfoMetricName()` and `promutil.BuildMetricPrefix()`.
+* Refactored out the name-building part of `promutil.BuildNamespaceInfoMetrics()` and `promutil.BuildMetrics()` into `promutil.BuildMetricName()`.
 
 **Dependencies**
 

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -17,7 +17,7 @@ import (
 
 var Percentile = regexp.MustCompile(`^p(\d{1,2}(\.\d{0,2})?|100)$`)
 
-func BuildInfoMetricName(namespace string) string {
+func buildMetricPrefix(namespace string) string {
 	sb := strings.Builder{}
 	promNs := PromString(strings.ToLower(namespace))
 	// Some namespaces have a leading forward slash like
@@ -28,6 +28,12 @@ func BuildInfoMetricName(namespace string) string {
 		sb.WriteString("aws_")
 	}
 	sb.WriteString(promNs)
+	return sb.String()
+}
+
+func BuildInfoMetricName(namespace string) string {
+	sb := strings.Builder{}
+	sb.WriteString(buildMetricPrefix(namespace))
 	sb.WriteString("_info")
 	return sb.String()
 }
@@ -99,11 +105,7 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 				}
 
 				sb := strings.Builder{}
-				promNs := PromString(strings.ToLower(metric.Namespace))
-				if !strings.HasPrefix(promNs, "aws") {
-					sb.WriteString("aws_")
-				}
-				sb.WriteString(promNs)
+				sb.WriteString(buildMetricPrefix(metric.Namespace))
 				sb.WriteString("_")
 				sb.WriteString(PromString(metric.MetricName))
 				sb.WriteString("_")

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -17,7 +17,7 @@ import (
 
 var Percentile = regexp.MustCompile(`^p(\d{1,2}(\.\d{0,2})?|100)$`)
 
-func buildMetricPrefix(namespace string) string {
+func BuildMetricPrefix(namespace string) string {
 	sb := strings.Builder{}
 	promNs := PromString(strings.ToLower(namespace))
 	// Some namespaces have a leading forward slash like
@@ -33,7 +33,7 @@ func buildMetricPrefix(namespace string) string {
 
 func BuildInfoMetricName(namespace string) string {
 	sb := strings.Builder{}
-	sb.WriteString(buildMetricPrefix(namespace))
+	sb.WriteString(BuildMetricPrefix(namespace))
 	sb.WriteString("_info")
 	return sb.String()
 }
@@ -105,7 +105,7 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 				}
 
 				sb := strings.Builder{}
-				sb.WriteString(buildMetricPrefix(metric.Namespace))
+				sb.WriteString(BuildMetricPrefix(metric.Namespace))
 				sb.WriteString("_")
 				sb.WriteString(PromString(metric.MetricName))
 				sb.WriteString("_")

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -23,6 +23,10 @@ func BuildNamespaceInfoMetrics(tagData []model.TaggedResourceResult, metrics []*
 		for _, d := range tagResult.Data {
 			sb := strings.Builder{}
 			promNs := PromString(strings.ToLower(d.Namespace))
+			// Some namespaces have a leading forward slash like
+			// /aws/sagemaker/TrainingJobs, which gets converted to
+			// a leading _ by PromString().
+			promNs = strings.TrimPrefix(promNs, "_")
 			if !strings.HasPrefix(promNs, "aws") {
 				sb.WriteString("aws_")
 			}

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -222,6 +222,46 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "metric with nonstandard namespace",
+			resources: []model.TaggedResourceResult{
+				{
+					Context: nil,
+					Data: []*model.TaggedResource{
+						{
+							ARN:       "arn:aws:sagemaker:us-east-1:123456789012:training-job/sagemaker-xgboost",
+							Namespace: "/aws/sagemaker/TrainingJobs",
+							Region:    "us-east-1",
+							Tags: []model.Tag{
+								{
+									Key:   "CustomTag",
+									Value: "tag_Value",
+								},
+							},
+						},
+					},
+				},
+			},
+			metrics:              []*PrometheusMetric{},
+			observedMetricLabels: map[string]model.LabelSet{},
+			labelsSnakeCase:      false,
+			expectedMetrics: []*PrometheusMetric{
+				{
+					Name: aws.String("aws_sagemaker_trainingjobs_info"),
+					Labels: map[string]string{
+						"name":          "arn:aws:sagemaker:us-east-1:123456789012:training-job/sagemaker-xgboost",
+						"tag_CustomTag": "tag_Value",
+					},
+					Value: 0,
+				},
+			},
+			expectedLabels: map[string]model.LabelSet{
+				"aws_sagemaker_trainingjobs_info": map[string]struct{}{
+					"name":          {},
+					"tag_CustomTag": {},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Some namespaces like `/aws/sagemaker/TrainingJobs` are converted to `_aws_sagemaker_trainingjobs` by `PromString()`. Trim the leading '_' if it exists so that the namespace format continues to be built correctly.