### PR TITLE
getmetricdata: Move batching to an iterator

### DIFF
--- a/pkg/job/getmetricdata/iterator.go
+++ b/pkg/job/getmetricdata/iterator.go
@@ -1,0 +1,103 @@
+package getmetricdata
+
+import (
+	"math"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+type iteratorFactory struct {
+	metricsPerQuery int
+}
+
+func (b iteratorFactory) Build(data []*model.CloudwatchData, jobMetricLength, jobMetricDelay int64, jobRoundingPeriod *int64) Iterator {
+	if len(data) == 0 {
+		return nothingToIterate{}
+	}
+
+	return NewSimpleBatchIterator(b.metricsPerQuery, data, jobMetricLength, jobMetricDelay, jobRoundingPeriod)
+}
+
+type nothingToIterate struct{}
+
+func (n nothingToIterate) Size() int {
+	return 0
+}
+
+func (n nothingToIterate) Next() ([]*model.CloudwatchData, *model.GetMetricDataProcessingParams) {
+	return nil, nil
+}
+
+func (n nothingToIterate) HasMore() bool {
+	return false
+}
+
+type simpleBatchingIterator struct {
+	size            int
+	currentBatch    int
+	params          *model.GetMetricDataProcessingParams
+	data            []*model.CloudwatchData
+	entriesPerBatch int
+	roundingPeriod  *int64
+}
+
+func (s *simpleBatchingIterator) Size() int {
+	return s.size
+}
+
+func (s *simpleBatchingIterator) Next() ([]*model.CloudwatchData, *model.GetMetricDataProcessingParams) {
+	// We are out of data return defaults
+	if s.currentBatch >= s.size {
+		return nil, nil
+	}
+
+	startingIndex := s.currentBatch * s.entriesPerBatch
+	endingIndex := startingIndex + s.entriesPerBatch
+	if endingIndex > len(s.data) {
+		endingIndex = len(s.data)
+	}
+
+	// TODO are we technically doing this https://go.dev/wiki/SliceTricks#batching-with-minimal-allocation and if not
+	// would it change allocations to do this ahead of time?
+	result := s.data[startingIndex:endingIndex]
+	s.currentBatch++
+
+	batchPeriod := model.DefaultPeriodSeconds
+	if s.roundingPeriod == nil {
+		for _, data := range result {
+			if data.GetMetricDataProcessingParams.Period < batchPeriod {
+				batchPeriod = data.GetMetricDataProcessingParams.Period
+			}
+		}
+	} else {
+		batchPeriod = *s.roundingPeriod
+	}
+
+	// shallow copy all fields are non-pointers so should be safe
+	batchParams := &(*s.params)
+	batchParams.Period = batchPeriod
+
+	return result, batchParams
+}
+
+func (s *simpleBatchingIterator) HasMore() bool {
+	return s.currentBatch < s.size
+}
+
+// NewSimpleBatchIterator returns an iterator which slices the data in place based on the metricsPerQuery.
+func NewSimpleBatchIterator(metricsPerQuery int, data []*model.CloudwatchData, jobMetricLength, jobMetricDelay int64, jobRoundingPeriod *int64) Iterator {
+	size := int(math.Ceil(float64(len(data)) / float64(metricsPerQuery)))
+
+	params := &model.GetMetricDataProcessingParams{
+		Length: jobMetricLength,
+		Delay:  jobMetricDelay,
+	}
+
+	return &simpleBatchingIterator{
+		size:            size,
+		params:          params,
+		roundingPeriod:  jobRoundingPeriod,
+		data:            data,
+		entriesPerBatch: metricsPerQuery,
+	}
+}

--- a/pkg/job/getmetricdata/iterator_test.go
+++ b/pkg/job/getmetricdata/iterator_test.go
@@ -144,7 +144,6 @@ func TestSimpleBatchingIterator_IterateFlow(t *testing.T) {
 				data = append(data, getSampleMetricDatas(strconv.Itoa(i)))
 			}
 			iterator := NewSimpleBatchIterator(tc.metricsPerQuery, data, data[0].GetMetricDataProcessingParams.Length, data[0].GetMetricDataProcessingParams.Delay, nil)
-			assert.Equal(t, tc.expectedSizeAndNumberOfCallsToNext, iterator.Size())
 
 			numberOfCallsToNext := 0
 			for iterator.HasMore() {

--- a/pkg/job/getmetricdata/iterator_test.go
+++ b/pkg/job/getmetricdata/iterator_test.go
@@ -1,0 +1,158 @@
+package getmetricdata
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nerdswords/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+func TestIteratorFactory_Build(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            []*model.CloudwatchData
+		expectedIterator Iterator
+	}{
+		{
+			name:             "empty returns nothing to iterator",
+			input:            []*model.CloudwatchData{},
+			expectedIterator: nothingToIterate{},
+		},
+		{
+			name: "input with data returns simple batching",
+			input: []*model.CloudwatchData{
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10, Delay: 100}},
+			},
+			expectedIterator: &simpleBatchingIterator{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			factory := iteratorFactory{100}
+			iterator := factory.Build(tc.input, 10, 100, aws.Int64(100))
+			assert.IsType(t, tc.expectedIterator, iterator)
+		})
+	}
+}
+
+func TestSimpleBatchingIterator_SetsLengthAndDelay(t *testing.T) {
+	data := []*model.CloudwatchData{
+		{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 101, Delay: 100}},
+	}
+	jobLength := int64(101)
+	jobDelay := int64(100)
+	iterator := NewSimpleBatchIterator(1, data, jobLength, jobDelay, nil)
+	_, params := iterator.Next()
+	assert.Equal(t, jobLength, params.Length)
+	assert.Equal(t, jobDelay, params.Delay)
+}
+
+func TestSimpleBatchingIterator_CalculatesPeriod(t *testing.T) {
+	tests := []struct {
+		name                        string
+		data                        []*model.CloudwatchData
+		metricsPerQuery             int
+		roundingPeriod              *int64
+		iterateCallToExpectedPeriod map[int]int64
+	}{
+		{
+			name: "rounding period overrides all",
+			data: []*model.CloudwatchData{
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+			},
+			metricsPerQuery:             1,
+			roundingPeriod:              aws.Int64(100),
+			iterateCallToExpectedPeriod: map[int]int64{1: 100, 2: 100, 3: 100},
+		},
+		{
+			name: "uses metric period when no rounding period is set",
+			data: []*model.CloudwatchData{
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 200}},
+			},
+			metricsPerQuery:             1,
+			roundingPeriod:              nil,
+			iterateCallToExpectedPeriod: map[int]int64{1: 200, 2: 200, 3: 200},
+		},
+		{
+			name: "smallest period wins",
+			data: []*model.CloudwatchData{
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 10}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 100}},
+				{GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{Period: 1000}},
+			},
+			metricsPerQuery:             3,
+			roundingPeriod:              nil,
+			iterateCallToExpectedPeriod: map[int]int64{1: 10},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			iterator := NewSimpleBatchIterator(tc.metricsPerQuery, tc.data, 10, 100, tc.roundingPeriod)
+
+			numberOfCallsToNext := 0
+			for iterator.HasMore() {
+				numberOfCallsToNext++
+				_, params := iterator.Next()
+				assert.Equal(t, tc.iterateCallToExpectedPeriod[numberOfCallsToNext], params.Period)
+			}
+		})
+	}
+}
+
+func TestSimpleBatchingIterator_IterateFlow(t *testing.T) {
+	tests := []struct {
+		name                               string
+		metricsPerQuery                    int
+		lengthOfCloudwatchData             int
+		expectedSizeAndNumberOfCallsToNext int
+	}{
+		{
+			name:                               "1 per batch",
+			metricsPerQuery:                    1,
+			lengthOfCloudwatchData:             10,
+			expectedSizeAndNumberOfCallsToNext: 10,
+		},
+		{
+			name:                               "divisible batches and requests",
+			metricsPerQuery:                    5,
+			lengthOfCloudwatchData:             100,
+			expectedSizeAndNumberOfCallsToNext: 20,
+		},
+		{
+			name:                               "indivisible batches and requests",
+			metricsPerQuery:                    5,
+			lengthOfCloudwatchData:             94,
+			expectedSizeAndNumberOfCallsToNext: 19,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := make([]*model.CloudwatchData, 0, tc.lengthOfCloudwatchData)
+			for i := 0; i < tc.lengthOfCloudwatchData; i++ {
+				data = append(data, getSampleMetricDatas(strconv.Itoa(i)))
+			}
+			iterator := NewSimpleBatchIterator(tc.metricsPerQuery, data, data[0].GetMetricDataProcessingParams.Length, data[0].GetMetricDataProcessingParams.Delay, nil)
+			assert.Equal(t, tc.expectedSizeAndNumberOfCallsToNext, iterator.Size())
+
+			numberOfCallsToNext := 0
+			for iterator.HasMore() {
+				numberOfCallsToNext++
+				iterator.Next()
+			}
+
+			assert.Equal(t, tc.expectedSizeAndNumberOfCallsToNext, numberOfCallsToNext)
+		})
+	}
+}

