### PR TITLE
exportedTagsOnMetrics: validate that keys match a defined job

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -71,6 +71,10 @@ func TestBadConfigs(t *testing.T) {
 			configFile: "discovery_job_exported_tags_alias.bad.yml",
 			errorMsg:   "Discovery jobs: Invalid key in 'exportedTagsOnMetrics', use namespace \"AWS/S3\" rather than alias \"s3\"",
 		},
+		{
+			configFile: "discovery_job_exported_tags_mismatch.bad.yml",
+			errorMsg:   "Discovery jobs: 'exportedTagsOnMetrics' key \"AWS/RDS\" does not match with any discovery job type",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/testdata/discovery_job_exported_tags_mismatch.bad.yml
+++ b/pkg/config/testdata/discovery_job_exported_tags_mismatch.bad.yml
@@ -1,0 +1,20 @@
+apiVersion: v1alpha1
+discovery:
+  exportedTagsOnMetrics:
+    AWS/RDS:
+      - ClusterName
+  jobs:
+  - type: AWS/S3
+    regions:
+      - eu-west-1
+    metrics:
+      - name: NumberOfObjects
+        statistics:
+          - Average
+        period: 86400
+        length: 172800
+      - name: BucketSizeBytes
+        statistics:
+          - Average
+        period: 86400
+        length: 172800


### PR DESCRIPTION
Validate in the config file that `discovery.exportedTagsOnMetrics` has keys that match with the type of at least one discovery job.