### PR TITLE
promutil: rewrite sanitisation funcs for memory optimisation

### DIFF
--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -255,7 +255,7 @@ func contextToLabels(context *model.ScrapeContext, labelsSnakeCase bool, logger 
 // the updated observedMetricLabels
 func recordLabelsForMetric(metricName string, promLabels map[string]string, observedMetricLabels map[string]model.LabelSet) map[string]model.LabelSet {
 	if _, ok := observedMetricLabels[metricName]; !ok {
-		observedMetricLabels[metricName] = make(model.LabelSet)
+		observedMetricLabels[metricName] = make(model.LabelSet, len(promLabels))
 	}
 	for label := range promLabels {
 		if _, ok := observedMetricLabels[metricName][label]; !ok {

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -792,6 +792,159 @@ func TestBuildMetrics(t *testing.T) {
 	}
 }
 
+func Benchmark_BuildMetrics(b *testing.B) {
+	ts := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	data := []model.CloudwatchMetricResult{{
+		Context: &model.ScrapeContext{
+			Region:     "us-east-1",
+			AccountID:  "123456789012",
+			CustomTags: nil,
+		},
+		Data: []*model.CloudwatchData{
+			{
+				MetricName: "CPUUtilization",
+				MetricMigrationParams: model.MetricMigrationParams{
+					NilToZero:              true,
+					AddCloudwatchTimestamp: false,
+				},
+				Namespace: "AWS/ElastiCache",
+				GetMetricDataResult: &model.GetMetricDataResult{
+					Statistic: "Average",
+					Datapoint: aws.Float64(1),
+					Timestamp: ts,
+				},
+				Dimensions: []model.Dimension{
+					{
+						Name:  "CacheClusterId",
+						Value: "redis-cluster",
+					},
+				},
+				ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+				Tags: []model.Tag{{
+					Key:   "managed_by",
+					Value: "terraform",
+				}},
+			},
+			{
+				MetricName: "FreeableMemory",
+				MetricMigrationParams: model.MetricMigrationParams{
+					NilToZero:              false,
+					AddCloudwatchTimestamp: false,
+				},
+				Namespace: "AWS/ElastiCache",
+				Dimensions: []model.Dimension{
+					{
+						Name:  "CacheClusterId",
+						Value: "redis-cluster",
+					},
+				},
+				GetMetricDataResult: &model.GetMetricDataResult{
+					Statistic: "Average",
+					Datapoint: aws.Float64(2),
+					Timestamp: ts,
+				},
+				ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+				Tags: []model.Tag{{
+					Key:   "managed_by",
+					Value: "terraform",
+				}},
+			},
+			{
+				MetricName: "NetworkBytesIn",
+				MetricMigrationParams: model.MetricMigrationParams{
+					NilToZero:              true,
+					AddCloudwatchTimestamp: false,
+				},
+				Namespace: "AWS/ElastiCache",
+				Dimensions: []model.Dimension{
+					{
+						Name:  "CacheClusterId",
+						Value: "redis-cluster",
+					},
+				},
+				GetMetricDataResult: &model.GetMetricDataResult{
+					Statistic: "Average",
+					Datapoint: aws.Float64(3),
+					Timestamp: ts,
+				},
+				ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+				Tags: []model.Tag{{
+					Key:   "managed_by",
+					Value: "terraform",
+				}},
+			},
+			{
+				MetricName: "NetworkBytesOut",
+				MetricMigrationParams: model.MetricMigrationParams{
+					NilToZero:              true,
+					AddCloudwatchTimestamp: true,
+				},
+				Namespace: "AWS/ElastiCache",
+				Dimensions: []model.Dimension{
+					{
+						Name:  "CacheClusterId",
+						Value: "redis-cluster",
+					},
+				},
+				GetMetricDataResult: &model.GetMetricDataResult{
+					Statistic: "Average",
+					Datapoint: aws.Float64(4),
+					Timestamp: ts,
+				},
+				ResourceName: "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
+				Tags: []model.Tag{{
+					Key:   "managed_by",
+					Value: "terraform",
+				}},
+			},
+		},
+	}}
+
+	var labels map[string]model.LabelSet
+	var err error
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, labels, err = BuildMetrics(data, false, logging.NewNopLogger())
+	}
+
+	expectedLabels := map[string]model.LabelSet{
+		"aws_elasticache_cpuutilization_average": {
+			"account_id":               {},
+			"name":                     {},
+			"region":                   {},
+			"dimension_CacheClusterId": {},
+			"tag_managed_by":           {},
+		},
+		"aws_elasticache_freeable_memory_average": {
+			"account_id":               {},
+			"name":                     {},
+			"region":                   {},
+			"dimension_CacheClusterId": {},
+			"tag_managed_by":           {},
+		},
+		"aws_elasticache_network_bytes_in_average": {
+			"account_id":               {},
+			"name":                     {},
+			"region":                   {},
+			"dimension_CacheClusterId": {},
+			"tag_managed_by":           {},
+		},
+		"aws_elasticache_network_bytes_out_average": {
+			"account_id":               {},
+			"name":                     {},
+			"region":                   {},
+			"dimension_CacheClusterId": {},
+			"tag_managed_by":           {},
+		},
+	}
+
+	require.NoError(b, err)
+	require.Equal(b, expectedLabels, labels)
+}
+
 // replaceNaNValues replaces any NaN floating-point values with a marker value (54321.0)
 // so that require.Equal() can compare them. By default, require.Equal() will fail if any
 // struct values are NaN because NaN != NaN

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -3,8 +3,8 @@ package promutil
 import (
 	"strings"
 	"time"
+	"unsafe"
 
-	"github.com/grafana/regexp"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 )
@@ -90,7 +90,6 @@ var replacer = strings.NewReplacer(
 	">", "_",
 	"%", "_percent",
 )
-var splitRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
 
 type PrometheusMetric struct {
 	Name             *string
@@ -155,10 +154,54 @@ func PromStringTag(text string, labelsSnakeCase bool) (bool, string) {
 	return model.LabelName(s).IsValid(), s
 }
 
+// sanitize replaces some invalid chars with an underscore
 func sanitize(text string) string {
-	return replacer.Replace(text)
+	if strings.ContainsAny(text, "“%") {
+		// fallback to the replacer for complex cases:
+		// - '“' is non-ascii rune
+		// - '%' is replaced with a whole string
+		return replacer.Replace(text)
+	}
+
+	b := []byte(text)
+	for i := 0; i < len(b); i++ {
+		switch b[i] {
+		case ' ', ',', '\t', '/', '\\', '.', '-', ':', '=', '@', '<', '>':
+			b[i] = '_'
+		}
+	}
+	return *(*string)(unsafe.Pointer(&b))
 }
 
+// splitString replaces consecutive occurrences of a lowercase and uppercase letter,
+// or a number and an upper case letter, by putting a dot between the two chars.
+//
+// This is an optimised version of the original implementation:
+//
+//	  var splitRegexp = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+//
+//		func splitString(text string) string {
+//		  return splitRegexp.ReplaceAllString(text, `$1.$2`)
+//		}
 func splitString(text string) string {
-	return splitRegexp.ReplaceAllString(text, `$1.$2`)
+	sb := strings.Builder{}
+	sb.Grow(len(text) + 4) // make some room for replacements
+
+	i := 0
+	for i < len(text) {
+		c := text[i]
+		sb.WriteByte(c)
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			if i < (len(text) - 1) {
+				c = text[i+1]
+				if c >= 'A' && c <= 'Z' {
+					sb.WriteByte('.')
+					sb.WriteByte(c)
+					i++
+				}
+			}
+		}
+		i++
+	}
+	return sb.String()
 }

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -3,7 +3,6 @@ package promutil
 import (
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
@@ -170,7 +169,7 @@ func sanitize(text string) string {
 			b[i] = '_'
 		}
 	}
-	return *(*string)(unsafe.Pointer(&b))
+	return string(b)
 }
 
 // splitString replaces consecutive occurrences of a lowercase and uppercase letter,


### PR DESCRIPTION
Rewrite `sanitize` to attempt to modify the string in place, if possible.
Rewrite `splitString` to avoid using a regex.

```
% benchstat before.txt after.txt
goos: darwin
goarch: arm64
pkg: github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil
                 │ before.txt  │              after.txt              │
                 │   sec/op    │   sec/op     vs base                │
_BuildMetrics-12   201.1µ ± 2%   114.5µ ± 6%  -43.07% (p=0.000 n=10)

                 │  before.txt  │              after.txt               │
                 │     B/op     │     B/op      vs base                │
_BuildMetrics-12   5.750Ki ± 1%   4.281Ki ± 0%  -25.55% (p=0.000 n=10)

                 │ before.txt  │             after.txt              │
                 │  allocs/op  │ allocs/op   vs base                │
_BuildMetrics-12   168.00 ± 0%   95.00 ± 0%  -43.45% (p=0.000 n=10)
```