### PR TITLE
Fix all value for function_name variable in lambda dashboard

### DIFF
--- a/mixin/dashboards/lambda.libsonnet
+++ b/mixin/dashboards/lambda.libsonnet
@@ -51,6 +51,7 @@ grafana.dashboard.new(
     includeAll=true,
     multi=true,
     sort=common.sortAlphabeticalAsc,
+    allValue='.+',
   )
 )
 .addTemplate(


### PR DESCRIPTION
This PR adds a well-defined all value for the `function_name` variable, in the lambda dashboard. With this not present, an all value is generated by "|"-joining all the discovered lambda names, which, if someone has a ton, would lead to Prometheus receving a too long query and answering 414.

```
https://stack.grafana.net/api/datasources/uid/grafanacloud-prom/resources/api/v1/label/dimension_Resource/values?match%5B%5D=aws_lambda_invocations_sum%7Bscrape_job%3D~%22.%2B%22%2C%20region%3D~%22(us-east-2%7Cus-west-2)%22%2C%20dimension_FunctionName%3D~%22(GrafanaCloudALBLogsForwarder%7CGrafanaCloudLambdaPromtail%7Clogging-lambda)%22%7D&start=1715259298&end=1715261098
```

For example the query above shows the query generated to prometheus label values endpoints, upong booting the dashboard. If the lambda were much more the query would grow and grow.
