### PR TITLE
Fix linting issues detected by golangci-lint 1.60.3

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,17 +2,19 @@ run:
   timeout: 5m
 
 output:
-  format: line-number
+  formats:
+    - format: line-number
+      path: stderr
 
 linters:
   disable-all: true
   enable:
     - asasalint
     - bodyclose
+    - copyloopvar
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - gofmt
     - gofumpt
     - goimports

--- a/pkg/clients/cloudwatch/v2/client.go
+++ b/pkg/clients/cloudwatch/v2/client.go
@@ -178,8 +178,6 @@ func (c client) GetMetricStatistics(ctx context.Context, logger logging.Logger, 
 
 	ptrs := make([]*types.Datapoint, 0, len(resp.Datapoints))
 	for _, datapoint := range resp.Datapoints {
-		// Force a dereference to avoid loop variable pointer issues
-		datapoint := datapoint
 		ptrs = append(ptrs, &datapoint)
 	}
 
@@ -192,7 +190,6 @@ func toModelDatapoints(cwDatapoints []*types.Datapoint) []*model.Datapoint {
 	for _, cwDatapoint := range cwDatapoints {
 		extendedStats := make(map[string]*float64, len(cwDatapoint.ExtendedStatistics))
 		for name, value := range cwDatapoint.ExtendedStatistics {
-			value := value
 			extendedStats[name] = &value
 		}
 		modelDataPoints = append(modelDataPoints, &model.Datapoint{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -264,7 +264,7 @@ func (j *CustomNamespace) validateCustomNamespaceJob(logger logging.Logger, jobI
 	} else {
 		return fmt.Errorf("no IAM roles configured. If the current IAM role is desired, an empty Role should be configured")
 	}
-	if j.Regions == nil || len(j.Regions) == 0 {
+	if len(j.Regions) == 0 {
 		return fmt.Errorf("CustomNamespace job [%s/%d]: Regions should not be empty", j.Name, jobIdx)
 	}
 	if len(j.Metrics) == 0 {

--- a/pkg/config/feature_flags.go
+++ b/pkg/config/feature_flags.go
@@ -2,10 +2,7 @@ package config
 
 import "context"
 
-var (
-	flagsCtxKey         = struct{}{}
-	defaultFeatureFlags = noFeatureFlags{}
-)
+type flagsCtxKey struct{}
 
 // AwsSdkV2 is a feature flag used to enable the use of aws sdk v2 which is expected to come with performance benefits
 const AwsSdkV2 = "aws-sdk-v2"
@@ -21,15 +18,15 @@ type FeatureFlags interface {
 
 // CtxWithFlags injects a FeatureFlags inside a given context.Context, so that they are easily communicated through layers.
 func CtxWithFlags(ctx context.Context, ctrl FeatureFlags) context.Context {
-	return context.WithValue(ctx, flagsCtxKey, ctrl)
+	return context.WithValue(ctx, flagsCtxKey{}, ctrl)
 }
 
 // FlagsFromCtx retrieves a FeatureFlags from a given context.Context, defaulting to one with all feature flags disabled if none is found.
 func FlagsFromCtx(ctx context.Context) FeatureFlags {
-	if ctrl := ctx.Value(flagsCtxKey); ctrl != nil {
+	if ctrl := ctx.Value(flagsCtxKey{}); ctrl != nil {
 		return ctrl.(FeatureFlags)
 	}
-	return defaultFeatureFlags
+	return noFeatureFlags{}
 }
 
 // noFeatureFlags implements a no-op FeatureFlags

--- a/pkg/job/static.go
+++ b/pkg/job/static.go
@@ -59,7 +59,6 @@ func runStaticJob(
 func createStaticDimensions(dimensions []model.Dimension) []model.Dimension {
 	out := make([]model.Dimension, 0, len(dimensions))
 	for _, d := range dimensions {
-		d := d
 		out = append(out, model.Dimension{
 			Name:  d.Name,
 			Value: d.Value,


### PR DESCRIPTION
- .golangci.yml: fix output.formats and swap exportloopref for copyloopvar
- fix issues detected by copyloopvar
- fix use of context key detected by staticcheck
- fix nil check detected by gosimple