--- a/pkg/job/getmetricdata/processor.go
+++ b/pkg/job/getmetricdata/processor.go
@@ -24,9 +24,6 @@ type IteratorFactory interface {
 }
 
 type Iterator interface {
-	// Size returns the number of batches in the iterator
-	Size() int
-
 	// Next returns the next batch of CloudWatch data be used when calling GetMetricData and the start + end time for
 	// the GetMetricData call
 	// If called when there are no more batches default values will be returned

--- a/pkg/job/getmetricdata/processor.go
+++ b/pkg/job/getmetricdata/processor.go
@@ -3,7 +3,6 @@ package getmetricdata
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -19,70 +18,70 @@ type Client interface {
 	GetMetricData(ctx context.Context, getMetricData []*model.CloudwatchData, namespace string, startTime time.Time, endTime time.Time) []cloudwatch.MetricDataResult
 }
 
+type IteratorFactory interface {
+	// Build returns an ideal batch iterator based on the provided CloudwatchData
+	Build(requests []*model.CloudwatchData, jobMetricLength, jobMetricDelay int64, jobRoundingPeriod *int64) Iterator
+}
+
+type Iterator interface {
+	// Size returns the number of batches in the iterator
+	Size() int
+
+	// Next returns the next batch of CloudWatch data be used when calling GetMetricData and the start + end time for
+	// the GetMetricData call
+	// If called when there are no more batches default values will be returned
+	Next() ([]*model.CloudwatchData, *model.GetMetricDataProcessingParams)
+
+	// HasMore returns true if there are more batches to iterate otherwise false. Should be used in a loop
+	// to govern calls to Next()
+	HasMore() bool
+}
+
 type Processor struct {
-	metricsPerQuery  int
 	client           Client
 	concurrency      int
 	windowCalculator MetricWindowCalculator
 	logger           logging.Logger
+	factory          IteratorFactory
 }
 
 func NewDefaultProcessor(logger logging.Logger, client Client, metricsPerQuery int, concurrency int) Processor {
-	return NewProcessor(logger, client, metricsPerQuery, concurrency, MetricWindowCalculator{clock: TimeClock{}})
+	return NewProcessor(logger, client, concurrency, MetricWindowCalculator{clock: TimeClock{}}, &iteratorFactory{metricsPerQuery: metricsPerQuery})
 }
 
-func NewProcessor(logger logging.Logger, client Client, metricsPerQuery int, concurrency int, windowCalculator MetricWindowCalculator) Processor {
+func NewProcessor(logger logging.Logger, client Client, concurrency int, windowCalculator MetricWindowCalculator, factory IteratorFactory) Processor {
 	return Processor{
 		logger:           logger,
-		metricsPerQuery:  metricsPerQuery,
 		client:           client,
 		concurrency:      concurrency,
 		windowCalculator: windowCalculator,
+		factory:          factory,
 	}
 }
 
 func (p Processor) Run(ctx context.Context, namespace string, jobMetricLength, jobMetricDelay int64, jobRoundingPeriod *int64, requests []*model.CloudwatchData) ([]*model.CloudwatchData, error) {
-	metricDataLength := len(requests)
-	partitionSize := int(math.Ceil(float64(metricDataLength) / float64(p.metricsPerQuery)))
-	p.logger.Debug("GetMetricData partitions", "size", partitionSize)
+	if len(requests) == 0 {
+		return requests, nil
+	}
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(p.concurrency)
 
-	count := 0
-	for i := 0; i < metricDataLength; i += p.metricsPerQuery {
-		start := i
-		end := i + p.metricsPerQuery
-		if end > metricDataLength {
-			end = metricDataLength
-		}
-		partitionNum := count
-		count++
-
+	iterator := p.factory.Build(requests, jobMetricLength, jobMetricDelay, jobRoundingPeriod)
+	for iterator.HasMore() {
+		batch, batchParams := iterator.Next()
 		g.Go(func() error {
-			input := addQueryIDsToBatch(requests[start:end])
-
-			batchPeriod := model.DefaultPeriodSeconds
-			if jobRoundingPeriod == nil {
-				for _, data := range input {
-					if data.GetMetricDataProcessingParams.Period < batchPeriod {
-						batchPeriod = data.GetMetricDataProcessingParams.Period
-					}
-				}
-			} else {
-				batchPeriod = *jobRoundingPeriod
-			}
-
-			startTime, endTime := p.windowCalculator.Calculate(toSecondDuration(batchPeriod), toSecondDuration(jobMetricLength), toSecondDuration(jobMetricDelay))
+			batch = addQueryIDsToBatch(batch)
+			startTime, endTime := p.windowCalculator.Calculate(toSecondDuration(batchParams.Period), toSecondDuration(batchParams.Length), toSecondDuration(batchParams.Delay))
 			if p.logger.IsDebugEnabled() {
 				p.logger.Debug("GetMetricData Window", "start_time", startTime.Format(TimeFormat), "end_time", endTime.Format(TimeFormat))
 			}
 
-			data := p.client.GetMetricData(gCtx, input, namespace, startTime, endTime)
+			data := p.client.GetMetricData(gCtx, batch, namespace, startTime, endTime)
 			if data != nil {
-				mapResultsToBatch(p.logger, data, input)
+				mapResultsToBatch(p.logger, data, batch)
 			} else {
-				p.logger.Warn("GetMetricData partition empty result", "start", start, "end", end, "partitionNum", partitionNum)
+				p.logger.Warn("GetMetricData partition empty result", "start", startTime, "end", endTime)
 			}
 
 			return nil


### PR DESCRIPTION
Second chunk from https://github.com/nerdswords/yet-another-cloudwatch-exporter/pull/1368 to introduce the new iterator for batching without making further changes to rounding period or other start + endtime calculations.

Related to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1290
Related to https://github.com/nerdswords/yet-another-cloudwatch-exporter/issues/1094