### PR TITLE
Fix ElastiCache metric namespace typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Only the latest version gets security updates. We won't support older versions.
   * `AWS/EC2Spot` - Elastic Compute Cloud for Spot Instances
   * `AWS/ECS` - Elastic Container Service (Service Metrics)
   * `AWS/EFS` - Elastic File System
-  * `AWS/Elasticache` - ElastiCache
+  * `AWS/ElastiCache` - ElastiCache
   * `AWS/ElasticBeanstalk` - Elastic Beanstalk
   * `AWS/ElasticMapReduce` - Elastic MapReduce
   * `AWS/ELB` - Elastic Load Balancer


### PR DESCRIPTION
Came across this while adapting our config to the breaking changes on 0.59.

`{"caller":"main.go:67","err":"Couldn't read /config/config.yml: Discovery job [0]: Service is not in known list!: AWS/Elasticache","level":"error","msg":"Error running yace","ts":"2024-04-19T11:23:31.748809706Z","version":"v0.59.0"}`

Cheers!