### PR TITLE
getmetricdata: move window calculator to processor

### DIFF
--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -22,7 +22,7 @@ type Client interface {
 
 	// GetMetricData returns the output of the GetMetricData CloudWatch API.
 	// Results pagination is handled automatically.
-	GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []MetricDataResult
+	GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []MetricDataResult
 
 	// GetMetricStatistics returns the output of the GetMetricStatistics CloudWatch API.
 	GetMetricStatistics(ctx context.Context, logger logging.Logger, dimensions []model.Dimension, namespace string, metric *model.MetricConfig) []*model.Datapoint
@@ -68,9 +68,9 @@ func (c limitedConcurrencyClient) GetMetricStatistics(ctx context.Context, logge
 	return res
 }
 
-func (c limitedConcurrencyClient) GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []MetricDataResult {
+func (c limitedConcurrencyClient) GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []MetricDataResult {
 	c.limiter.Acquire(getMetricDataCall)
-	res := c.client.GetMetricData(ctx, logger, getMetricData, namespace, length, delay, configuredRoundingPeriod)
+	res := c.client.GetMetricData(ctx, getMetricData, namespace, startTime, endTime)
 	c.limiter.Release(getMetricDataCall)
 	return res
 }

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
@@ -87,17 +88,38 @@ func toModelDimensions(dimensions []types.Dimension) []model.Dimension {
 	return modelDimensions
 }
 
-func (c client) GetMetricData(ctx context.Context, logger logging.Logger, getMetricData []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []cloudwatch_client.MetricDataResult {
-	filter := createGetMetricDataInput(logger, getMetricData, &namespace, length, delay, configuredRoundingPeriod)
-	promutil.CloudwatchGetMetricDataAPIMetricsCounter.Add(float64(len(filter.MetricDataQueries)))
-
-	var resp cloudwatch.GetMetricDataOutput
-
-	if c.logger.IsDebugEnabled() {
-		c.logger.Debug("GetMetricData", "input", filter)
+func (c client) GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch_client.MetricDataResult {
+	metricDataQueries := make([]types.MetricDataQuery, 0, len(getMetricData))
+	for _, data := range getMetricData {
+		metricStat := &types.MetricStat{
+			Metric: &types.Metric{
+				Dimensions: toCloudWatchDimensions(data.Dimensions),
+				MetricName: &data.MetricName,
+				Namespace:  &namespace,
+			},
+			Period: aws.Int32(int32(data.GetMetricDataProcessingParams.Period)),
+			Stat:   &data.GetMetricDataProcessingParams.Statistic,
+		}
+		metricDataQueries = append(metricDataQueries, types.MetricDataQuery{
+			Id:         &data.GetMetricDataProcessingParams.QueryID,
+			MetricStat: metricStat,
+			ReturnData: aws.Bool(true),
+		})
 	}
 
-	paginator := cloudwatch.NewGetMetricDataPaginator(c.cloudwatchAPI, filter, func(options *cloudwatch.GetMetricDataPaginatorOptions) {
+	input := &cloudwatch.GetMetricDataInput{
+		EndTime:           &endTime,
+		StartTime:         &startTime,
+		MetricDataQueries: metricDataQueries,
+		ScanBy:            "TimestampDescending",
+	}
+	var resp cloudwatch.GetMetricDataOutput
+	promutil.CloudwatchGetMetricDataAPIMetricsCounter.Add(float64(len(input.MetricDataQueries)))
+	if c.logger.IsDebugEnabled() {
+		c.logger.Debug("GetMetricData", "input", input)
+	}
+
+	paginator := cloudwatch.NewGetMetricDataPaginator(c.cloudwatchAPI, input, func(options *cloudwatch.GetMetricDataPaginatorOptions) {
 		options.StopOnDuplicateToken = true
 	})
 	for paginator.HasMorePages() {

--- a/pkg/clients/cloudwatch/v2/input.go
+++ b/pkg/clients/cloudwatch/v2/input.go
@@ -9,56 +9,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 
-	cloudwatch_client "github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/logging"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
 	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/promutil"
 )
-
-func createGetMetricDataInput(logger logging.Logger, getMetricData []*model.CloudwatchData, namespace *string, length int64, delay int64, configuredRoundingPeriod *int64) *cloudwatch.GetMetricDataInput {
-	metricsDataQuery := make([]types.MetricDataQuery, 0, len(getMetricData))
-	roundingPeriod := model.DefaultPeriodSeconds
-	for _, data := range getMetricData {
-		if data.GetMetricDataProcessingParams.Period < roundingPeriod {
-			roundingPeriod = data.GetMetricDataProcessingParams.Period
-		}
-		metricStat := &types.MetricStat{
-			Metric: &types.Metric{
-				Dimensions: toCloudWatchDimensions(data.Dimensions),
-				MetricName: &data.MetricName,
-				Namespace:  namespace,
-			},
-			Period: aws.Int32(int32(data.GetMetricDataProcessingParams.Period)),
-			Stat:   &data.GetMetricDataProcessingParams.Statistic,
-		}
-		metricsDataQuery = append(metricsDataQuery, types.MetricDataQuery{
-			Id:         &data.GetMetricDataProcessingParams.QueryID,
-			MetricStat: metricStat,
-			ReturnData: aws.Bool(true),
-		})
-	}
-
-	if configuredRoundingPeriod != nil {
-		roundingPeriod = *configuredRoundingPeriod
-	}
-
-	startTime, endTime := cloudwatch_client.DetermineGetMetricDataWindow(
-		cloudwatch_client.TimeClock{},
-		time.Duration(roundingPeriod)*time.Second,
-		time.Duration(length)*time.Second,
-		time.Duration(delay)*time.Second)
-
-	if logger.IsDebugEnabled() {
-		logger.Debug("GetMetricData Window", "start_time", startTime.Format(cloudwatch_client.TimeFormat), "end_time", endTime.Format(cloudwatch_client.TimeFormat))
-	}
-
-	return &cloudwatch.GetMetricDataInput{
-		EndTime:           &endTime,
-		StartTime:         &startTime,
-		MetricDataQueries: metricsDataQuery,
-		ScanBy:            "TimestampDescending",
-	}
-}
 
 func toCloudWatchDimensions(dimensions []model.Dimension) []types.Dimension {
 	cwDim := make([]types.Dimension, 0, len(dimensions))

--- a/pkg/clients/v2/factory_test.go
+++ b/pkg/clients/v2/factory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -474,7 +475,7 @@ func (t testClient) ListMetrics(_ context.Context, _ string, _ *model.MetricConf
 	return nil
 }
 
-func (t testClient) GetMetricData(_ context.Context, _ logging.Logger, _ []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch_client.MetricDataResult {
+func (t testClient) GetMetricData(_ context.Context, _ []*model.CloudwatchData, _ string, _ time.Time, _ time.Time) []cloudwatch_client.MetricDataResult {
 	return nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -103,7 +103,7 @@ func TestValidateConfigFailuresWhenUsingAsLibrary(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := tc.config.Validate()
+			_, err := tc.config.Validate(logging.NewNopLogger())
 			require.Error(t, err, "Expected config validation to fail")
 			require.Equal(t, tc.errorMsg, err.Error())
 		})

--- a/pkg/job/custom.go
+++ b/pkg/job/custom.go
@@ -24,7 +24,7 @@ func runCustomNamespaceJob(
 
 	jobLength := getLargestLengthForMetrics(job.Metrics)
 	var err error
-	cloudwatchDatas, err = gmdProcessor.Run(ctx, logger, job.Namespace, jobLength, job.Delay, job.RoundingPeriod, cloudwatchDatas)
+	cloudwatchDatas, err = gmdProcessor.Run(ctx, job.Namespace, jobLength, job.Delay, job.RoundingPeriod, cloudwatchDatas)
 	if err != nil {
 		logger.Error(err, "Failed to get metric data")
 		return nil

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -20,7 +20,7 @@ type resourceAssociator interface {
 }
 
 type getMetricDataProcessor interface {
-	Run(ctx context.Context, logger logging.Logger, namespace string, jobMetricLength int64, jobMetricDelay int64, jobRoundingPeriod *int64, requests []*model.CloudwatchData) ([]*model.CloudwatchData, error)
+	Run(ctx context.Context, namespace string, jobMetricLength, jobMetricDelay int64, period *int64, requests []*model.CloudwatchData) ([]*model.CloudwatchData, error)
 }
 
 func runDiscoveryJob(
@@ -56,7 +56,7 @@ func runDiscoveryJob(
 	}
 
 	jobLength := getLargestLengthForMetrics(job.Metrics)
-	getMetricDatas, err = gmdProcessor.Run(ctx, logger, svc.Namespace, jobLength, job.Delay, job.RoundingPeriod, getMetricDatas)
+	getMetricDatas, err = gmdProcessor.Run(ctx, svc.Namespace, jobLength, job.Delay, job.RoundingPeriod, getMetricDatas)
 	if err != nil {
 		logger.Error(err, "Failed to get metric data")
 		return nil, nil

--- a/pkg/job/getmetricdata/processor.go
+++ b/pkg/job/getmetricdata/processor.go
@@ -62,7 +62,7 @@ func (p Processor) Run(ctx context.Context, namespace string, jobMetricLength, j
 		g.Go(func() error {
 			input := addQueryIDsToBatch(requests[start:end])
 
-			var batchPeriod int64
+			batchPeriod := model.DefaultPeriodSeconds
 			if jobRoundingPeriod == nil {
 				for _, data := range input {
 					if data.GetMetricDataProcessingParams.Period < batchPeriod {

--- a/pkg/job/getmetricdata/processor_test.go
+++ b/pkg/job/getmetricdata/processor_test.go
@@ -3,8 +3,6 @@ package getmetricdata
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,14 +31,14 @@ type metricDataResultForMetric struct {
 }
 
 type testClient struct {
-	GetMetricDataFunc             func(ctx context.Context, logger logging.Logger, data []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []cloudwatch.MetricDataResult
+	GetMetricDataFunc             func(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch.MetricDataResult
 	GetMetricDataResultForMetrics []metricDataResultForMetric
 }
 
-func (t testClient) GetMetricData(ctx context.Context, logger logging.Logger, data []*model.CloudwatchData, namespace string, length int64, delay int64, configuredRoundingPeriod *int64) []cloudwatch.MetricDataResult {
+func (t testClient) GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch.MetricDataResult {
 	if t.GetMetricDataResultForMetrics != nil {
 		var result []cloudwatch.MetricDataResult
-		for _, datum := range data {
+		for _, datum := range getMetricData {
 			for _, response := range t.GetMetricDataResultForMetrics {
 				if datum.MetricName == response.MetricName {
 					response.result.ID = datum.GetMetricDataProcessingParams.QueryID
@@ -50,7 +48,7 @@ func (t testClient) GetMetricData(ctx context.Context, logger logging.Logger, da
 		}
 		return result
 	}
-	return t.GetMetricDataFunc(ctx, logger, data, namespace, length, delay, configuredRoundingPeriod)
+	return t.GetMetricDataFunc(ctx, getMetricData, namespace, startTime, endTime)
 }
 
 func TestProcessor_Run(t *testing.T) {
@@ -190,8 +188,8 @@ func TestProcessor_Run(t *testing.T) {
 			if tt.metricsPerBatch != 0 {
 				metricsPerQuery = tt.metricsPerBatch
 			}
-			r := NewProcessor(testClient{GetMetricDataResultForMetrics: tt.metricDataResultForMetrics}, metricsPerQuery, 1)
-			cloudwatchData, err := r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 100, 100, aws.Int64(100), ToCloudwatchData(tt.requests))
+			r := NewDefaultProcessor(logging.NewNopLogger(), testClient{GetMetricDataResultForMetrics: tt.metricDataResultForMetrics}, metricsPerQuery, 1)
+			cloudwatchData, err := r.Run(context.Background(), "anything_is_fine", 100, 100, nil, ToCloudwatchData(tt.requests))
 			require.NoError(t, err)
 			require.Len(t, cloudwatchData, len(tt.want))
 			got := make([]cloudwatchDataOutput, 0, len(cloudwatchData))
@@ -206,51 +204,6 @@ func TestProcessor_Run(t *testing.T) {
 			}
 
 			assert.ElementsMatch(t, tt.want, got)
-		})
-	}
-}
-
-func TestProcessor_Run_BatchesByMetricsPerQuery(t *testing.T) {
-	now := time.Now()
-	tests := []struct {
-		name                                 string
-		metricsPerQuery                      int
-		numberOfRequests                     int
-		expectedNumberOfCallsToGetMetricData int32
-	}{
-		{name: "1 per batch", metricsPerQuery: 1, numberOfRequests: 10, expectedNumberOfCallsToGetMetricData: 10},
-		{name: "divisible batches and requests", metricsPerQuery: 5, numberOfRequests: 100, expectedNumberOfCallsToGetMetricData: 20},
-		{name: "indivisible batches and requests", metricsPerQuery: 5, numberOfRequests: 94, expectedNumberOfCallsToGetMetricData: 19},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var callCounter atomic.Int32
-			getMetricDataFunc := func(_ context.Context, _ logging.Logger, data []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch.MetricDataResult {
-				callCounter.Add(1)
-				response := make([]cloudwatch.MetricDataResult, 0, len(data))
-				for _, gmd := range data {
-					response = append(response, cloudwatch.MetricDataResult{
-						ID:        gmd.GetMetricDataProcessingParams.QueryID,
-						Datapoint: aws.Float64(1000),
-						Timestamp: now,
-					})
-				}
-				return response
-			}
-
-			requests := make([]*model.CloudwatchData, 0, tt.numberOfRequests)
-			for i := 0; i < tt.numberOfRequests; i++ {
-				requests = append(requests, getSampleMetricDatas(strconv.Itoa(i)))
-			}
-			r := Processor{
-				metricsPerQuery: tt.metricsPerQuery,
-				client:          testClient{GetMetricDataFunc: getMetricDataFunc},
-				concurrency:     1,
-			}
-			cloudwatchData, err := r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 1, 1, aws.Int64(1), requests)
-			require.NoError(t, err)
-			assert.Len(t, cloudwatchData, tt.numberOfRequests)
-			assert.Equal(t, tt.expectedNumberOfCallsToGetMetricData, callCounter.Load())
 		})
 	}
 }
@@ -347,7 +300,7 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount int, concurrency 
 		testResourceIDs[i] = fmt.Sprintf("test-resource-%d", i)
 	}
 
-	client := testClient{GetMetricDataFunc: func(_ context.Context, _ logging.Logger, getMetricData []*model.CloudwatchData, _ string, _ int64, _ int64, _ *int64) []cloudwatch.MetricDataResult {
+	client := testClient{GetMetricDataFunc: func(_ context.Context, getMetricData []*model.CloudwatchData, _ string, _ time.Time, _ time.Time) []cloudwatch.MetricDataResult {
 		b.StopTimer()
 		results := make([]cloudwatch.MetricDataResult, 0, len(getMetricData))
 		for _, entry := range getMetricData {
@@ -369,12 +322,12 @@ func doBench(b *testing.B, metricsPerQuery, testResourcesCount int, concurrency 
 		for i := 0; i < testResourcesCount; i++ {
 			datas = append(datas, getSampleMetricDatas(testResourceIDs[i]))
 		}
-		r := NewProcessor(client, metricsPerQuery, concurrency)
+		r := NewDefaultProcessor(logging.NewNopLogger(), client, metricsPerQuery, concurrency)
 		// re-start timer
 		b.ReportAllocs()
 		b.StartTimer()
 
 		//nolint:errcheck
-		r.Run(context.Background(), logging.NewNopLogger(), "anything_is_fine", 100, 100, aws.Int64(100), datas)
+		r.Run(context.Background(), "anything_is_fine", 100, 100, nil, datas)
 	}
 }

--- a/pkg/job/getmetricdata/windowcalculator_test.go
+++ b/pkg/job/getmetricdata/windowcalculator_test.go
@@ -1,4 +1,4 @@
-package cloudwatch
+package getmetricdata
 
 import (
 	"testing"
@@ -85,7 +85,7 @@ func Test_MetricWindow(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			startTime, endTime := DetermineGetMetricDataWindow(tc.data.clock, tc.data.roundingPeriod, tc.data.length, tc.data.delay)
+			startTime, endTime := MetricWindowCalculator{tc.data.clock}.Calculate(tc.data.roundingPeriod, tc.data.length, tc.data.delay)
 			if !startTime.Equal(tc.data.expectedStartTime) {
 				t.Errorf("start time incorrect. Expected: %s, Actual: %s", tc.data.expectedStartTime.Format(TimeFormat), startTime.Format(TimeFormat))
 				t.Errorf("end time incorrect. Expected: %s, Actual: %s", tc.data.expectedEndTime.Format(TimeFormat), endTime.Format(TimeFormat))

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -41,7 +41,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", accountID)
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)
-					gmdProcessor := getmetricdata.NewProcessor(cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
+					gmdProcessor := getmetricdata.NewDefaultProcessor(logger, cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
 					resources, metrics := runDiscoveryJob(ctx, jobLogger, discoveryJob, region, factory.GetTaggingClient(region, role, taggingAPIConcurrency), cloudwatchClient, gmdProcessor)
 					addDataToOutput := len(metrics) != 0
 					if config.FlagsFromCtx(ctx).IsFeatureEnabled(config.AlwaysReturnInfoMetrics) {
@@ -120,7 +120,7 @@ func ScrapeAwsData(
 					jobLogger = jobLogger.With("account", accountID)
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)
-					gmdProcessor := getmetricdata.NewProcessor(cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
+					gmdProcessor := getmetricdata.NewDefaultProcessor(logger, cloudwatchClient, metricsPerQuery, cloudwatchConcurrency.GetMetricData)
 					metrics := runCustomNamespaceJob(ctx, jobLogger, customNamespaceJob, cloudwatchClient, gmdProcessor)
 					metricResult := model.CloudwatchMetricResult{
 						Context: &model.ScrapeContext{

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -9,7 +9,6 @@ import (
 const (
 	DefaultPeriodSeconds = int64(300)
 	DefaultLengthSeconds = int64(300)
-	DefaultDelaySeconds  = int64(300)
 )
 
 type JobsConfig struct {
@@ -49,12 +48,12 @@ type CustomNamespaceJob struct {
 	Regions                   []string
 	Name                      string
 	Namespace                 string
+	RoundingPeriod            *int64
 	RecentlyActiveOnly        bool
 	Roles                     []Role
 	Metrics                   []*MetricConfig
 	CustomTags                []Tag
 	DimensionNameRequirements []string
-	RoundingPeriod            *int64
 	JobLevelMetricFields
 }
 


### PR DESCRIPTION
This slices off a chunk of the pr here, https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/1368 to move the GetMetricData start and end time to the processor vs duplicated in the clients. It doesn't go as far as the original does with removing rounding period but it adds the deprecation notice + a log about metric level delay being ignored.

Related to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1290
Related to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1094