### PR TITLE
getmetricdata: introduce an iterator

### DIFF
--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -22,7 +22,7 @@ type Client interface {
 
 	// GetMetricData returns the output of the GetMetricData CloudWatch API.
 	// Results pagination is handled automatically.
-	GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []MetricDataResult
+	GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []MetricDataResult
 
 	// GetMetricStatistics returns the output of the GetMetricStatistics CloudWatch API.
 	GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint
@@ -68,9 +68,9 @@ func (c limitedConcurrencyClient) GetMetricStatistics(ctx context.Context, logge
 	return res
 }
 
-func (c limitedConcurrencyClient) GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []MetricDataResult {
+func (c limitedConcurrencyClient) GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []MetricDataResult {
 	c.limiter.Acquire(getMetricDataCall)
-	res := c.client.GetMetricData(ctx, logger, getMetricData, namespace, length, delay, configuredRoundingPeriod)
+	res := c.client.GetMetricData(ctx, getMetricData, namespace, startTime, endTime)
 	c.limiter.Release(getMetricDataCall)
 	return res
 }

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -101,9 +101,6 @@ func (c client) GetMetricData(ctx context.Context, getMetricData []*model.Cloudw
 			Stat:   &data.GetMetricDataProcessingParams.Statistic,
 		}
 		metricDataQueries = append(metricDataQueries, types.MetricDataQuery{
-			// TODO consider switching this to be id_<i> and mapping the data directly to getMetricData after the API
-			//  call saving the need to allocate all the response array, and all the other work done else where
-			//  to map the results
 			Id:         &data.GetMetricDataProcessingParams.QueryID,
 			MetricStat: metricStat,
 			ReturnData: aws.Bool(true),

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -9,56 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
-	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
-
-func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.CloudwatchData, namespace *string, length int64, delay int64, configuredRoundingPeriod *int64) *cloudwatch.GetMetricDataInput {
-	metricsDataQuery := make([]types.MetricDataQuery, 0, len(getMetricData))
-	roundingPeriod := model.DefaultPeriodSeconds
-	for _, data := range getMetricData {
-		if data.GetMetricDataProcessingParams.Period < roundingPeriod {
-			roundingPeriod = data.GetMetricDataProcessingParams.Period
-		}
-		metricStat := &types.MetricStat{
-			Metric: &types.Metric{
-				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: &data.MetricName,
-				Namespace:  namespace,
-			},
-			Period: aws.Int32(int32(data.GetMetricDataProcessingParams.Period)),
-			Stat:   &data.GetMetricDataProcessingParams.Statistic,
-		}
-		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
-			Id:         &data.GetMetricDataProcessingParams.QueryID,
-			MetricStat: metricStat,
-			ReturnData: aws.Bool(true),
-		})
-	}
-
-	if configuredRoundingPeriod != nil {
-		roundingPeriod = *configuredRoundingPeriod
-	}
-
-	startTime, endTime := cloudwatch_client.DetermineGetMetricDataWindow(
-		cloudwatch_client.TimeClock{},
-		time.Duration(roundingPeriod)*time.Second,
-		time.Duration(length)*time.Second,
-		time.Duration(delay)*time.Second)
-
-	if logger.IsDebugEnabled() {
-		logger.Debug("GetMetricData Window", "start_time", startTime.Format(cloudwatch_client.TimeFormat), "end_time", endTime.Format(cloudwatch_client.TimeFormat))
-	}
-
-	return &cloudwatch.GetMetricDataInput{
-		EndTime:           &endTime,
-		StartTime:         &startTime,
-		MetricDataQueries: metricsDataQuery,
-		ScanBy:            "TimestampDescending",
-	}
-}
 
 func toCloudWatchDimensions(dimensions []model.Dimension) []types.Dimension {
 	cwDim := make([]types.Dimension, 0, len(dimensions))

--- a/pkg/clients/v2/factory_test.go
+++ b/pkg/clients/v2/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -474,7 +475,7 @@ func (t testClient) ListMetrics(_ context.Context, _ string, _ *model.MetricConf
 	return nil
 }
 
-func (t testClient) GetMetricData(_ context.Context, _ logging.Logger, _ []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch_client.MetricDataResult {
+func (t testClient) GetMetricData(_ context.Context, _ []*model.CloudwatchData, _ string, _ time.Time, _ time.Time) []cloudwatch_client.MetricDataResult {
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,17 +137,17 @@ func (c *ScrapeConf) Load(file string, logger logging.Logger) (model.JobsConfig,
 		}
 	}
 
-	return c.Validate()
+	return c.Validate(logger)
 }
 
-func (c *ScrapeConf) Validate() (model.JobsConfig, error) {
+func (c *ScrapeConf) Validate(logger logging.Logger) (model.JobsConfig, error) {
 	if c.Discovery.Jobs == nil && c.Static == nil && c.CustomNamespace == nil {
 		return model.JobsConfig{}, fmt.Errorf("At least 1 Discovery job, 1 Static or one CustomNamespace must be defined")
 	}
 
 	if c.Discovery.Jobs != nil {
 		for idx, job := range c.Discovery.Jobs {
-			err := job.validateDiscoveryJob(idx)
+			err := job.validateDiscoveryJob(logger, idx)
 			if err != nil {
 				return model.JobsConfig{}, err
 			}
@@ -156,7 +156,7 @@ func (c *ScrapeConf) Validate() (model.JobsConfig, error) {
 
 	if c.CustomNamespace != nil {
 		for idx, job := range c.CustomNamespace {
-			err := job.validateCustomNamespaceJob(idx)
+			err := job.validateCustomNamespaceJob(logger, idx)
 			if err != nil {
 				return model.JobsConfig{}, err
 			}
@@ -165,7 +165,7 @@ func (c *ScrapeConf) Validate() (model.JobsConfig, error) {
 
 	if c.Static != nil {
 		for idx, job := range c.Static {
-			err := job.validateStaticJob(idx)
+			err := job.validateStaticJob(logger, idx)
 			if err != nil {
 				return model.JobsConfig{}, err
 			}
@@ -178,7 +178,7 @@ func (c *ScrapeConf) Validate() (model.JobsConfig, error) {
 	return c.toModelConfig(), nil
 }
 
-func (j *Job) validateDiscoveryJob(jobIdx int) error {
+func (j *Job) validateDiscoveryJob(logger logging.Logger, jobIdx int) error {
 	if j.Type != "" {
 		if SupportedServices.GetService(j.Type) == nil {
 			return fmt.Errorf("Discovery job [%d]: Service is not in known list!: %s", jobIdx, j.Type)
@@ -203,7 +203,7 @@ func (j *Job) validateDiscoveryJob(jobIdx int) error {
 		return fmt.Errorf("Discovery job [%s/%d]: Metrics should not be empty", j.Type, jobIdx)
 	}
 	for metricIdx, metric := range j.Metrics {
-		err := metric.validateMetric(metricIdx, parent, &j.JobLevelMetricFields)
+		err := metric.validateMetric(logger, metricIdx, parent, &j.JobLevelMetricFields)
 		if err != nil {
 			return err
 		}
@@ -215,10 +215,14 @@ func (j *Job) validateDiscoveryJob(jobIdx int) error {
 		}
 	}
 
+	if j.RoundingPeriod != nil {
+		logger.Warn("Discovery job [%s/%d]: Setting rounding period is deprecated. It is always enabled and set to the value of the metric Period.", j.Type, jobIdx)
+	}
+
 	return nil
 }
 
-func (j *CustomNamespace) validateCustomNamespaceJob(jobIdx int) error {
+func (j *CustomNamespace) validateCustomNamespaceJob(logger logging.Logger, jobIdx int) error {
 	if j.Name == "" {
 		return fmt.Errorf("CustomNamespace job [%v]: Name should not be empty", jobIdx)
 	}
@@ -242,16 +246,17 @@ func (j *CustomNamespace) validateCustomNamespaceJob(jobIdx int) error {
 		return fmt.Errorf("CustomNamespace job [%s/%d]: Metrics should not be empty", j.Name, jobIdx)
 	}
 	for metricIdx, metric := range j.Metrics {
-		err := metric.validateMetric(metricIdx, parent, &j.JobLevelMetricFields)
+		err := metric.validateMetric(logger, metricIdx, parent, &j.JobLevelMetricFields)
 		if err != nil {
 			return err
 		}
 	}
 
+	logger.Warn("CustomNamespace job [%s/%d]: Setting rounding period is deprecated. It is always enabled and set to the value of the metric Period.", j.Name, jobIdx)
 	return nil
 }
 
-func (j *Static) validateStaticJob(jobIdx int) error {
+func (j *Static) validateStaticJob(logger logging.Logger, jobIdx int) error {
 	if j.Name == "" {
 		return fmt.Errorf("Static job [%v]: Name should not be empty", jobIdx)
 	}
@@ -272,7 +277,7 @@ func (j *Static) validateStaticJob(jobIdx int) error {
 		return fmt.Errorf("Static job [%s/%d]: Regions should not be empty", j.Name, jobIdx)
 	}
 	for metricIdx, metric := range j.Metrics {
-		err := metric.validateMetric(metricIdx, parent, nil)
+		err := metric.validateMetric(logger, metricIdx, parent, nil)
 		if err != nil {
 			return err
 		}
@@ -281,7 +286,7 @@ func (j *Static) validateStaticJob(jobIdx int) error {
 	return nil
 }
 
-func (m *Metric) validateMetric(metricIdx int, parent string, discovery *JobLevelMetricFields) error {
+func (m *Metric) validateMetric(logger logging.Logger, metricIdx int, parent string, discovery *JobLevelMetricFields) error {
 	if m.Name == "" {
 		return fmt.Errorf("Metric [%s/%d] in %v: Name should not be empty", m.Name, metricIdx, parent)
 	}
@@ -315,13 +320,14 @@ func (m *Metric) validateMetric(metricIdx int, parent string, discovery *JobLeve
 		}
 	}
 
-	mDelay := m.Delay
-	if mDelay == 0 {
-		if discovery != nil && discovery.Delay != 0 {
-			mDelay = discovery.Delay
-		} else {
-			mDelay = model.DefaultDelaySeconds
-		}
+	// Delay at the metric level has been ignored for an incredibly long time. If we started respecting metric delay
+	// now a lot of configurations would break on release. This logs a warning for now
+	if m.Delay != 0 {
+		logger.Warn(fmt.Sprintf("Metric [%s/%d] in %v: Metric is configured with delay that has been being ignored. This behavior will change in the future, if your config works now remove this delay to prevent a future issue.", m.Name, metricIdx, parent))
+	}
+	var mDelay int64
+	if discovery != nil && discovery.Delay != 0 {
+		mDelay = discovery.Delay
 	}
 
 	mNilToZero := m.NilToZero
@@ -369,7 +375,6 @@ func (c *ScrapeConf) toModelConfig() model.JobsConfig {
 		job.Regions = discoveryJob.Regions
 		job.Type = discoveryJob.Type
 		job.DimensionNameRequirements = discoveryJob.DimensionNameRequirements
-		job.RoundingPeriod = discoveryJob.RoundingPeriod
 		job.RecentlyActiveOnly = discoveryJob.RecentlyActiveOnly
 		job.Statistics = discoveryJob.Statistics
 		job.Period = discoveryJob.Period
@@ -414,7 +419,6 @@ func (c *ScrapeConf) toModelConfig() model.JobsConfig {
 		job.Name = customNamespaceJob.Name
 		job.Namespace = customNamespaceJob.Namespace
 		job.DimensionNameRequirements = customNamespaceJob.DimensionNameRequirements
-		job.RoundingPeriod = customNamespaceJob.RoundingPeriod
 		job.RecentlyActiveOnly = customNamespaceJob.RecentlyActiveOnly
 		job.Statistics = customNamespaceJob.Statistics
 		job.Period = customNamespaceJob.Period

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -103,7 +103,7 @@ func TestValidateConfigFailuresWhenUsingAsLibrary(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := tc.config.Validate()
+			_, err := tc.config.Validate(logging.NewNopLogger())
 			require.Error(t, err, "Expected config validation to fail")
 			require.Equal(t, tc.errorMsg, err.Error())
 		})

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -24,7 +24,7 @@ func runCustomNamespaceJob(
 
 	jobLength := getLargestLengthForMetrics(job.Metrics)
 	var err error
-	cloudwatchDatas, err = gmdProcessor.Run(ctx, logger, job.Namespace, jobLength, job.Delay, job.RoundingPeriod, cloudwatchDatas)
+	cloudwatchDatas, err = gmdProcessor.Run(ctx, job.Namespace, jobLength, job.Delay, cloudwatchDatas)
 	if err != nil {
 		logger.Error(err, "Failed to get metric data")
 		return nil

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -20,7 +20,7 @@ type resourceAssociator interface {
 }
 
 type getMetricDataProcessor interface {
-	Run(ctx context.Context, logger logging.Logger, namespace string, jobMetricLength int64, jobMetricDelay int64, jobRoundingPeriod *int64, requests []*model.CloudwatchData) ([]*model.CloudwatchData, error)
+	Run(ctx context.Context, namespace string, jobMetricLength, jobMetricDelay int64, requests []*model.CloudwatchData) ([]*model.CloudwatchData, error)
 }
 
 func runDiscoveryJob(
@@ -56,7 +56,7 @@ func runDiscoveryJob(
 	}
 
 	jobLength := getLargestLengthForMetrics(job.Metrics)
-	getMetricDatas, err = gmdProcessor.Run(ctx, logger, svc.Namespace, jobLength, job.Delay, job.RoundingPeriod, getMetricDatas)
+	getMetricDatas, err = gmdProcessor.Run(ctx, svc.Namespace, jobLength, job.Delay, getMetricDatas)
 	if err != nil {
 		logger.Error(err, "Failed to get metric data")
 		return nil, nil

--- a/pkg/job/getmetricdata/batching.go
+++ b/pkg/job/getmetricdata/batching.go
@@ -1,0 +1,97 @@
+package getmetricdata
+
+import (
+	"math"
+	"time"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+type WindowCalculator interface {
+	Calculate(period time.Duration, length time.Duration, delay time.Duration) (time.Time, time.Time)
+}
+
+type iteratorFactory struct {
+	metricsPerQuery  int
+	windowCalculator WindowCalculator
+}
+
+func (b iteratorFactory) Build(data []*model.CloudwatchData, jobMetricLength, jobMetricDelay int64) BatchIterator {
+	if len(data) == 0 {
+		return nothingToIterate{}
+	}
+
+	params := data[0].GetMetricDataProcessingParams
+	params.Length = jobMetricLength
+	params.Delay = jobMetricDelay
+
+	return NewSimpleBatchIterator(b.windowCalculator, b.metricsPerQuery, data, params)
+}
+
+type nothingToIterate struct{}
+
+func (n nothingToIterate) Size() int {
+	return 0
+}
+
+func (n nothingToIterate) Next() ([]*model.CloudwatchData, time.Time, time.Time) {
+	return nil, time.Time{}, time.Time{}
+}
+
+func (n nothingToIterate) HasMore() bool {
+	return false
+}
+
+type simpleBatchingIterator struct {
+	size            int
+	currentBatch    int
+	startTime       time.Time
+	endTime         time.Time
+	data            []*model.CloudwatchData
+	entriesPerBatch int
+}
+
+func (s *simpleBatchingIterator) Size() int {
+	return s.size
+}
+
+func (s *simpleBatchingIterator) Next() ([]*model.CloudwatchData, time.Time, time.Time) {
+	// We are out of data return defaults
+	if s.currentBatch >= s.size {
+		return nil, time.Time{}, time.Time{}
+	}
+
+	startingIndex := s.currentBatch * s.entriesPerBatch
+	endingIndex := startingIndex + s.entriesPerBatch
+	if endingIndex > len(s.data) {
+		endingIndex = len(s.data)
+	}
+
+	// TODO are we technically doing this https://go.dev/wiki/SliceTricks#batching-with-minimal-allocation and if not
+	// would it change allocations to do this ahead of time?
+	result := s.data[startingIndex:endingIndex]
+	s.currentBatch++
+	return result, s.startTime, s.endTime
+}
+
+func (s *simpleBatchingIterator) HasMore() bool {
+	return s.currentBatch < s.size
+}
+
+// NewSimpleBatchIterator returns an iterator which slices the data in place based on the metricsPerQuery.
+func NewSimpleBatchIterator(windowCalculator WindowCalculator, metricsPerQuery int, data []*model.CloudwatchData, params *model.GetMetricDataProcessingParams) BatchIterator {
+	startTime, endTime := windowCalculator.Calculate(
+		time.Duration(params.Period)*time.Second,
+		time.Duration(params.Length)*time.Second,
+		time.Duration(params.Delay)*time.Second)
+
+	size := int(math.Ceil(float64(len(data)) / float64(metricsPerQuery)))
+
+	return &simpleBatchingIterator{
+		size:            size,
+		startTime:       startTime,
+		endTime:         endTime,
+		data:            data,
+		entriesPerBatch: metricsPerQuery,
+	}
+}

--- a/pkg/job/getmetricdata/batching_test.go
+++ b/pkg/job/getmetricdata/batching_test.go
@@ -1,0 +1,119 @@
+package getmetricdata
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+func TestIteratorFactory_Build(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            []*model.CloudwatchData
+		expectedIterator BatchIterator
+	}{
+		{
+			name:             "empty returns nothing to iterator",
+			input:            []*model.CloudwatchData{},
+			expectedIterator: nothingToIterate{},
+		},
+		{
+			name: "input with data returns simple batching",
+			input: []*model.CloudwatchData{
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+			},
+			expectedIterator: &simpleBatchingIterator{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := iteratorFactory{100, MetricWindowCalculator{clock: TimeClock{}}}
+			iterator := factory.Build(tc.input, 10, 100)
+			assert.IsType(t, tc.expectedIterator, iterator)
+		})
+	}
+}
+
+type testWindowCalculator struct {
+	startTime time.Time
+	endTime   time.Time
+}
+
+func (t testWindowCalculator) Calculate(time.Duration, time.Duration, time.Duration) (time.Time, time.Time) {
+	return t.startTime, t.endTime
+}
+
+func TestSimpleBatchingIterator_SetsStartAndEndTime(t *testing.T) {
+	calc := testWindowCalculator{
+		startTime: time.Now().Truncate(time.Second).Add(-time.Second * 5),
+		endTime:   time.Now().Truncate(time.Second),
+	}
+	data := []*model.CloudwatchData{
+		{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 101, Delay: 100}},
+	}
+	iterator := NewSimpleBatchIterator(calc, 1, data, data[0].GetMetricDataProcessingParams)
+	_, startTime, endTime := iterator.Next()
+	assert.Equal(t, calc.startTime, startTime)
+	assert.Equal(t, calc.endTime, endTime)
+}
+
+func TestSimpleBatchingIterator_IterateFlow(t *testing.T) {
+	tests := []struct {
+		name                               string
+		metricsPerQuery                    int
+		lengthOfCloudwatchData             int
+		expectedSizeAndNumberOfCallsToNext int
+	}{
+		{
+			name:                               "1 per batch",
+			metricsPerQuery:                    1,
+			lengthOfCloudwatchData:             10,
+			expectedSizeAndNumberOfCallsToNext: 10,
+		},
+		{
+			name:                               "divisible batches and requests",
+			metricsPerQuery:                    5,
+			lengthOfCloudwatchData:             100,
+			expectedSizeAndNumberOfCallsToNext: 20,
+		},
+		{
+			name:                               "indivisible batches and requests",
+			metricsPerQuery:                    5,
+			lengthOfCloudwatchData:             94,
+			expectedSizeAndNumberOfCallsToNext: 19,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]*model.CloudwatchData, 0, tc.lengthOfCloudwatchData)
+			for i := 0; i < tc.lengthOfCloudwatchData; i++ {
+				data = append(data, getSampleMetricDatas(strconv.Itoa(i)))
+			}
+			iterator := NewSimpleBatchIterator(testWindowCalculator{}, tc.metricsPerQuery, data, data[0].GetMetricDataProcessingParams)
+			assert.Equal(t, tc.expectedSizeAndNumberOfCallsToNext, iterator.Size())
+
+			numberOfCallsToNext := 0
+			for iterator.HasMore() {
+				numberOfCallsToNext++
+				iterator.Next()
+			}
+
+			assert.Equal(t, tc.expectedSizeAndNumberOfCallsToNext, numberOfCallsToNext)
+		})
+	}
+}

--- a/pkg/job/getmetricdata/processor_test.go
+++ b/pkg/job/getmetricdata/processor_test.go
@@ -3,8 +3,6 @@ package getmetricdata
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,14 +31,14 @@ type metricDataResultForMetric struct {
 }
 
 type testClient struct {
-	GetMetricDataFunc             func(ctx context.Context, logger logging.Logger, data []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []cloudwatch.MetricDataResult
+	GetMetricDataFunc             func(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch.MetricDataResult
 	GetMetricDataResultForMetrics []metricDataResultForMetric
 }
 
-func (t testClient) GetMetricData(ctx context.Context, logger logging.Logger, data []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []cloudwatch.MetricDataResult {
+func (t testClient) GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch.MetricDataResult {
 	if t.GetMetricDataResultForMetrics != nil {
 		var result []cloudwatch.MetricDataResult
-		for _, datum := range data {
+		for _, datum := range getMetricData {
 			for _, response := range t.GetMetricDataResultForMetrics {
 				if datum.MetricName == response.MetricName {
 					response.result.ID = datum.GetMetricDataProcessingParams.QueryID
@@ -50,7 +48,7 @@ func (t testClient) GetMetricData(ctx context.Context, logger logging.Logger, da
 		}
 		return result
 	}
-	return t.GetMetricDataFunc(ctx, logger, data, namespace, length, delay, configuredRoundingPeriod)
+	return t.GetMetricDataFunc(ctx, getMetricData, namespace, startTime, endTime)
 }
 
 func TestProcessor_Run(t *testing.T) {
@@ -190,8 +188,8 @@ func TestProcessor_Run(t *testing.T) {
 			if tt.metricsPerBatch != 0 {
 				metricsPerQuery = tt.metricsPerBatch
 			}
-			r := NewProcessor(testClient{GetMetricDataResultForMetrics: tt.metricDataResultForMetrics}, metricsPerQuery, 1)
-			cloudwatchData, err := r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 100, 100, aws.Int64(100), ToCloudwatchData(tt.requests))
+			r := NewDefaultProcessor(logging.NewNopLogger(), testClient{GetMetricDataResultForMetrics: tt.metricDataResultForMetrics}, metricsPerQuery, 1)
+			cloudwatchData, err := r.Run(context.Background(), "anything_is_fine", 100, 100, ToCloudwatchData(tt.requests))
 			require.NoError(t, err)
 			require.Len(t, cloudwatchData, len(tt.want))
 			got := make([]cloudwatchDataOutput, 0, len(cloudwatchData))
@@ -206,51 +204,6 @@ func TestProcessor_Run(t *testing.T) {
 			}
 
 			assert.ElementsMatch(t, tt.want, got)
-		})
-	}
-}
-
-func TestProcessor_Run_BatchesByMetricsPerQuery(t *testing.T) {
-	now := time.Now()
-	tests := []struct {
-		name                                 string
-		metricsPerQuery                      int
-		numberOfRequests                     int
-		expectedNumberOfCallsToGetMetricData int32
-	}{
-		{name: "1 per batch", metricsPerQuery: 1, numberOfRequests: 10, expectedNumberOfCallsToGetMetricData: 10},
-		{name: "divisible batches and requests", metricsPerQuery: 5, numberOfRequests: 100, expectedNumberOfCallsToGetMetricData: 20},
-		{name: "indivisible batches and requests", metricsPerQuery: 5, numberOfRequests: 94, expectedNumberOfCallsToGetMetricData: 19},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var callCounter atomic.Int32
-			getMetricDataFunc := func(_ context.Context, _ logging.Logger, data []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch.MetricDataResult {
-				callCounter.Add(1)
-				response := make([]cloudwatch.MetricDataResult, 0, len(data))
-				for _, gmd := range data {
-					response = append(response, cloudwatch.MetricDataResult{
-						ID:        gmd.GetMetricDataProcessingParams.QueryID,
-						Datapoint: aws.Float64(1000),
-						Timestamp: now,
-					})
-				}
-				return response
-			}
-
-			requests := make([]*model.CloudwatchData, 0, tt.numberOfRequests)
-			for i := 0; i < tt.numberOfRequests; i++ {
-				requests = append(requests, getSampleMetricDatas(strconv.Itoa(i)))
-			}
-			r := Processor{
-				metricsPerQuery: tt.metricsPerQuery,
-				client:          testClient{GetMetricDataFunc: getMetricDataFunc},
-				concurrency:     1,
-			}
-			cloudwatchData, err := r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 1, 1, aws.Int64(1), requests)
-			require.NoError(t, err)
-			assert.Len(t, cloudwatchData, tt.numberOfRequests)
-			assert.Equal(t, tt.expectedNumberOfCallsToGetMetricData, callCounter.Load())
 		})
 	}
 }
@@ -347,7 +300,7 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount int, concurrency 
 		testResourceIDs[i] = fmt.Sprintf("test-resource-%d", i)
 	}
 
-	client := testClient{GetMetricDataFunc: func(_ context.Context, _ logging.Logger, getMetricData []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch.MetricDataResult {
+	client := testClient{GetMetricDataFunc: func(_ context.Context, getMetricData []*model.CloudwatchData, _ string, _ time.Time, _ time.Time) []cloudwatch.MetricDataResult {
 		b.StopTimer()
 		results := make([]cloudwatch.MetricDataResult, 0, len(getMetricData))
 		for _, entry := range getMetricData {
@@ -369,12 +322,12 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount int, concurrency 
 		for i := 0; i < testResourcesCount; i++ {
 			datas = append(datas, getSampleMetricDatas(testResourceIDs[i]))
 		}
-		r := NewProcessor(client, metricsPerQuery, concurrency)
+		r := NewDefaultProcessor(logging.NewNopLogger(), client, metricsPerQuery, concurrency)
 		// re-start timer
 		b.ReportAllocs()
 		b.StartTimer()
 
 		//nolint:errcheck
-		r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 100, 100, aws.Int64(100), datas)
+		r.Run(context.Background(), "anything_is_fine", 100, 100, datas)
 	}
 }

--- a/pkg/job/getmetricdata/windowcalculator_test.go
+++ b/pkg/job/getmetricdata/windowcalculator_test.go
@@ -1,4 +1,4 @@
-package cloudwatch
+package getmetricdata
 
 import (
 	"testing"
@@ -85,7 +85,7 @@ func Test_MetricWindow(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			startTime, endTime := DetermineGetMetricDataWindow(tc.data.clock, tc.data.roundingPeriod, tc.data.length, tc.data.delay)
+			startTime, endTime := MetricWindowCalculator{tc.data.clock}.Calculate(tc.data.roundingPeriod, tc.data.length, tc.data.delay)
 			if !startTime.Equal(tc.data.expectedStartTime) {
 				t.Errorf("start time incorrect. Expected: %s, Actual: %s", tc.data.expectedStartTime.Format(TimeFormat), startTime.Format(TimeFormat))
 				t.Errorf("end time incorrect. Expected: %s, Actual: %s", tc.data.expectedEndTime.Format(TimeFormat), endTime.Format(TimeFormat))

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -41,7 +41,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", accountID)
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)
-					gmdProcessor := getmetricdata.NewProcessor(cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
+					gmdProcessor := getmetricdata.NewDefaultProcessor(logger, cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
 					resources, metrics := runDiscoveryJob(ctx, jobLogger, discoveryJob, region, factory.GetTaggingClient(region, role, taggingAPIConcurrency), cloudwatchClient, gmdProcessor)
 					addDataToOutput := len(metrics) != 0
 					if config.FlagsFromCtx(ctx).IsFeatureEnabled(config.AlwaysReturnInfoMetrics) {
@@ -120,7 +120,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", accountID)
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)
-					gmdProcessor := getmetricdata.NewProcessor(cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
+					gmdProcessor := getmetricdata.NewDefaultProcessor(logger, cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
 					metrics := runCustomNamespaceJob(ctx, jobLogger, customNamespaceJob, cloudwatchClient, gmdProcessor)
 					metricResult := model.CloudwatchMetricResult{
 						Context: &model.ScrapeContext{

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -9,7 +9,6 @@ import (
 const (
 	DefaultPeriodSeconds = int64(300)
 	DefaultLengthSeconds = int64(300)
-	DefaultDelaySeconds  = int64(300)
 )
 
 type JobsConfig struct {
@@ -27,7 +26,6 @@ type DiscoveryJob struct {
 	CustomTags                  []Tag
 	DimensionNameRequirements   []string
 	Metrics                     []*MetricConfig
-	RoundingPeriod              *int64
 	RecentlyActiveOnly          bool
 	ExportedTagsOnMetrics       []string
 	IncludeContextOnInfoMetrics bool
@@ -54,7 +52,6 @@ type CustomNamespaceJob struct {
 	Metrics                   []*MetricConfig
 	CustomTags                []Tag
 	DimensionNameRequirements []string
-	RoundingPeriod            *int64
 	JobLevelMetricFields
 }
 


### PR DESCRIPTION
This PR introduces an iterator to the `getmetricsdata.Processor` allowing further abstraction to how metrics batches are created. This iterator has the responsibility of creating usable batches for calling GetMetricData ensuring the `Start` and `EndTime` values are consistent for the batch. 

This abstraction helps to move towards fixing the 3 issues laid out in https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1290,
1.  Eliminating the ability to set rounding period manually and always uses the metric period
    * The current logic for rounding period can result in inconsistent `Start` and `EndTime` between batches
    * This negates its intent to ensure `Start` and `EndTime` align with the metric period for [CloudWatch best practices]
    (https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html)
<img width="648" alt="image" src="https://github.com/nerdswords/yet-another-cloudwatch-exporter/assets/4571540/d6a2c846-e575-423f-81e8-899b3c0bf866">

2. This abstraction can be used to inject a batching implementation which batches by `length` + `period` combinations (have this done in a follow up) 
3. Removes the logic to add a delay at the metric level and instead logging a warning. We can choose to eliminate the field all together from the config or add support for metric delay later.

This also sets up an abstraction to build upon to accomplish https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1094 without goroutines. This will be expanded upon further in a comment in that issue.