### PR TITLE
promutil: clean up prom metric names that duplicate parts of the namespace

### DIFF
--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -29,7 +29,14 @@ func BuildMetricName(namespace, metricName, statistic string) string {
 	}
 	sb.WriteString(promNs)
 	sb.WriteString("_")
-	sb.WriteString(PromString(metricName))
+	promMetricName := PromString(metricName)
+	// Some metric names duplicate parts of the namespace as a prefix,
+	// For example, the `Glue` namespace metrics have names prefixed also by `glue``
+	for _, part := range strings.Split(promNs, "_") {
+		promMetricName = strings.TrimPrefix(promMetricName, part)
+	}
+	promMetricName = strings.TrimPrefix(promMetricName, "_")
+	sb.WriteString(promMetricName)
 	if statistic != "" {
 		sb.WriteString("_")
 		sb.WriteString(PromString(statistic))

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -717,6 +717,61 @@ func TestBuildMetrics(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			name: "metric with nonstandard namespace and metric name",
+			data: []model.CloudwatchMetricResult{{
+				Context: &model.ScrapeContext{
+					Region:     "us-east-1",
+					AccountID:  "123456789012",
+					CustomTags: nil,
+				},
+				Data: []*model.CloudwatchData{
+					{
+						MetricName: "glue.driver.aggregate.bytesRead",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
+						},
+						Namespace: "Glue",
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: aws.Float64(1),
+							Timestamp: ts,
+						},
+						Dimensions: []model.Dimension{
+							{
+								Name:  "JobName",
+								Value: "test-job",
+							},
+						},
+						ResourceName: "arn:aws:glue:us-east-1:123456789012:job/test-job",
+					},
+				},
+			}},
+			labelsSnakeCase: true,
+			expectedMetrics: []*PrometheusMetric{
+				{
+					Name:      aws.String("aws_glue_driver_aggregate_bytes_read_average"),
+					Value:     1,
+					Timestamp: ts,
+					Labels: map[string]string{
+						"account_id":         "123456789012",
+						"name":               "arn:aws:glue:us-east-1:123456789012:job/test-job",
+						"region":             "us-east-1",
+						"dimension_job_name": "test-job",
+					},
+				},
+			},
+			expectedLabels: map[string]model.LabelSet{
+				"aws_glue_driver_aggregate_bytes_read_average": {
+					"account_id":         {},
+					"name":               {},
+					"region":             {},
+					"dimension_job_name": {},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
 			name: "custom tag",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -717,7 +717,7 @@ func TestBuildMetrics(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "metric with nonstandard namespace and metric name",
+			name: "metric with metric name that does duplicates part of the namespace as a prefix",
 			data: []model.CloudwatchMetricResult{{
 				Context: &model.ScrapeContext{
 					Region:     "us-east-1",
@@ -763,6 +763,61 @@ func TestBuildMetrics(t *testing.T) {
 			},
 			expectedLabels: map[string]model.LabelSet{
 				"aws_glue_driver_aggregate_bytes_read_average": {
+					"account_id":         {},
+					"name":               {},
+					"region":             {},
+					"dimension_job_name": {},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "metric with metric name that does not duplicate part of the namespace as a prefix",
+			data: []model.CloudwatchMetricResult{{
+				Context: &model.ScrapeContext{
+					Region:     "us-east-1",
+					AccountID:  "123456789012",
+					CustomTags: nil,
+				},
+				Data: []*model.CloudwatchData{
+					{
+						MetricName: "aggregate.glue.jobs.bytesRead",
+						MetricMigrationParams: model.MetricMigrationParams{
+							NilToZero:              false,
+							AddCloudwatchTimestamp: false,
+						},
+						Namespace: "Glue",
+						GetMetricDataResult: &model.GetMetricDataResult{
+							Statistic: "Average",
+							Datapoint: aws.Float64(1),
+							Timestamp: ts,
+						},
+						Dimensions: []model.Dimension{
+							{
+								Name:  "JobName",
+								Value: "test-job",
+							},
+						},
+						ResourceName: "arn:aws:glue:us-east-1:123456789012:job/test-job",
+					},
+				},
+			}},
+			labelsSnakeCase: true,
+			expectedMetrics: []*PrometheusMetric{
+				{
+					Name:      aws.String("aws_glue_aggregate_glue_jobs_bytes_read_average"),
+					Value:     1,
+					Timestamp: ts,
+					Labels: map[string]string{
+						"account_id":         "123456789012",
+						"name":               "arn:aws:glue:us-east-1:123456789012:job/test-job",
+						"region":             "us-east-1",
+						"dimension_job_name": "test-job",
+					},
+				},
+			},
+			expectedLabels: map[string]model.LabelSet{
+				"aws_glue_aggregate_glue_jobs_bytes_read_average": {
 					"account_id":         {},
 					"name":               {},
 					"region":             {},


### PR DESCRIPTION
See https://github.com/grafana/cloud-onboarding/pull/6490#issuecomment-2047563725

This PR makes it so that Prom metric names look more clean in the case that a cloudwatch metric name duplicates part of the namespace as a prefix. For example, `Glue` namespace metrics are all prefaced with `glue.`. Therefore, without this change, the prom metrics would appear as `aws_glue_glue` as a prefix of the name.