### PR TITLE
feat: add AWS/RUM as supported service

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Only the latest version gets security updates. We won't support older versions.
   * `AWS/Redshift` - Redshift Database
   * `AWS/Route53` - Route53 Health Checks
   * `AWS/Route53Resolver` - Route53 Resolver
+  * `AWS/RUM` - Real User Monitoring
   * `AWS/S3` - Object Storage
   * `AWS/Sagemaker/ModelBuildingPipeline` - Sagemaker Model Building Pipelines
   * `AWS/SageMaker` - Sagemaker invocations

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -730,6 +730,10 @@ var SupportedServices = serviceConfigs{
 		},
 	},
 	{
+		Namespace: "AWS/RUM",
+		Alias:     "rum",
+	},
+	{
 		Namespace: "AWS/S3",
 		Alias:     "s3",
 		ResourceFilters: []*string{


### PR DESCRIPTION
Added this locally and ran using docker-compose. Correctly fetches the metric as seen below.

```yaml
    - type: AWS/RUM
      regions: [eu-west-1]
      period: 60
      length: 60
      metrics:
        - name: JsErrorCount
          statistics:
            - Sum
```


```
aws_rum_js_error_count_sum{account_id="<redacted>", dimension_application_name="portal-monitor-dev", instance="yace:8080", job="yace", name="global", region="eu-west-1"}
```