### PR TITLE
refactor prom metric creation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,10 +23,12 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/grafana/regexp v0.0.0-20221123153739-15dc172cd2db
 	github.com/prometheus/client_golang v1.20.2
+	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.57.0
 	github.com/r3labs/diff/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.4
+	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
 	golang.org/x/sync v0.8.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -50,7 +52,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 h1:kx6Ds3MlpiUHKj7syVnbp57++8WpuKPcR5yjLBjvLEA=
+golang.org/x/exp v0.0.0-20240823005443-9b4947da3948/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=

--- a/pkg/promutil/migrate.go
+++ b/pkg/promutil/migrate.go
@@ -66,7 +66,7 @@ func BuildNamespaceInfoMetrics(tagData []model.TaggedResourceResult, metrics []*
 
 			observedMetricLabels = recordLabelsForMetric(metricName, promLabels, observedMetricLabels)
 			metrics = append(metrics, &PrometheusMetric{
-				Name:   &metricName,
+				Name:   metricName,
 				Labels: promLabels,
 				Value:  0,
 			})
@@ -116,7 +116,7 @@ func BuildMetrics(results []model.CloudwatchMetricResult, labelsSnakeCase bool, 
 				observedMetricLabels = recordLabelsForMetric(name, promLabels, observedMetricLabels)
 
 				output = append(output, &PrometheusMetric{
-					Name:             &name,
+					Name:             name,
 					Labels:           promLabels,
 					Value:            exportedDatapoint,
 					Timestamp:        ts,
@@ -285,13 +285,13 @@ func EnsureLabelConsistencyAndRemoveDuplicates(metrics []*PrometheusMetric, obse
 	output := make([]*PrometheusMetric, 0, len(metrics))
 
 	for _, metric := range metrics {
-		for observedLabels := range observedMetricLabels[*metric.Name] {
+		for observedLabels := range observedMetricLabels[metric.Name] {
 			if _, ok := metric.Labels[observedLabels]; !ok {
 				metric.Labels[observedLabels] = ""
 			}
 		}
 
-		metricKey := fmt.Sprintf("%s-%d", *metric.Name, prom_model.LabelsToSignature(metric.Labels))
+		metricKey := fmt.Sprintf("%s-%d", metric.Name, prom_model.LabelsToSignature(metric.Labels))
 		if _, exists := metricKeys[metricKey]; !exists {
 			metricKeys[metricKey] = struct{}{}
 			output = append(output, metric)

--- a/pkg/promutil/migrate_test.go
+++ b/pkg/promutil/migrate_test.go
@@ -48,7 +48,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			labelsSnakeCase:      false,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_elasticache_info"),
+					Name: "aws_elasticache_info",
 					Labels: map[string]string{
 						"name":          "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_CustomTag": "tag_Value",
@@ -88,7 +88,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			labelsSnakeCase:      true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_elasticache_info"),
+					Name: "aws_elasticache_info",
 					Labels: map[string]string{
 						"name":           "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_custom_tag": "tag_Value",
@@ -125,7 +125,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			},
 			metrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_ec2_cpuutilization_maximum"),
+					Name: "aws_ec2_cpuutilization_maximum",
 					Labels: map[string]string{
 						"name":                 "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
 						"dimension_InstanceId": "i-abc123",
@@ -142,7 +142,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_ec2_cpuutilization_maximum"),
+					Name: "aws_ec2_cpuutilization_maximum",
 					Labels: map[string]string{
 						"name":                 "arn:aws:ec2:us-east-1:123456789012:instance/i-abc123",
 						"dimension_InstanceId": "i-abc123",
@@ -150,7 +150,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 					Value: 0,
 				},
 				{
-					Name: aws.String("aws_elasticache_info"),
+					Name: "aws_elasticache_info",
 					Labels: map[string]string{
 						"name":           "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_custom_tag": "tag_Value",
@@ -201,7 +201,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			labelsSnakeCase:      true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_elasticache_info"),
+					Name: "aws_elasticache_info",
 					Labels: map[string]string{
 						"name":                   "arn:aws:elasticache:us-east-1:123456789012:cluster:redis-cluster",
 						"tag_cache_name":         "cache_instance_1",
@@ -247,7 +247,7 @@ func TestBuildNamespaceInfoMetrics(t *testing.T) {
 			labelsSnakeCase:      false,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name: aws.String("aws_sagemaker_trainingjobs_info"),
+					Name: "aws_sagemaker_trainingjobs_info",
 					Labels: map[string]string{
 						"name":          "arn:aws:sagemaker:us-east-1:123456789012:training-job/sagemaker-xgboost",
 						"tag_CustomTag": "tag_Value",
@@ -380,7 +380,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: false,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_elasticache_cpuutilization_average"),
+					Name:      "aws_elasticache_cpuutilization_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -391,7 +391,7 @@ func TestBuildMetrics(t *testing.T) {
 					},
 				},
 				{
-					Name:      aws.String("aws_elasticache_freeable_memory_average"),
+					Name:      "aws_elasticache_freeable_memory_average",
 					Value:     2,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -402,7 +402,7 @@ func TestBuildMetrics(t *testing.T) {
 					},
 				},
 				{
-					Name:      aws.String("aws_elasticache_network_bytes_in_average"),
+					Name:      "aws_elasticache_network_bytes_in_average",
 					Value:     3,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -413,7 +413,7 @@ func TestBuildMetrics(t *testing.T) {
 					},
 				},
 				{
-					Name:             aws.String("aws_elasticache_network_bytes_out_average"),
+					Name:             "aws_elasticache_network_bytes_out_average",
 					Value:            4,
 					Timestamp:        ts,
 					IncludeTimestamp: true,
@@ -548,7 +548,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: false,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_elasticache_cpuutilization_average"),
+					Name:      "aws_elasticache_cpuutilization_average",
 					Value:     0,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -560,7 +560,7 @@ func TestBuildMetrics(t *testing.T) {
 					IncludeTimestamp: false,
 				},
 				{
-					Name:      aws.String("aws_elasticache_freeable_memory_average"),
+					Name:      "aws_elasticache_freeable_memory_average",
 					Value:     math.NaN(),
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -572,7 +572,7 @@ func TestBuildMetrics(t *testing.T) {
 					IncludeTimestamp: false,
 				},
 				{
-					Name:      aws.String("aws_elasticache_network_bytes_in_average"),
+					Name:      "aws_elasticache_network_bytes_in_average",
 					Value:     0,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -640,7 +640,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_elasticache_cpuutilization_average"),
+					Name:      "aws_elasticache_cpuutilization_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -695,7 +695,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_sagemaker_trainingjobs_cpuutilization_average"),
+					Name:      "aws_sagemaker_trainingjobs_cpuutilization_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -750,7 +750,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_glue_driver_aggregate_bytes_read_average"),
+					Name:      "aws_glue_driver_aggregate_bytes_read_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -805,7 +805,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_glue_aggregate_glue_jobs_bytes_read_average"),
+					Name:      "aws_glue_aggregate_glue_jobs_bytes_read_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -863,7 +863,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_elasticache_cpuutilization_average"),
+					Name:      "aws_elasticache_cpuutilization_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -920,7 +920,7 @@ func TestBuildMetrics(t *testing.T) {
 			labelsSnakeCase: true,
 			expectedMetrics: []*PrometheusMetric{
 				{
-					Name:      aws.String("aws_elasticache_cpuutilization_average"),
+					Name:      "aws_elasticache_cpuutilization_average",
 					Value:     1,
 					Timestamp: ts,
 					Labels: map[string]string{
@@ -1170,17 +1170,17 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "adds missing labels",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 					Value:  1.0,
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label2": "value2"},
 					Value:  2.0,
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{},
 					Value:  3.0,
 				},
@@ -1188,17 +1188,17 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			observedLabels: map[string]model.LabelSet{"metric1": {"label1": {}, "label2": {}, "label3": {}}},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1", "label2": "", "label3": ""},
 					Value:  1.0,
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "", "label3": "", "label2": "value2"},
 					Value:  2.0,
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "", "label2": "", "label3": ""},
 					Value:  3.0,
 				},
@@ -1208,18 +1208,18 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "duplicate metric",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},
@@ -1228,18 +1228,18 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "duplicate metric, multiple labels",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1", "label2": "value2"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label2": "value2", "label1": "value1"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1", "label2": "value2"},
 				},
 			},
@@ -1248,22 +1248,22 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "metric with different labels",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label2": "value2"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label2": "value2"},
 				},
 			},
@@ -1272,22 +1272,22 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "two metrics",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},
@@ -1296,22 +1296,22 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "two metrics with different labels",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label2": "value2"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label2": "value2"},
 				},
 			},
@@ -1320,38 +1320,38 @@ func Test_EnsureLabelConsistencyAndRemoveDuplicates(t *testing.T) {
 			name: "multiple duplicates and non-duplicates",
 			metrics: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label2": "value2"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},
 			observedLabels: map[string]model.LabelSet{},
 			output: []*PrometheusMetric{
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label2": "value2"},
 				},
 				{
-					Name:   aws.String("metric2"),
+					Name:   "metric2",
 					Labels: map[string]string{"label1": "value1"},
 				},
 				{
-					Name:   aws.String("metric1"),
+					Name:   "metric1",
 					Labels: map[string]string{"label1": "value1"},
 				},
 			},

--- a/pkg/promutil/prometheus_test.go
+++ b/pkg/promutil/prometheus_test.go
@@ -1,11 +1,13 @@
 package promutil
 
 import (
-	"fmt"
-	"math/rand/v2"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitString(t *testing.T) {
@@ -119,63 +121,113 @@ func TestPromStringTag(t *testing.T) {
 	}
 }
 
-func Benchmark_CreateMetrics(b *testing.B) {
-	tests := []struct {
-		uniqueMetrics    int
-		numberOfLabels   int
-		metricsToMigrate int
-	}{
-		{10, 1, 1000},
-		{10, 1, 10000},
-		{10, 1, 100000},
-		{10, 5, 1000},
-		{10, 5, 10000},
-		{10, 5, 100000},
-		{10, 10, 1000},
-		{10, 10, 10000},
-		{10, 10, 100000},
-		{10, 20, 1000},
-		{10, 20, 10000},
-		{10, 20, 100000},
-		{20, 20, 1000},
-		{20, 20, 10000},
-		{20, 20, 100000},
-	}
-
-	for _, tc := range tests {
-		metricsToMigrate := createTestData(tc.uniqueMetrics, tc.numberOfLabels, tc.metricsToMigrate)
-
-		b.Run(fmt.Sprintf("current: unique metrics %d, number of labels %d, metrics to migrate %d", tc.uniqueMetrics, tc.numberOfLabels, tc.metricsToMigrate), func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				toMetrics(metricsToMigrate)
-			}
-		})
-
-		b.Run(fmt.Sprintf("new: unique metrics %d, number of labels %d, metrics to migrate %d", tc.uniqueMetrics, tc.numberOfLabels, tc.metricsToMigrate), func(b *testing.B) {
-			b.ReportAllocs()
-			for i := 0; i < b.N; i++ {
-				toConstMetrics(metricsToMigrate)
-			}
-		})
-	}
-}
-
-func createTestData(uniqueMetrics int, numberOfLabels int, totalToMigrate int) []*PrometheusMetric {
-	result := make([]*PrometheusMetric, 0, totalToMigrate)
-	for i := 0; i < totalToMigrate; i++ {
-		metricName := fmt.Sprintf("metric_%d", rand.IntN(uniqueMetrics-1))
-		labels := make(map[string]string, numberOfLabels)
-		for j := 0; j < numberOfLabels; j++ {
-			labels[fmt.Sprintf("label_%d", j)] = fmt.Sprintf("label-value-%d", j)
-		}
-		result = append(result, &PrometheusMetric{
-			Name:             metricName,
-			Labels:           labels,
+func TestNewPrometheusCollector_CanReportMetricsAndErrors(t *testing.T) {
+	metrics := []*PrometheusMetric{
+		{
+			Name:             "this*is*not*valid",
+			Labels:           map[string]string{},
 			Value:            0,
 			IncludeTimestamp: false,
-		})
+		},
+		{
+			Name:             "this_is_valid",
+			Labels:           map[string]string{"key": "value1"},
+			Value:            0,
+			IncludeTimestamp: false,
+		},
+	}
+	collector := NewPrometheusCollector(metrics)
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(collector))
+	families, err := registry.Gather()
+	assert.Error(t, err)
+	assert.Len(t, families, 1)
+	family := families[0]
+	assert.Equal(t, "this_is_valid", family.GetName())
+}
+
+func TestNewPrometheusCollector_CanReportMetrics(t *testing.T) {
+	ts := time.Now()
+
+	labelSet1 := map[string]string{"key1": "value", "key2": "value", "key3": "value"}
+	labelSet2 := map[string]string{"key2": "out", "key3": "of", "key1": "order"}
+	labelSet3 := map[string]string{"key2": "out", "key1": "of", "key3": "order"}
+	metrics := []*PrometheusMetric{
+		{
+			Name:             "metric_with_labels",
+			Labels:           labelSet1,
+			Value:            1,
+			IncludeTimestamp: false,
+		},
+		{
+			Name:             "metric_with_labels",
+			Labels:           labelSet2,
+			Value:            2,
+			IncludeTimestamp: false,
+		},
+		{
+			Name:             "metric_with_labels",
+			Labels:           labelSet3,
+			Value:            3,
+			IncludeTimestamp: false,
+		},
+		{
+			Name:             "metric_with_timestamp",
+			Labels:           map[string]string{},
+			Value:            1,
+			IncludeTimestamp: true,
+			Timestamp:        ts,
+		},
 	}
 
-	return result
+	collector := NewPrometheusCollector(metrics)
+	registry := prometheus.NewRegistry()
+	require.NoError(t, registry.Register(collector))
+	families, err := registry.Gather()
+	assert.NoError(t, err)
+	assert.Len(t, families, 2)
+
+	var metricWithLabels *dto.MetricFamily
+	var metricWithTs *dto.MetricFamily
+
+	for _, metricFamily := range families {
+		assert.Equal(t, dto.MetricType_GAUGE, metricFamily.GetType())
+
+		switch {
+		case metricFamily.GetName() == "metric_with_labels":
+			metricWithLabels = metricFamily
+		case metricFamily.GetName() == "metric_with_timestamp":
+			metricWithTs = metricFamily
+		default:
+			require.Failf(t, "Encountered an unexpected metric family %s", metricFamily.GetName())
+		}
+	}
+	require.NotNil(t, metricWithLabels)
+	require.NotNil(t, metricWithTs)
+
+	assert.Len(t, metricWithLabels.Metric, 3)
+	for _, metric := range metricWithLabels.Metric {
+		assert.Len(t, metric.Label, 3)
+		var labelSetToMatch map[string]string
+		switch *metric.Gauge.Value {
+		case 1.0:
+			labelSetToMatch = labelSet1
+		case 2.0:
+			labelSetToMatch = labelSet2
+		case 3.0:
+			labelSetToMatch = labelSet3
+		default:
+			require.Fail(t, "Encountered an metric value value %v", *metric.Gauge.Value)
+		}
+
+		for _, labelPairs := range metric.Label {
+			require.Contains(t, labelSetToMatch, *labelPairs.Name)
+			require.Equal(t, labelSetToMatch[*labelPairs.Name], *labelPairs.Value)
+		}
+	}
+
+	require.Len(t, metricWithTs.Metric, 1)
+	tsMetric := metricWithTs.Metric[0]
+	assert.Equal(t, ts.UnixMilli(), *tsMetric.TimestampMs)
+	assert.Equal(t, 1.0, *tsMetric.Gauge.Value)
 }


### PR DESCRIPTION
This PR has a few changes intended to reduce the memory required in the prometheus collector. The main culprit for resource utilization appears to be the use of ConstLabels when we create the gauge to be used in the collector
```go
gauge := prometheus.NewGauge(prometheus.GaugeOpts{
	Name:        metric.Name,
	Help:        "Help is not implemented yet.",
	ConstLabels: metric.Labels,
})
```
Each `NewGauge` created generates a `prometheus.Desc` that is rather heavy. We cannot reuse/change this due to using `ConstLabels` as we generate one Gauge per metric to be exposed. This PR changes that so we generate a single `prometheus.Desc` per metric name and use that to create constant metrics with varying label values. The results are less CPU and less memory overhead in all use cases run through the benchmark with larger result sets showing significant reductions.
```
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_1000-8         	    2660	    430650 ns/op	  384389 B/op	   10001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_1000-8             	    3630	    306107 ns/op	  347602 B/op	   10075 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_10000-8        	     260	   4549788 ns/op	 3843860 B/op	  100001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_10000-8            	     358	   3292149 ns/op	 3447069 B/op	  100075 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_100000-8       	      25	  45688968 ns/op	38405658 B/op	 1000001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_1,_metrics_to_migrate_100000-8           	      34	  33856609 ns/op	34408861 B/op	 1000075 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_1000-8         	    1084	   1131961 ns/op	  936394 B/op	   22001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_1000-8             	    1587	    749740 ns/op	  837050 B/op	   22111 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_10000-8        	      96	  11379392 ns/op	 9363895 B/op	  220001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_10000-8            	     148	   8153597 ns/op	 8328530 B/op	  220111 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_100000-8       	       9	 111724319 ns/op	93605664 B/op	 2200001 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_5,_metrics_to_migrate_100000-8           	      14	  91462923 ns/op	83210305 B/op	 2200111 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_1000-8        	     393	   2650320 ns/op	 1899468 B/op	   38022 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_1000-8            	     788	   1521121 ns/op	 1433470 B/op	   37165 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_10000-8       	      43	  26282797 ns/op	18994978 B/op	  380217 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_10000-8           	      70	  15704540 ns/op	14252937 B/op	  370165 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_100000-8      	       4	 256912406 ns/op	189913120 B/op	 3802136 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_10,_metrics_to_migrate_100000-8          	       7	 153158482 ns/op	142414781 B/op	 3700165 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_1000-8        	     195	   6101884 ns/op	 3974494 B/op	   69432 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_1000-8            	     381	   3107051 ns/op	 2644098 B/op	   67268 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_10000-8       	      18	  61265692 ns/op	39747202 B/op	  694330 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_10000-8           	      36	  31769720 ns/op	26263616 B/op	  670268 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_100000-8      	       2	 633238146 ns/op	397399504 B/op	 6943014 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_10,_number_of_labels_20,_metrics_to_migrate_100000-8          	       4	 304946854 ns/op	262425428 B/op	 6700268 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_1000-8        	     194	   6171846 ns/op	 3974453 B/op	   69432 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_1000-8            	     363	   3326605 ns/op	 2667287 B/op	   67565 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_10000-8       	      18	  61538363 ns/op	39743394 B/op	  694303 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_10000-8           	      37	  32133752 ns/op	26286688 B/op	  670565 allocs/op
Benchmark_CreateMetrics/current:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_100000-8      	       2	 625001584 ns/op	397419568 B/op	 6943153 allocs/op
Benchmark_CreateMetrics/new:_unique_metrics_20,_number_of_labels_20,_metrics_to_migrate_100000-8          	       4	 315513042 ns/op	262448560 B/op	 6700565 allocs/op
```

There's two other minor changes included in this PR,
1. Translate our internal []*PrometheusMetric to []prometheus.Metric when the collector is created
    * If a user has their scrape interval faster than the async scrape interval we would end up doing this translation multiple times which is a rather large waste
    * It also allows the large []*PrometheusMetric to be available to GC sooner
2. Stop using a pointer for the `Name` field on `PrometheusMetric` it's superficial and adds more overhead with no gain

I'll cleanup the dead code from the old code path before merging just wanted to show what was benchmarked first.