### PR TITLE
feat: add AWS/AppRunner as supported service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Only the latest version gets security updates. We won't support older versions.
   * `AmazonMWAA` - Managed Apache Airflow
   * `AWS/ACMPrivateCA` - ACM Private CA
   * `AWS/AmazonMQ` - Managed Message Broker Service
+  * `AWS/AppRunner` - Managed Container Apps Service
   * `AWS/AOSS` - OpenSearch Serverless
   * `AWS/ApiGateway` - ApiGateway (V1 and V2)
   * `AWS/ApplicationELB` - Application Load Balancer

--- a/examples/apprunner.yaml
+++ b/examples/apprunner.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1alpha1
+discovery:
+  jobs:
+  - regions:
+    - us-east-1
+    period: 300
+    length: 300
+    type: AWS/AppRunner
+    metrics:
+      - name: MemoryUtilization
+        statistics: [Average, Maximum]
+      - name: CPUUtilization
+        statistics: [Average, Maximum]
+      - name: 2xxStatusResponses
+        statistics: [Sum]
+      - name: Requests
+        statistics: [Sum]
+      - name: RequestLatency
+        statistics: [Average]
+      - name: ActiveInstances
+        statistics: [Maximum]
+      - name: 4xxStatusResponses
+        statistics: [Sum]
+      - name: Concurrency
+        statistics: [Maximum]

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -163,6 +163,10 @@ var SupportedServices = serviceConfigs{
 		},
 	},
 	{
+		Namespace: "AWS/AppRunner",
+		Alias:     "apprunner",
+	},
+	{
 		Namespace: "AWS/AppSync",
 		Alias:     "appsync",
 		ResourceFilters: []*string{


### PR DESCRIPTION
I have confirmed that it can be retrieved using the following configuration.

```
apiVersion: v1alpha1
discovery:
  jobs:
  - regions:
    - us-east-1
    period: 300
    length: 300
    type: AWS/AppRunner
    metrics:
      - name: MemoryUtilization
        statistics: [Average, Maximum]
      - name: CPUUtilization
        statistics: [Average, Maximum]
      - name: 2xxStatusResponses
        statistics: [Sum]
      - name: Requests
        statistics: [Sum]
      - name: RequestLatency
        statistics: [Average]
      - name: ActiveInstances
        statistics: [Maximum]
      - name: 4xxStatusResponses
        statistics: [Sum]
      - name: Concurrency
        statistics: [Maximum]
```

![スクリーンショット 2024-06-05 15 10 04](https://github.com/nerdswords/yet-another-cloudwatch-exporter/assets/10270136/887989d4-e969-4271-ad7e-291cb837c27b)
